### PR TITLE
Deliver queued updates before reporting a closed cache channel

### DIFF
--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -58,6 +58,11 @@ where
 
     /// Drains all buffered messages from the channel, keeping only the newest value.
     /// Returns `true` if any value was stored.
+    ///
+    /// A closed channel is only reported once its queue is exhausted: an actor
+    /// that broadcasts a final update and then stops leaves that update behind,
+    /// and it is usually the one worth having. Closing is permanent, so the
+    /// next call reports it.
     fn drain_to_newest(&mut self) -> Result<bool, CacheRecvNewestError> {
         let mut received = false;
         loop {
@@ -67,6 +72,7 @@ where
                     received = true;
                 }
                 Err(TryRecvError::Empty) => return Ok(received),
+                Err(TryRecvError::Closed) if received => return Ok(true),
                 Err(TryRecvError::Closed) => return Err(CacheRecvNewestError::Closed),
                 Err(TryRecvError::Lagged(nr)) => log_lag::<T>(nr),
             }
@@ -156,7 +162,8 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`CacheRecvNewestError::Closed`] if the actor is dropped (after the first call).
+    /// Returns [`CacheRecvNewestError::Closed`] once the actor has been dropped
+    /// and every update it broadcast has been delivered (after the first call).
     ///
     /// # Examples
     ///
@@ -248,7 +255,9 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`CacheRecvNewestError::Closed`] if the actor is dropped.
+    /// Returns [`CacheRecvNewestError::Closed`] once the actor has been dropped
+    /// and every update it broadcast has been delivered. A final update sent
+    /// just before the actor stopped is therefore still returned.
     ///
     /// # Examples
     ///
@@ -417,7 +426,8 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`CacheRecvNewestError::Closed`] if the actor is dropped (after the first call).
+    /// Returns [`CacheRecvNewestError::Closed`] once the actor has been dropped
+    /// and every update it broadcast has been delivered (after the first call).
     ///
     /// # Examples
     ///

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -661,6 +661,38 @@ mod tests {
         assert_eq!(cache.try_recv_newest(), Err(CacheRecvNewestError::Closed));
     }
 
+    /// A value broadcast just before the actor stops is still buffered in the
+    /// channel, so it must be delivered before the channel is reported closed.
+    #[tokio::test(start_paused = true)]
+    async fn test_last_value_before_close_is_not_lost() {
+        let handle = Handle::new(1);
+        let mut cache = handle.create_cache().await;
+        cache.try_recv_newest().unwrap(); // Consume first request
+
+        handle.set(2).await;
+        drop(handle); // The actor stops, but its last update is queued
+        sleep(Duration::from_millis(10)).await; // Let the actor task exit
+
+        assert_eq!(cache.try_recv_newest().unwrap(), Some(&2));
+        // Only once the queue is drained does the closed channel surface
+        assert_eq!(cache.try_recv_newest(), Err(CacheRecvNewestError::Closed));
+    }
+
+    /// The same guarantee for the awaiting variant.
+    #[tokio::test(start_paused = true)]
+    async fn test_recv_newest_returns_last_value_before_close() {
+        let handle = Handle::new(1);
+        let mut cache = handle.create_cache().await;
+        cache.recv_newest().await.unwrap(); // Consume first request
+
+        handle.set(2).await;
+        drop(handle);
+        sleep(Duration::from_millis(10)).await;
+
+        assert_eq!(cache.recv_newest().await.unwrap(), &2);
+        assert_eq!(cache.recv_newest().await, Err(CacheRecvNewestError::Closed));
+    }
+
     #[tokio::test(start_paused = true)]
     async fn test_blocking_recv() {
         let handle = Handle::new(1);


### PR DESCRIPTION
Tenth PR of the 0.8.3 release train. TDD: commit 1 adds the tests, commit 2 fixes the bug.

### The bug

`drain_to_newest` tracked whether it had stored a value, then threw that away when the channel turned out to be closed:

```rust
Ok(val) => { self.inner = val; received = true; }
Err(TryRecvError::Closed) => return Err(CacheRecvNewestError::Closed),   // `received` lost
```

An actor that broadcasts a final update and then stops leaves that update sitting in the channel. `try_recv_newest` (and `get_newest`, which calls it) would receive it, store it, and then report `Err(Closed)` — so the caller saw an error for a call that had genuinely received data, and the value silently became unreachable. Being the *newest* value at shutdown, it is usually the one worth having.

### The fix

A closed channel is only reported once its queue is exhausted; the value is returned now and `Closed` surfaces on the next call, since closing is permanent.

```rust
Err(TryRecvError::Closed) if received => return Ok(true),
Err(TryRecvError::Closed) => return Err(CacheRecvNewestError::Closed),
```

### What the tests showed

Two tests were added, and only one failed — which is itself the interesting part:

- `test_last_value_before_close_is_not_lost` (`try_recv_newest`) **failed**: `Err(Closed)` instead of the queued value.
- `test_recv_newest_returns_last_value_before_close` (`recv_newest`) **already passed**: the awaiting path takes buffered values from `rx.recv()` before the channel reports closed.

So the two families disagreed at shutdown, and only the non-blocking one lost data. Both tests are kept, pinning them to the same guarantee. I also checked `blocking_recv_newest`, which re-implements the drain inline — it uses `blocking_recv()` and was never affected.

The existing `test_closed_channel` still passes unchanged: nothing is broadcast before the drop there, so `Closed` is still reported immediately.

### Docs

The three `# Errors` sections for the `*_newest` family said `Closed` is returned "if the actor is dropped"; they now say once the actor has been dropped **and every update it broadcast has been delivered**.

### Verified locally on rustc 1.97.1 (matching CI)

139 tests pass across all feature legs; clippy `--all-targets --all-features` clean; fmt clean; `cargo doc` with `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)