### PR TITLE
Fix clippy warnings

### DIFF
--- a/actify-macros/src/parse.rs
+++ b/actify-macros/src/parse.rs
@@ -212,9 +212,9 @@ const PROPAGATED_ATTRIBUTES: &[&str] = &[
 fn is_propagated_attribute(attr: &Attribute) -> bool {
     let segments = &attr.path().segments;
     segments.len() == 1
-        && segments.first().map_or(false, |seg| {
-            PROPAGATED_ATTRIBUTES.contains(&seg.ident.to_string().as_str())
-        })
+        && segments
+            .first()
+            .is_some_and(|seg| PROPAGATED_ATTRIBUTES.contains(&seg.ident.to_string().as_str()))
 }
 
 /// Keep only whitelisted built-in attributes for generated code.
@@ -273,7 +273,6 @@ fn transform_args(
                 arg_names.push(ident);
                 arg_types.push(*pat_type.ty.clone());
             }
-            #[cfg_attr(test, deny(clippy::non_exhaustive_omitted_patterns))]
             _ => {}
         }
     }

--- a/actify-test/src/main.rs
+++ b/actify-test/src/main.rs
@@ -424,8 +424,7 @@ mod tests {
             let _handle_2 = Handle::new("test");
             let handle_3 = Handle::new(1.); // This goes out of scope
             let _handle_1_clone = handle_1.clone();
-            let cache_3 = handle_3.create_cache().await; // But the cache doesn't
-            cache_3
+            handle_3.create_cache().await // But the cache doesn't
         };
 
         sleep(Duration::from_secs(1)).await;


### PR DESCRIPTION
First PR of the 0.8.3 release train (production-readiness plan).

Fixes all remaining clippy warnings so the upcoming `clippy -D warnings` CI job (next PR) starts green:

- `actify-macros/src/parse.rs`: `map_or(false, ..)` → `is_some_and(..)` (`clippy::unnecessary_map_or`)
- `actify-test/src/main.rs`: removed a `let_and_return` binding in the cache scope test
- `actify-macros/src/parse.rs`: dropped `#[cfg_attr(test, deny(clippy::non_exhaustive_omitted_patterns))]` — that lint name doesn't exist in clippy (the rustc lint of that name is unstable/nightly-only), so the attribute was inert and produced an unknown-lint warning under `--all-targets`

Verified: `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean, `cargo fmt --all --check` clean, all 128 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)