### PR TITLE
Match only actify's own marker attribute paths

### DIFF
--- a/actify-macros/src/parse.rs
+++ b/actify-macros/src/parse.rs
@@ -267,10 +267,19 @@ fn filter_attributes(attrs: &[Attribute]) -> Vec<Attribute> {
 }
 
 /// Find one of actify's marker attributes (`broadcast`, `skip_broadcast`).
+///
+/// Only the two spellings actify actually exports are recognised: bare
+/// (`#[broadcast]`, via a `use`) and crate-qualified (`#[actify::broadcast]`).
+/// Matching a name anywhere in the path would claim another crate's attribute,
+/// and the author would be told their own attribute is a superfluous actify one.
 fn find_marker_attribute<'a>(attrs: &'a [Attribute], name: &str) -> Option<&'a Attribute> {
-    attrs
-        .iter()
-        .find(|attr| attr.path().segments.iter().any(|seg| seg.ident == name))
+    attrs.iter().find(|attr| {
+        let path = attr.path();
+        path.is_ident(name)
+            || (path.segments.len() == 2
+                && path.segments[0].ident == "actify"
+                && path.segments[1].ident == name)
+    })
 }
 
 /// Verify the method has a receiver and that it borrows rather than consumes.

--- a/actify-macros/src/parse.rs
+++ b/actify-macros/src/parse.rs
@@ -129,18 +129,8 @@ impl MethodInfo {
         });
         let is_async = method.sig.asyncness.is_some();
 
-        let skip_attr = method.attrs.iter().find(|attr| {
-            attr.path()
-                .segments
-                .iter()
-                .any(|seg| seg.ident == "skip_broadcast")
-        });
-        let broadcast_attr = method.attrs.iter().find(|attr| {
-            attr.path()
-                .segments
-                .iter()
-                .any(|seg| seg.ident == "broadcast")
-        });
+        let skip_attr = find_marker_attribute(&method.attrs, "skip_broadcast");
+        let broadcast_attr = find_marker_attribute(&method.attrs, "broadcast");
 
         let mut errors = None;
 
@@ -274,6 +264,13 @@ fn filter_attributes(attrs: &[Attribute]) -> Vec<Attribute> {
         .filter(|attr| is_propagated_attribute(attr))
         .cloned()
         .collect()
+}
+
+/// Find one of actify's marker attributes (`broadcast`, `skip_broadcast`).
+fn find_marker_attribute<'a>(attrs: &'a [Attribute], name: &str) -> Option<&'a Attribute> {
+    attrs
+        .iter()
+        .find(|attr| attr.path().segments.iter().any(|seg| seg.ident == name))
 }
 
 /// Verify the method has a receiver and that it borrows rather than consumes.
@@ -494,6 +491,45 @@ mod tests {
         let filtered = filter_attributes(&attrs);
         assert_eq!(filtered.len(), 1);
         assert!(filtered[0].path().is_ident("doc"));
+    }
+
+    #[test]
+    fn marker_attributes_are_recognised_bare_and_qualified() {
+        let attrs: Vec<Attribute> = vec![attr(parse_quote!(#[broadcast]))];
+        assert!(find_marker_attribute(&attrs, "broadcast").is_some());
+
+        let attrs: Vec<Attribute> = vec![attr(parse_quote!(#[actify::broadcast]))];
+        assert!(find_marker_attribute(&attrs, "broadcast").is_some());
+
+        let attrs: Vec<Attribute> = vec![attr(parse_quote!(#[skip_broadcast]))];
+        assert!(find_marker_attribute(&attrs, "skip_broadcast").is_some());
+
+        let attrs: Vec<Attribute> = vec![attr(parse_quote!(#[actify::skip_broadcast]))];
+        assert!(find_marker_attribute(&attrs, "skip_broadcast").is_some());
+    }
+
+    /// Another crate's attribute must not be mistaken for one of actify's, or
+    /// the user is told their own attribute is a superfluous actify one.
+    #[test]
+    fn marker_attributes_of_other_crates_are_ignored() {
+        let attrs: Vec<Attribute> = vec![attr(parse_quote!(#[other_crate::broadcast]))];
+        assert!(find_marker_attribute(&attrs, "broadcast").is_none());
+
+        let attrs: Vec<Attribute> = vec![attr(parse_quote!(#[broadcast::configure]))];
+        assert!(find_marker_attribute(&attrs, "broadcast").is_none());
+
+        let attrs: Vec<Attribute> = vec![attr(parse_quote!(#[a::b::skip_broadcast]))];
+        assert!(find_marker_attribute(&attrs, "skip_broadcast").is_none());
+    }
+
+    /// `skip_broadcast` must not register as `broadcast`.
+    #[test]
+    fn marker_attribute_names_do_not_overlap() {
+        let attrs: Vec<Attribute> = vec![attr(parse_quote!(#[skip_broadcast]))];
+        assert!(find_marker_attribute(&attrs, "broadcast").is_none());
+
+        let attrs: Vec<Attribute> = vec![attr(parse_quote!(#[actify::skip_broadcast]))];
+        assert!(find_marker_attribute(&attrs, "broadcast").is_none());
     }
 
     #[test]


### PR DESCRIPTION
Eighth PR of the 0.8.3 release train, and the last macro-focused one. TDD: commit 1 adds the failing test, commit 2 fixes it.

### The bug

The marker attributes were detected by checking whether **any** path segment carried the name:

```rust
attr.path().segments.iter().any(|seg| seg.ident == "broadcast")
```

So `#[other_crate::broadcast]` on a method inside an `#[actify]` impl block was claimed as actify's own. The user-visible result is worse than silent consumption: since the block broadcasts by default, actify rejects the method with

> `#[broadcast]` is superfluous: methods already broadcast by default; use `#[actify(skip_broadcast)]` on the impl block to change the default

— telling the author that *their* unrelated attribute is a redundant actify one. `#[broadcast::configure]` and `#[a::b::skip_broadcast]` matched the same way.

### The fix

Only the two spellings actify actually exports are recognised: bare (`#[broadcast]`, via a `use`) and crate-qualified (`#[actify::broadcast]`). Everything else passes through untouched.

### Tests

The lookup was first extracted into `find_marker_attribute` with behaviour unchanged (commit 1), so the rule could be tested directly. Three unit tests cover it:

- both accepted spellings, for both markers
- `#[other_crate::broadcast]`, `#[broadcast::configure]`, `#[a::b::skip_broadcast]` are ignored — **this one failed before the fix**
- `skip_broadcast` does not register as `broadcast` (it never did, but the names overlap as substrings, so it's worth pinning)

A trybuild case would have been the more end-to-end proof, but demonstrating it needs a *second* crate exporting an attribute named `broadcast`, which the workspace has no reason to carry. The unit tests exercise the same predicate the macro uses.

### Verified locally on rustc 1.97.1 (matching CI)

136 tests pass including the full trybuild suite; clippy `--all-targets --all-features` clean; fmt clean; `cargo doc` with `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)