### PR TITLE
Label set_if_changed broadcasts with their own method name

### DIFF
--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -287,7 +287,7 @@ impl<T: Send + Sync + 'static, V> Handle<T, V> {
         self.run(val, |s, val| {
             if s.inner != val {
                 s.inner = val;
-                s.broadcast(&format!("{}::set", type_name::<T>()));
+                s.broadcast(&format!("{}::set_if_changed", type_name::<T>()));
             }
         })
         .await

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -491,6 +491,35 @@ mod tests {
         handle.panic().await;
     }
 
+    /// The profiler counts broadcasts per method name, so each method must
+    /// report its own name.
+    ///
+    /// The counters are process-global and shared with every test running in
+    /// parallel, so this uses a type no other test touches and only inspects
+    /// the keys belonging to it.
+    #[cfg(feature = "profiler")]
+    #[tokio::test]
+    async fn test_set_if_changed_broadcasts_under_its_own_name() {
+        #[derive(Debug, Clone, PartialEq)]
+        struct SetIfChangedProbe(i32);
+
+        let handle = Handle::new(SetIfChangedProbe(0));
+        handle.set_if_changed(SetIfChangedProbe(1)).await;
+
+        let counts = crate::get_broadcast_counts();
+        let keys: Vec<_> = counts
+            .keys()
+            .filter(|key| key.contains("SetIfChangedProbe"))
+            .collect();
+
+        assert_eq!(keys.len(), 1, "expected a single label, got {keys:?}");
+        assert!(
+            keys[0].ends_with("::set_if_changed"),
+            "broadcast was labelled {}",
+            keys[0]
+        );
+    }
+
     #[derive(Debug, Clone)]
     struct PanicStruct {}
 


### PR DESCRIPTION
Ninth PR of the 0.8.3 release train, and the first runtime fix. TDD: commit 1 is the failing test, commit 2 the one-word fix.

### The bug

`Handle::set_if_changed` announced its broadcast as `set`:

```rust
s.broadcast(&format!("{}::set", type_name::<T>()));   // in set_if_changed
```

Every broadcast label is a profiler counter key (`actor.rs`), so calls to `set_if_changed` were counted against `set`. Anyone reading `get_broadcast_counts()` saw an inflated figure for `set` and **no entry at all** for `set_if_changed` — the exact opposite of what the profiler exists to tell you, and misleading in precisely the case it is used for: finding which method is flooding subscribers.

Only the label was wrong; broadcast behaviour itself was always correct.

### The test

It asserts on the label rather than on a count, because the profiler's counters are a **process-global `Mutex<HashMap>`** shared by every test in the binary — absolute counts are not assertable under parallel execution. So the test declares a probe type that no other test uses, filters the counter keys to that type, and asserts there is exactly one, ending in `::set_if_changed`. Before the fix it failed with:

```
broadcast was labelled ...::SetIfChangedProbe::set
```

The test is `#[cfg(feature = "profiler")]`, so it runs in the `test-features` CI job and under `cargo test --workspace` (where feature unification enables the profiler), but not in the default-feature `cargo test -p actify` leg.

### Verified locally on rustc 1.97.1 (matching CI)

137 tests pass across all feature legs; clippy `--all-targets --all-features` clean; fmt clean; `cargo doc` with `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)