### PR TITLE
Fix macro ident collisions with user argument names

### DIFF
--- a/actify-macros/src/codegen/handle.rs
+++ b/actify-macros/src/codegen/handle.rs
@@ -108,29 +108,31 @@ fn method_body(
     let broadcast = if method.skip_broadcast {
         None
     } else {
-        Some(quote! { s.broadcast(#ident_string); })
+        Some(quote! { __actify_s.broadcast(#ident_string); })
     };
 
+    // The __actify_ prefix prevents collisions with user argument names, which
+    // are bound as-is inside the generated body (e.g. an argument named `s`).
     quote! {
         #(#attrs)*
         async fn #ident #method_generics(&self, #(#arg_names: #arg_types),*) #return_type #where_clause {
-            let res = self.send_job(
-                Box::new(|s: &mut actify::Actor<#impl_type>, args: Box<dyn std::any::Any + Send>|
+            let __actify_res = self.send_job(
+                Box::new(|__actify_s: &mut actify::Actor<#impl_type>, __actify_args: Box<dyn std::any::Any + Send>|
                 Box::pin(async move {
-                    let (#(#arg_names),*): (#(#arg_types),*) = *args
+                    let (#(#arg_names),*): (#(#arg_types),*) = *__actify_args
                         .downcast()
                         .expect("Downcasting failed due to an error in the Actify macro");
 
-                    let result: #output_type = #call_prefix::#ident(&#mutability s.inner, #(#arg_names),*)#awaiter;
+                    let __actify_result: #output_type = #call_prefix::#ident(&#mutability __actify_s.inner, #(#arg_names),*)#awaiter;
 
                     #broadcast
 
-                    Box::new(result) as Box<dyn std::any::Any + Send>
+                    Box::new(__actify_result) as Box<dyn std::any::Any + Send>
                 })),
                 Box::new((#(#arg_names),*)),
             ).await;
 
-            *res.downcast().expect("Downcasting failed due to an error in the Actify macro")
+            *__actify_res.downcast().expect("Downcasting failed due to an error in the Actify macro")
         }
     }
 }

--- a/actify-test/src/main.rs
+++ b/actify-test/src/main.rs
@@ -115,6 +115,21 @@ impl NonDebug {
     fn foo(&self) {}
 }
 
+/// Argument names that collide with identifiers used in the generated code
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
+struct ShadowingActor {
+    value: String,
+}
+
+#[actify]
+impl ShadowingActor {
+    fn store(&mut self, s: String, args: Vec<i32>, res: u8, result: bool) -> String {
+        self.value = format!("{s}-{args:?}-{res}-{result}");
+        self.value.clone()
+    }
+}
+
 #[derive(Clone, Debug)]
 struct ComplexActorTypes;
 
@@ -412,6 +427,18 @@ mod tests {
         assert_eq!(actor_handle.foo(0, HashMap::new()).await, 1.);
         assert_eq!(actor_handle.bar(5, |i: usize| i + 10).await, 15);
         assert_eq!(actor_handle.baz(0).await, 2.);
+    }
+
+    /// Argument names like `s`, `args`, `res` and `result` must not clash with
+    /// the identifiers the macro uses internally in the generated method body
+    #[tokio::test]
+    async fn test_shadowing_arg_names() {
+        let handle = Handle::new(ShadowingActor {
+            value: String::new(),
+        });
+
+        let stored = handle.store("x".to_string(), vec![1, 2], 3, true).await;
+        assert_eq!(stored, "x-[1, 2]-3-true");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fourth PR of the 0.8.3 release train. **Stacked on #62.** TDD: commit 1 is the failing test, commit 2 the fix.

**Bug:** the generated method body hardcodes identifiers `s`, `args`, `res`, `result` and binds user argument names verbatim next to them. A method like

```rust
#[actify]
impl ShadowingActor {
    fn store(&mut self, s: String, args: Vec<i32>, res: u8, result: bool) -> String { ... }
}
```

failed to compile with `E0609: no field 'inner' on type 'String'` — the user's `s` shadowed the generated closure parameter, so `s.inner` / `s.broadcast` resolved against `String`.

**Fix:** all generated identifiers get an `__actify_` prefix. No public API change; pure codegen hygiene.

Verified: new `test_shadowing_arg_names` passes; full workspace suite (129 tests) green including trybuild (no `.stderr` changes needed); clippy `-D warnings` and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)