### PR TITLE
Build generics and call expressions from the self type as written

### DIFF
--- a/actify-macros/src/codegen/handle.rs
+++ b/actify-macros/src/codegen/handle.rs
@@ -28,11 +28,15 @@ pub fn generate_trait_impl(info: &ImplInfo) -> proc_macro2::TokenStream {
     let impl_attrs = &info.attributes;
     let handle_trait_ident = &info.handle_trait_ident;
     let impl_type = &info.impl_type;
-    let trait_generics = &info.generics;
-    let where_clause = &info.generics.where_clause;
 
-    let mut impl_generics = info.generics.clone();
-    impl_generics.params.push(syn::parse_quote!(__V));
+    // Bounds and `const` declarations belong only in the impl's parameter list.
+    // The trait reference takes the parameter names alone, which is what
+    // TypeGenerics renders; the full Generics would emit `T: Clone` there.
+    let (_, trait_generics, where_clause) = info.generics.split_for_impl();
+
+    let mut generics_with_broadcast = info.generics.clone();
+    generics_with_broadcast.params.push(syn::parse_quote!(__V));
+    let (impl_generics, _, _) = generics_with_broadcast.split_for_impl();
 
     let call_prefix = build_call_prefix(info);
     let methods = info
@@ -139,25 +143,18 @@ fn method_body(
 
 /// Build the fully qualified syntax prefix for calling the original method.
 /// This is the same for every method in the impl block:
-/// - Direct impl, no generics: `TypeName`
-/// - Direct impl, with generics: `TypeName::<T>`
+/// - Direct impl: `<Type>`
 /// - Trait impl: `<Type as Trait>`
+///
+/// The self type is used exactly as written, so `impl<T> Wrapper<Vec<T>>` calls
+/// `<Wrapper<Vec<T>>>::method`. Rebuilding it from the impl block's parameter
+/// list would instead produce `Wrapper::<T>`, which names a different type.
 fn build_call_prefix(info: &ImplInfo) -> proc_macro2::TokenStream {
-    let type_ident = &info.type_ident;
+    let impl_type = &info.impl_type;
 
     match &info.trait_path {
-        None => {
-            if info.generics.params.is_empty() {
-                quote! { #type_ident }
-            } else {
-                let generics = &info.generics;
-                quote! { #type_ident::#generics }
-            }
-        }
-        Some(path) => {
-            let impl_type = &info.impl_type;
-            quote! { <#impl_type as #path> }
-        }
+        None => quote! { <#impl_type> },
+        Some(path) => quote! { <#impl_type as #path> },
     }
 }
 

--- a/actify-test/src/main.rs
+++ b/actify-test/src/main.rs
@@ -130,6 +130,51 @@ impl ShadowingActor {
     }
 }
 
+/// Generic bounds written inline on the impl block instead of in a where clause
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
+struct InlineBounds<T> {
+    value: T,
+}
+
+#[actify]
+impl<T: Clone + Debug + Send + Sync + 'static> InlineBounds<T> {
+    fn get_value(&self) -> T {
+        self.value.clone()
+    }
+}
+
+/// A self type whose generic argument is not the bare type parameter
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
+struct Wrapper<C> {
+    items: C,
+}
+
+#[actify]
+impl<T> Wrapper<Vec<T>>
+where
+    T: Clone + Debug + Send + Sync + 'static,
+{
+    fn first_item(&self) -> Option<T> {
+        self.items.first().cloned()
+    }
+}
+
+/// A const generic parameter on the impl block
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
+struct ConstActor<const N: usize> {
+    data: [u8; N],
+}
+
+#[actify]
+impl<const N: usize> ConstActor<N> {
+    fn capacity(&self) -> usize {
+        N
+    }
+}
+
 #[derive(Clone, Debug)]
 struct ComplexActorTypes;
 
@@ -427,6 +472,30 @@ mod tests {
         assert_eq!(actor_handle.foo(0, HashMap::new()).await, 1.);
         assert_eq!(actor_handle.bar(5, |i: usize| i + 10).await, 15);
         assert_eq!(actor_handle.baz(0).await, 2.);
+    }
+
+    /// Bounds written inline on the impl block must not leak into the generated
+    /// trait reference or the call expression, where they are not valid syntax
+    #[tokio::test]
+    async fn test_inline_generic_bounds() {
+        let handle = Handle::new(InlineBounds { value: 7_i32 });
+        assert_eq!(handle.get_value().await, 7);
+    }
+
+    /// The call must go through the full self type: `Wrapper<Vec<T>>`, not
+    /// `Wrapper<T>` reconstructed from the impl block's generic parameters
+    #[tokio::test]
+    async fn test_non_identity_generic_argument() {
+        let handle = Handle::new(Wrapper {
+            items: vec![1_u8, 2, 3],
+        });
+        assert_eq!(handle.first_item().await, Some(1));
+    }
+
+    #[tokio::test]
+    async fn test_impl_level_const_generic() {
+        let handle = Handle::new(ConstActor { data: [0_u8; 4] });
+        assert_eq!(handle.capacity().await, 4);
     }
 
     /// Argument names like `s`, `args`, `res` and `result` must not clash with

--- a/actify-test/src/main.rs
+++ b/actify-test/src/main.rs
@@ -170,7 +170,7 @@ struct ConstActor<const N: usize> {
 
 #[actify]
 impl<const N: usize> ConstActor<N> {
-    fn capacity(&self) -> usize {
+    fn slots(&self) -> usize {
         N
     }
 }
@@ -495,7 +495,7 @@ mod tests {
     #[tokio::test]
     async fn test_impl_level_const_generic() {
         let handle = Handle::new(ConstActor { data: [0_u8; 4] });
-        assert_eq!(handle.capacity().await, 4);
+        assert_eq!(handle.slots().await, 4);
     }
 
     /// Argument names like `s`, `args`, `res` and `result` must not clash with


### PR DESCRIPTION
Fifth PR of the 0.8.3 release train. TDD: commit 1 is the failing tests, commit 2 the fix.

### The bug

The generated code rebuilt generics from the impl block's **parameter list** rather than using the self type as written. Three shapes were broken — silently, since every existing test and doc example happens to use a `where` clause with identity parameters:

| Shape | Generated | Error |
|---|---|---|
| `impl<T: Clone> InlineBounds<T>` | `InlineBoundsHandle<T: Clone>` in trait-ref position | `E0229: associated item constraints are not allowed here` |
| `impl<const N: usize> ConstActor<N>` | `ConstActorHandle<const N: usize>` | `error: unexpected const parameter declaration` |
| `impl<T> Wrapper<Vec<T>>` | `Wrapper::<T>::method(...)` | `E0599: no associated function 'first_item' found for struct 'Wrapper<T>'` |

The third is the nastiest: `Wrapper::<T>` is a *different type* than `Wrapper<Vec<T>>`, so the call silently targets the wrong thing.

### The fix

- `generics.split_for_impl()` — bounds and `const` declarations stay in the impl's parameter list; the trait reference gets `TypeGenerics`, which renders bare parameter names. The `__V` broadcast parameter is appended before splitting, so it lands in impl position only.
- `build_call_prefix` now emits `<SelfType>::method` using `info.impl_type` verbatim. This is correct for every self type by construction, and it collapses the direct-impl and trait-impl branches into one shape (`<Type>` vs `<Type as Trait>`).

### Incidental finding

The const-generic test originally named its method `capacity` and failed with `` `usize` is not a future ``: the inherent `Handle::capacity()` shadows any generated trait method of the same name, since inherent methods win method resolution. That's independent supporting evidence for removing `Handle::capacity` in 0.9.0 — it silently steals user method names. Test method renamed to `slots`.

### Verified locally on rustc 1.97.1 (matching CI)

- 132 tests pass, including the three new ones and the full trybuild suite (no `.stderr` changes needed — those files contain our own `compile_error!` output, which is stable across rustc versions)
- `cargo clippy --workspace --all-targets --all-features` — zero issues
- `cargo fmt --all --check`, `cargo doc` with `-D warnings`, and the MSRV check — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)