### PR TITLE
Overhaul CI: fmt, clippy, test matrix, feature legs, docs, MSRV, pinned trybuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: actify-test
+name: CI
 
 on:
   push:
@@ -6,12 +6,94 @@ on:
   pull_request:
     branches: ["main"]
 
-jobs:
-  build-and-test:
-    runs-on: ubuntu-latest
+permissions:
+  contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # The toolchain used to generate the trybuild .stderr files. Compiler error
+  # output changes between rustc releases, so the trybuild job pins this
+  # version. To regenerate the .stderr files, see CONTRIBUTING.md.
+  TRYBUILD_TOOLCHAIN: "1.87.0"
+
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-      - name: Build
-        run: cargo test --workspace
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # Trybuild tests are skipped here (see the trybuild job): they pin exact
+      # rustc diagnostics and only run on the pinned toolchain.
+      - run: cargo test --workspace --all-features
+
+  # Workspace feature unification means `cargo test --workspace` always builds
+  # actify with the profiler feature enabled (actify-test requires it). This job
+  # is the only place the default (no-feature) build of actify is compiled.
+  test-features:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Test default features
+        run: cargo test -p actify
+      - name: Test profiler feature
+        run: cargo test -p actify --features profiler
+
+  docs:
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo doc --workspace --no-deps --all-features
+
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@1.85
+      - uses: Swatinem/rust-cache@v2
+      # check, not test: building dev-dependencies would raise the effective MSRV.
+      - run: cargo check -p actify -p actify-macros --all-features
+
+  trybuild:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.TRYBUILD_TOOLCHAIN }}
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test -p actify-test --test unsupported_arg_types
+        env:
+          TRYBUILD_TESTS: "1"

--- a/actify-test/tests/unsupported_arg_types.rs
+++ b/actify-test/tests/unsupported_arg_types.rs
@@ -4,6 +4,15 @@
 /// will suddenly compile when it shouldn't.
 #[test]
 fn compile_fail_tests() {
+    // The .stderr files match the exact diagnostics of one rustc version. On CI,
+    // only the dedicated trybuild job (pinned to that version) runs these tests;
+    // the regular test matrix on unpinned stable skips them. Locally they always
+    // run. See CONTRIBUTING.md for how to regenerate the .stderr files.
+    if std::env::var_os("CI").is_some() && std::env::var_os("TRYBUILD_TESTS").is_none() {
+        eprintln!("skipping trybuild tests: CI is set and TRYBUILD_TESTS is not");
+        return;
+    }
+
     let t = trybuild::TestCases::new();
 
     // Argument type validation

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -1,8 +1,0 @@
-FROM rust:1.64
-
-WORKDIR /app
-
-COPY ./src ./src
-COPY ./Cargo.toml ./Cargo.toml
-
-CMD ["cargo", "test"]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,0 @@
-# See for options: https://rust-lang.github.io/rustfmt/
-max_width=100
-reorder_imports = true


### PR DESCRIPTION
Second PR of the 0.8.3 release train. **Stacked on #60** (base is `chore/clippy`; GitHub will retarget to `main` once #60 merges) so the new `clippy -D warnings` job is green from the start.

Replaces the single `cargo test --workspace` workflow with:

| Job | What it guards |
|---|---|
| `fmt` | `cargo fmt --all --check` |
| `clippy` | `--workspace --all-targets --all-features -- -D warnings` |
| `test` (ubuntu + **windows**) | full workspace suite — dev happens on Windows, so it's now tested |
| `test-features` | `cargo test -p actify` — the **only** place the non-profiler build of `actor.rs` compiles (actify-test force-enables `profiler` via workspace feature unification) + a profiler leg |
| `docs` | `cargo doc` with `RUSTDOCFLAGS=-D warnings` |
| `msrv` | `cargo check` on 1.85 (edition-2024 floor); check not test, so dev-deps don't raise the effective MSRV |
| `trybuild` | compile-fail suite on a **pinned** 1.87.0 toolchain — the `.stderr` files match one rustc version's diagnostics; unpinned stable would break on every rustc release |

The trybuild test fn is env-gated: on CI it only runs when `TRYBUILD_TESTS=1` (set only by the pinned job); locally it always runs.

Also removes two dead files:
- `ci.Dockerfile` — `FROM rust:1.64` cannot build edition 2024, and it copies a `./src` that doesn't exist
- `rustfmt.toml` — both settings (`max_width=100`, `reorder_imports=true`) are rustfmt defaults; the `fmt` job enforces defaults directly

All actions updated: checkout@v5, dtolnay/rust-toolchain, Swatinem/rust-cache@v2, plus `permissions: contents: read` and a `concurrency` group.

Note: the windows test leg may surface wall-clock timing flakes in actify-test's task-count tests — a dedicated de-flake PR follows in this train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)