### PR TITLE
link to repository

### DIFF
--- a/actify-macros/Cargo.toml
+++ b/actify-macros/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.3.1"
 edition = "2021"
 description = "Actify's procedural macros"
 license = "MIT"
+repository = "https://github.com/AvalorAI/actify"
 
 [dependencies]
 quote = "1.0"


### PR DESCRIPTION
to allow crates.io and rust-digger to link to it.