### PR TITLE
Fix: Fire throttle on creation

### DIFF
--- a/actify-test/Cargo.toml
+++ b/actify-test/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/AvalorAI/actify"
 categories = ["testing"]
 
 [dependencies]
-actify = { version = "0.4.0", path = "../actify", features = ["profiler"]}
+actify = { version = "0.5.0", path = "../actify", features = ["profiler"]}
 async-trait = "0.1"
 env_logger = "0.11"
 log = "0.4"

--- a/actify/Cargo.toml
+++ b/actify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actify"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 description = "An intutive actor model with minimal boilerplate"
 license = "MIT"

--- a/actify/src/actors.rs
+++ b/actify/src/actors.rs
@@ -114,7 +114,7 @@ where
     }
 
     /// Spawns a throttle that fires given a specificed [Frequency], given any broadcasted updates by the actor.
-    pub fn spawn_throttle<C, F>(
+    pub async fn spawn_throttle<C, F>(
         &self,
         client: C,
         call: fn(&C, F),
@@ -125,8 +125,10 @@ where
         T: Throttled<F>,
         F: Clone + Send + Sync + 'static,
     {
+        let val = self.get().await?;
         ThrottleBuilder::<C, T, F>::new(client, call, freq)
             .attach(self.clone())
+            .init(val)
             .spawn()?;
         Ok(())
     }

--- a/actify/src/throttle.rs
+++ b/actify/src/throttle.rs
@@ -221,6 +221,22 @@ mod tests {
     use tokio::time::{sleep, Duration, Instant};
 
     #[tokio::test]
+    async fn test_first_shot() {
+        let handle = Handle::new(1);
+        let counter = CounterClient::new();
+
+        // Spawn throttle that should only activate once on creation
+        handle
+            .spawn_throttle(counter.clone(), CounterClient::call, Frequency::OnEvent)
+            .await
+            .unwrap();
+        sleep(Duration::from_millis(200)).await;
+
+        let count = *counter.count.lock().unwrap();
+        assert_eq!(count, 1)
+    }
+
+    #[tokio::test]
     async fn test_exit_on_shutdown() {
         let handle = Handle::new(1);
 


### PR DESCRIPTION
Before, when a throttle was created based on a handle it never fires on creation, even though this was intended behavior. To prevent this, on creation the value of the handle is obtained and given to the throttle.

This requires an async context, meaning the API was changed in an incompatible way but it's still not a stable release so a minor bump is performed.