### PR TITLE
Validate method signatures and return types in the macro

### DIFF
--- a/actify-macros/src/parse.rs
+++ b/actify-macros/src/parse.rs
@@ -170,7 +170,20 @@ impl MethodInfo {
             skip_attr.is_some()
         };
 
-        if let Err(error) = validate_has_receiver(method) {
+        if let Err(error) = validate_signature_modifiers(method) {
+            accumulate(&mut errors, error);
+        }
+
+        if let Err(error) = validate_receiver(method) {
+            accumulate(&mut errors, error);
+        }
+
+        let output_type = match &method.sig.output {
+            ReturnType::Type(_, ty) => ty.clone(),
+            ReturnType::Default => Box::new(syn::parse_quote! { () }),
+        };
+
+        if let Err(error) = validate_return_type(&output_type) {
             accumulate(&mut errors, error);
         }
 
@@ -185,11 +198,6 @@ impl MethodInfo {
         if let Some(errors) = errors {
             return Err(errors);
         }
-
-        let output_type = match &method.sig.output {
-            ReturnType::Type(_, ty) => ty.clone(),
-            ReturnType::Default => Box::new(syn::parse_quote! { () }),
-        };
 
         let attributes = filter_attributes(&method.attrs);
 
@@ -268,29 +276,88 @@ fn filter_attributes(attrs: &[Attribute]) -> Vec<Attribute> {
         .collect()
 }
 
-/// Verify the method has a receiver (`&self` or `&mut self`).
-fn validate_has_receiver(method: &ImplItemFn) -> syn::Result<()> {
-    let has_receiver = method
-        .sig
-        .inputs
-        .iter()
-        .any(|arg| matches!(arg, FnArg::Receiver(_)));
+/// Verify the method has a receiver and that it borrows rather than consumes.
+fn validate_receiver(method: &ImplItemFn) -> syn::Result<()> {
+    let receiver = method.sig.inputs.iter().find_map(|arg| match arg {
+        FnArg::Receiver(receiver) => Some(receiver),
+        FnArg::Typed(_) => None,
+    });
 
-    if !has_receiver {
+    let Some(receiver) = receiver else {
         return Err(Error::new(
             method.span(),
             "Static method cannot be actified: the method requires a receiver to the impl type, using either &self or &mut self",
+        ));
+    };
+
+    // The actor owns its state for as long as it runs, so it can only lend it
+    // to a method. Consuming it would leave the actor without state to serve
+    // the next job.
+    if receiver.reference.is_none() {
+        return Err(Error::new(
+            receiver.span(),
+            "Actor methods cannot take self by value: the actor owns its state for its entire lifetime, so use &self or &mut self",
         ));
     }
 
     Ok(())
 }
 
+/// Verify the method has no signature modifier the generated handle cannot honour.
+fn validate_signature_modifiers(method: &ImplItemFn) -> syn::Result<()> {
+    if let Some(unsafety) = method.sig.unsafety {
+        return Err(Error::new(
+            unsafety.span,
+            "Unsafe methods cannot be actified: the generated handle would call them from safe code, so the safety contract could not be upheld",
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate that a return type can travel back from the actor task.
+///
+/// Results are boxed as `Box<dyn Any + Send>`, which requires an owned
+/// `'static` type, and the generated code names the type in a `let` binding.
+///
+/// Unlike arguments this rejects a known set rather than accepting one: return
+/// types are more varied, and an allowlist risks refusing something that
+/// compiles fine today.
+fn validate_return_type(ty: &Type) -> syn::Result<()> {
+    match ty {
+        // `&'static T` outlives the actor and boxes fine. Any other borrow is
+        // tied to the actor's state and cannot leave the task with the result.
+        Type::Reference(reference)
+            if !reference
+                .lifetime
+                .as_ref()
+                .is_some_and(|lifetime| lifetime.ident == "static") =>
+        {
+            Err(Error::new_spanned(
+                ty,
+                "Actor methods must return owned types or 'static references: a result borrowed from the actor state cannot outlive the call (e.g. return String instead of &str)",
+            ))
+        }
+
+        Type::ImplTrait(_) => Err(Error::new_spanned(
+            ty,
+            "impl Trait is not supported as an actor method return type; return a concrete owned type instead (e.g. Vec<T> rather than impl Iterator<Item = T>)",
+        )),
+
+        Type::Ptr(_) => Err(Error::new_spanned(
+            ty,
+            "Raw pointer types (*const T, *mut T) are not supported as actor method return types because they are not Send",
+        )),
+
+        _ => Ok(()),
+    }
+}
+
 /// Extract and validate argument names and types from method inputs.
 /// For ident patterns, uses the original name. For non-ident patterns (e.g.
 /// destructuring `(a, b): (i32, i32)`), generates a positional name so the
 /// handle can box/unbox the value; the original method destructures at the call site.
-#[allow(clippy::type_complexity, clippy::single_match)]
+#[allow(clippy::type_complexity)]
 fn transform_args(
     args: &Punctuated<FnArg, Comma>,
 ) -> syn::Result<(Punctuated<Ident, Comma>, Punctuated<Type, Comma>)> {
@@ -316,7 +383,8 @@ fn transform_args(
                 arg_names.push(ident);
                 arg_types.push(*pat_type.ty.clone());
             }
-            _ => {}
+            // Checked by validate_receiver; it contributes no boxed argument.
+            syn::FnArg::Receiver(_) => {}
         }
     }
 

--- a/actify-test/src/main.rs
+++ b/actify-test/src/main.rs
@@ -492,6 +492,14 @@ mod tests {
         assert_eq!(handle.first_item().await, Some(1));
     }
 
+    /// A `&'static` return outlives the actor, so it must keep working even
+    /// though borrows of the actor's own state are rejected
+    #[tokio::test]
+    async fn test_static_reference_return() {
+        let handle = Handle::new(CfgImplActor);
+        assert!(!handle.platform_value().await.is_empty());
+    }
+
     #[tokio::test]
     async fn test_impl_level_const_generic() {
         let handle = Handle::new(ConstActor { data: [0_u8; 4] });

--- a/actify-test/tests/compile_fail/by_value_self.rs
+++ b/actify-test/tests/compile_fail/by_value_self.rs
@@ -1,0 +1,16 @@
+// EXPECTED: a clear message that the receiver must be a reference.
+// The actor owns its state for its whole lifetime, so a method consuming
+// self cannot be dispatched through a handle.
+use actify::actify;
+
+#[derive(Clone, Debug)]
+struct MyActor;
+
+#[actify]
+impl MyActor {
+    fn consume(self) -> i32 {
+        42
+    }
+}
+
+fn main() {}

--- a/actify-test/tests/compile_fail/by_value_self.stderr
+++ b/actify-test/tests/compile_fail/by_value_self.stderr
@@ -1,0 +1,19 @@
+error[E0308]: mismatched types
+  --> tests/compile_fail/by_value_self.rs:9:1
+   |
+ 9 | #[actify]
+   | ^^^^^^^^^
+   | |
+   | expected `MyActor`, found `&MyActor`
+   | arguments to this function are incorrect
+   |
+note: method defined here
+  --> tests/compile_fail/by_value_self.rs:11:8
+   |
+11 |     fn consume(self) -> i32 {
+   |        ^^^^^^^ ----
+   = note: this error originates in the attribute macro `actify` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider using clone here
+   |
+ 9 | #[actify].clone()
+   |          ++++++++

--- a/actify-test/tests/compile_fail/by_value_self.stderr
+++ b/actify-test/tests/compile_fail/by_value_self.stderr
@@ -1,19 +1,5 @@
-error[E0308]: mismatched types
-  --> tests/compile_fail/by_value_self.rs:9:1
-   |
- 9 | #[actify]
-   | ^^^^^^^^^
-   | |
-   | expected `MyActor`, found `&MyActor`
-   | arguments to this function are incorrect
-   |
-note: method defined here
-  --> tests/compile_fail/by_value_self.rs:11:8
+error: Actor methods cannot take self by value: the actor owns its state for its entire lifetime, so use &self or &mut self
+  --> tests/compile_fail/by_value_self.rs:11:16
    |
 11 |     fn consume(self) -> i32 {
-   |        ^^^^^^^ ----
-   = note: this error originates in the attribute macro `actify` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider using clone here
-   |
- 9 | #[actify].clone()
-   |          ++++++++
+   |                ^^^^

--- a/actify-test/tests/compile_fail/impl_trait_return.rs
+++ b/actify-test/tests/compile_fail/impl_trait_return.rs
@@ -1,0 +1,16 @@
+// EXPECTED: a clear message that impl Trait is not supported as a return type.
+// The generated code names the return type in a let binding, where an
+// opaque type is not valid syntax.
+use actify::actify;
+
+#[derive(Clone, Debug)]
+struct MyActor;
+
+#[actify]
+impl MyActor {
+    fn counter(&self) -> impl Iterator<Item = u8> {
+        core::iter::once(1)
+    }
+}
+
+fn main() {}

--- a/actify-test/tests/compile_fail/impl_trait_return.stderr
+++ b/actify-test/tests/compile_fail/impl_trait_return.stderr
@@ -1,0 +1,8 @@
+error[E0562]: `impl Trait` is not allowed in the type of variable bindings
+  --> tests/compile_fail/impl_trait_return.rs:11:26
+   |
+11 |     fn counter(&self) -> impl Iterator<Item = u8> {
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `impl Trait` is only allowed in arguments and return types of functions and methods
+   = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information

--- a/actify-test/tests/compile_fail/impl_trait_return.stderr
+++ b/actify-test/tests/compile_fail/impl_trait_return.stderr
@@ -1,8 +1,5 @@
-error[E0562]: `impl Trait` is not allowed in the type of variable bindings
+error: impl Trait is not supported as an actor method return type; return a concrete owned type instead (e.g. Vec<T> rather than impl Iterator<Item = T>)
   --> tests/compile_fail/impl_trait_return.rs:11:26
    |
 11 |     fn counter(&self) -> impl Iterator<Item = u8> {
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: `impl Trait` is only allowed in arguments and return types of functions and methods
-   = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information

--- a/actify-test/tests/compile_fail/reference_return.rs
+++ b/actify-test/tests/compile_fail/reference_return.rs
@@ -1,0 +1,18 @@
+// EXPECTED: a clear message that return types must be owned.
+// Results travel back from the actor task as Box<dyn Any + Send>, which
+// requires 'static, so a borrow of the actor state cannot escape.
+use actify::actify;
+
+#[derive(Clone, Debug)]
+struct MyActor {
+    name: String,
+}
+
+#[actify]
+impl MyActor {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+fn main() {}

--- a/actify-test/tests/compile_fail/reference_return.stderr
+++ b/actify-test/tests/compile_fail/reference_return.stderr
@@ -1,0 +1,10 @@
+error: lifetime may not live long enough
+  --> tests/compile_fail/reference_return.rs:11:1
+   |
+11 | #[actify]
+   | -^^^^^^^^
+   | |
+   | let's call the lifetime of this reference `'1`
+   | cast requires that `'1` must outlive `'static`
+   |
+   = note: this error originates in the attribute macro `actify` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/actify-test/tests/compile_fail/reference_return.stderr
+++ b/actify-test/tests/compile_fail/reference_return.stderr
@@ -1,10 +1,5 @@
-error: lifetime may not live long enough
-  --> tests/compile_fail/reference_return.rs:11:1
+error: Actor methods must return owned types or 'static references: a result borrowed from the actor state cannot outlive the call (e.g. return String instead of &str)
+  --> tests/compile_fail/reference_return.rs:13:23
    |
-11 | #[actify]
-   | -^^^^^^^^
-   | |
-   | let's call the lifetime of this reference `'1`
-   | cast requires that `'1` must outlive `'static`
-   |
-   = note: this error originates in the attribute macro `actify` (in Nightly builds, run with -Z macro-backtrace for more info)
+13 |     fn name(&self) -> &str {
+   |                       ^^^^

--- a/actify-test/tests/compile_fail/unsafe_method.rs
+++ b/actify-test/tests/compile_fail/unsafe_method.rs
@@ -1,0 +1,16 @@
+// EXPECTED: a clear message that unsafe methods cannot be actified.
+// The generated handle calls the method from safe code, so without a
+// dedicated check the failure surfaces inside generated tokens.
+use actify::actify;
+
+#[derive(Clone, Debug)]
+struct MyActor;
+
+#[actify]
+impl MyActor {
+    unsafe fn danger(&self) -> i32 {
+        42
+    }
+}
+
+fn main() {}

--- a/actify-test/tests/compile_fail/unsafe_method.stderr
+++ b/actify-test/tests/compile_fail/unsafe_method.stderr
@@ -1,8 +1,5 @@
-error[E0133]: call to unsafe function `MyActor::danger` is unsafe and requires unsafe block
- --> tests/compile_fail/unsafe_method.rs:9:1
-  |
-9 | #[actify]
-  | ^^^^^^^^^ call to unsafe function
-  |
-  = note: consult the function's documentation for information on how to avoid undefined behavior
-  = note: this error originates in the attribute macro `actify` (in Nightly builds, run with -Z macro-backtrace for more info)
+error: Unsafe methods cannot be actified: the generated handle would call them from safe code, so the safety contract could not be upheld
+  --> tests/compile_fail/unsafe_method.rs:11:5
+   |
+11 |     unsafe fn danger(&self) -> i32 {
+   |     ^^^^^^

--- a/actify-test/tests/compile_fail/unsafe_method.stderr
+++ b/actify-test/tests/compile_fail/unsafe_method.stderr
@@ -1,0 +1,8 @@
+error[E0133]: call to unsafe function `MyActor::danger` is unsafe and requires unsafe block
+ --> tests/compile_fail/unsafe_method.rs:9:1
+  |
+9 | #[actify]
+  | ^^^^^^^^^ call to unsafe function
+  |
+  = note: consult the function's documentation for information on how to avoid undefined behavior
+  = note: this error originates in the attribute macro `actify` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/actify-test/tests/unsupported_arg_types.rs
+++ b/actify-test/tests/unsupported_arg_types.rs
@@ -21,8 +21,14 @@ fn compile_fail_tests() {
     t.compile_fail("tests/compile_fail/impl_trait_arg.rs");
     t.compile_fail("tests/compile_fail/unsupported_arg_type.rs");
 
+    // Return type validation
+    t.compile_fail("tests/compile_fail/reference_return.rs");
+    t.compile_fail("tests/compile_fail/impl_trait_return.rs");
+
     // Method validation
     t.compile_fail("tests/compile_fail/static_method.rs");
+    t.compile_fail("tests/compile_fail/unsafe_method.rs");
+    t.compile_fail("tests/compile_fail/by_value_self.rs");
 
     // Superfluous broadcast attributes
     t.compile_fail("tests/compile_fail/superfluous_skip_broadcast.rs");


### PR DESCRIPTION
Seventh PR of the 0.8.3 release train. TDD: commit 1 adds four trybuild cases whose snapshots record today's diagnostics; commit 2 fixes them. **The snapshot diff is the proof.**

### Before

None of these four shapes was checked, so each failed from inside generated tokens and pointed at the `#[actify]` attribute rather than the code:

| Shape | Diagnostic today |
|---|---|
| `unsafe fn danger(&self)` | `E0133: call to unsafe function` — attributed to `#[actify]` |
| `fn consume(self)` | `E0308: expected MyActor, found &MyActor`, plus `help: consider using clone here` suggesting **`#[actify].clone()`** |
| `fn name(&self) -> &str` | `error: lifetime may not live long enough` on the attribute |
| `fn counter(&self) -> impl Iterator<..>` | `E0562: impl Trait is not allowed in the type of variable bindings` |

### After

Each reports at the offending token with a message saying what to do instead — e.g. *"Actor methods cannot take self by value: the actor owns its state for its entire lifetime, so use `&self` or `&mut self`"*. Thanks to #67 these also accumulate, so a method with several problems reports them together.

### Two decisions worth reviewing

**Return types use a denylist, not an allowlist.** Arguments are validated against an allowlist of accepted types; doing the same for returns would risk refusing something that compiles fine today, which is unacceptable in a patch release. So only `impl Trait`, raw pointers, and non-`'static` references are rejected.

**`&'static` returns stay legal — and this nearly shipped as a regression.** My first draft rejected *every* reference return, and `cargo test --workspace` failed on this crate's own `fn platform_value(&self) -> &'static str`. A `&'static` borrow outlives the actor and boxes fine; only borrows of the actor's state are the problem. There's now a passing test (`test_static_reference_return`) locking that in.

### Bonus: the wildcard is gone

`syn::FnArg` turns out not to be `#[non_exhaustive]`, so `transform_args` now matches `Receiver` and `Typed` exhaustively — no wildcard at all. If a future syn adds a variant, actify-macros fails to build instead of silently dropping arguments. That's a stronger guarantee than the nightly-only `non_exhaustive_omitted_patterns` lint the (inert) attribute removed in #60 was reaching for, and it works on stable.

Scope note: strict attribute-path matching (`#[other_crate::broadcast]` being silently consumed) is a separate concern and gets its own PR.

### Verified locally on rustc 1.97.1 (matching CI)

133 tests pass including the full trybuild suite; clippy `--all-targets --all-features` clean; fmt clean; `cargo doc` with `-D warnings` clean; MSRV check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)