### PR TITLE
Document that get_newest counts as the cache's first read

### DIFF
--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -102,6 +102,10 @@ where
     /// Returns the newest value available, draining any pending updates from the channel.
     /// If the channel is closed, returns the last known value without error.
     ///
+    /// This is a read: it does not count as the first call to
+    /// [`recv`](Self::recv), [`try_recv`](Self::try_recv) or their `_newest`
+    /// counterparts, so a later receive still yields the initial value.
+    ///
     /// Note: when the cache is initialized with a default value (e.g. via
     /// [`create_cache_from_default`](crate::Handle::create_cache_from_default)),
     /// the returned value may differ from the actor's actual value until a broadcast occurs.
@@ -122,7 +126,9 @@ where
     /// # }
     /// ```
     pub fn get_newest(&mut self) -> &T {
-        _ = self.try_recv_newest(); // Update if possible
+        // Drains directly rather than through try_recv_newest, which would also
+        // spend the first-request token that belongs to the recv methods.
+        _ = self.drain_to_newest(); // Update if possible
         self.get_current()
     }
 

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -634,6 +634,29 @@ mod tests {
         assert_eq!(cache.get_newest(), &3);
     }
 
+    /// Reading the cache must not change what a later receive returns: the
+    /// first-call semantics of the recv methods belong to those methods.
+    #[tokio::test(start_paused = true)]
+    async fn test_get_newest_leaves_first_receive_intact() {
+        let handle = Handle::new(1);
+        let mut cache = handle.create_cache().await;
+
+        assert_eq!(cache.get_newest(), &1);
+
+        // The first receive still yields the initial value
+        assert_eq!(cache.try_recv().unwrap(), Some(&1));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_get_newest_leaves_first_receive_newest_intact() {
+        let handle = Handle::new(1);
+        let mut cache = handle.create_cache().await;
+
+        assert_eq!(cache.get_newest(), &1);
+
+        assert_eq!(cache.try_recv_newest().unwrap(), Some(&1));
+    }
+
     #[tokio::test(start_paused = true)]
     async fn test_has_updates() {
         let handle = Handle::new(1);

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -102,9 +102,9 @@ where
     /// Returns the newest value available, draining any pending updates from the channel.
     /// If the channel is closed, returns the last known value without error.
     ///
-    /// This is a read: it does not count as the first call to
-    /// [`recv`](Self::recv), [`try_recv`](Self::try_recv) or their `_newest`
-    /// counterparts, so a later receive still yields the initial value.
+    /// This delivers the cache's current value, so it counts as the first read.
+    /// A later [`recv`](Self::recv) or [`try_recv`](Self::try_recv) waits for
+    /// the next update instead of handing back a value already seen here.
     ///
     /// Note: when the cache is initialized with a default value (e.g. via
     /// [`create_cache_from_default`](crate::Handle::create_cache_from_default)),
@@ -125,10 +125,22 @@ where
     /// assert_eq!(cache.get_newest(), &3); // Synchronizes with latest value
     /// # }
     /// ```
+    ///
+    /// Reading here leaves nothing for the first receive to hand back:
+    ///
+    /// ```
+    /// # use actify::Handle;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(1);
+    /// let mut cache = handle.create_cache().await;
+    ///
+    /// assert_eq!(cache.get_newest(), &1);
+    /// assert_eq!(cache.try_recv().unwrap(), None);
+    /// # }
+    /// ```
     pub fn get_newest(&mut self) -> &T {
-        // Drains directly rather than through try_recv_newest, which would also
-        // spend the first-request token that belongs to the recv methods.
-        _ = self.drain_to_newest(); // Update if possible
+        _ = self.try_recv_newest(); // Update if possible
         self.get_current()
     }
 
@@ -159,8 +171,9 @@ where
 
     /// Receives the newest broadcasted value from the actor, discarding any older messages.
     ///
-    /// On the first call, returns the current cached value immediately, even if the channel is
-    /// closed. On subsequent calls, waits until an update is available.
+    /// On the first read of the cache, returns the current value immediately, even if the channel
+    /// is closed. Afterwards, waits until an update is available. A preceding
+    /// [`get_newest`](Self::get_newest) counts as that first read.
     ///
     /// Note: when the cache is initialized with a default value (e.g. via
     /// [`create_cache_from_default`](crate::Handle::create_cache_from_default)),
@@ -210,8 +223,9 @@ where
 
     /// Receives the next broadcasted value from the actor (FIFO).
     ///
-    /// On the first call, returns the current cached value immediately, even if the channel is
-    /// closed. On subsequent calls, waits until an update is available.
+    /// On the first read of the cache, returns the current value immediately, even if the channel
+    /// is closed. Afterwards, waits until an update is available. A preceding
+    /// [`get_newest`](Self::get_newest) counts as that first read.
     ///
     /// Note: when the cache is initialized with a default value (e.g. via
     /// [`create_cache_from_default`](crate::Handle::create_cache_from_default)),
@@ -252,8 +266,9 @@ where
     /// Tries to receive the newest broadcasted value from the actor, discarding any older
     /// messages. Returns immediately without waiting.
     ///
-    /// On the first call, returns `Some` with the current cached value, even if no updates are
-    /// present. On subsequent calls, returns `None` if no new updates are available.
+    /// On the first read of the cache, returns `Some` with the current value, even if no updates
+    /// are present. Afterwards, returns `None` if no new updates are available. A preceding
+    /// [`get_newest`](Self::get_newest) counts as that first read.
     ///
     /// Note: when the cache is initialized with a default value (e.g. via
     /// [`create_cache_from_default`](crate::Handle::create_cache_from_default)),
@@ -315,9 +330,9 @@ where
     /// Tries to receive the next broadcasted value from the actor (FIFO). Returns immediately
     /// without waiting.
     ///
-    /// On the first call, returns `Some` with the current cached value, even if no updates are
-    /// present or the channel is closed. On subsequent calls, returns `None` if no new updates
-    /// are available.
+    /// On the first read of the cache, returns `Some` with the current value, even if no updates
+    /// are present or the channel is closed. Afterwards, returns `None` if no new updates are
+    /// available. A preceding [`get_newest`](Self::get_newest) counts as that first read.
     ///
     /// Note: when the cache is initialized with a default value (e.g. via
     /// [`create_cache_from_default`](crate::Handle::create_cache_from_default)),
@@ -423,8 +438,9 @@ where
     /// Blocking version of [`recv_newest`](Self::recv_newest). Receives the newest broadcasted
     /// value, discarding any older messages. Must not be called from an async context.
     ///
-    /// On the first call, returns the newest available value immediately, even if the channel is
-    /// closed. On subsequent calls, blocks until an update is available.
+    /// On the first read of the cache, returns the newest available value immediately, even if the
+    /// channel is closed. Afterwards, blocks until an update is available. A preceding
+    /// [`get_newest`](Self::get_newest) counts as that first read.
     ///
     /// Note: when the cache is initialized with a default value (e.g. via
     /// [`create_cache_from_default`](crate::Handle::create_cache_from_default)),
@@ -640,27 +656,38 @@ mod tests {
         assert_eq!(cache.get_newest(), &3);
     }
 
-    /// Reading the cache must not change what a later receive returns: the
-    /// first-call semantics of the recv methods belong to those methods.
+    /// get_newest hands the caller the cache's current value, so a following
+    /// receive must not deliver that same value a second time.
     #[tokio::test(start_paused = true)]
-    async fn test_get_newest_leaves_first_receive_intact() {
+    async fn test_get_newest_counts_as_the_first_read() {
         let handle = Handle::new(1);
         let mut cache = handle.create_cache().await;
 
         assert_eq!(cache.get_newest(), &1);
 
-        // The first receive still yields the initial value
-        assert_eq!(cache.try_recv().unwrap(), Some(&1));
+        assert_eq!(cache.try_recv().unwrap(), None);
     }
 
     #[tokio::test(start_paused = true)]
-    async fn test_get_newest_leaves_first_receive_newest_intact() {
+    async fn test_get_newest_counts_as_the_first_read_for_newest() {
         let handle = Handle::new(1);
         let mut cache = handle.create_cache().await;
 
         assert_eq!(cache.get_newest(), &1);
 
-        assert_eq!(cache.try_recv_newest().unwrap(), Some(&1));
+        assert_eq!(cache.try_recv_newest().unwrap(), None);
+    }
+
+    /// Updates that arrive after the read are still delivered.
+    #[tokio::test(start_paused = true)]
+    async fn test_receive_after_get_newest_yields_later_updates() {
+        let handle = Handle::new(1);
+        let mut cache = handle.create_cache().await;
+
+        assert_eq!(cache.get_newest(), &1);
+
+        handle.set(2).await;
+        assert_eq!(cache.try_recv().unwrap(), Some(&2));
     }
 
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
Eleventh PR of the 0.8.3 release train. **Documentation and tests only — no behaviour change** (see the revision note below).

### What this is now

`Cache` has a one-shot first-read allowance: the first call to a `recv` method returns the currently held value instead of waiting for an update. `get_newest` also spends that allowance, because it hands the caller the same value — receiving it again afterwards would be a duplicate.

That behaviour is correct and unchanged. What was missing was any mention of it. All six `recv` docs promised to return the current value *"on the first call"*, which actually meant the first read of the whole family — so after a `get_newest`, `try_recv` returning `None` looked like a bug against its own documentation.

Changes:

- `get_newest` states that it counts as the first read, with an example showing the following `try_recv` returning `None`
- the six `recv` doc blocks say "on the first read of the cache" and note that a preceding `get_newest` counts as that read
- three tests pin the behaviour: `try_recv` and `try_recv_newest` both return `None` after a `get_newest`, and a later update is still delivered

### Revision note

The first version of this PR did the opposite: it changed `get_newest` to drain the channel directly so the allowance survived, on the grounds that a getter shouldn't alter what a later receive returns.

That was wrong to ship, for two reasons. The weaker one is the semantic argument — a read is a read, and handing the same value back twice is the more surprising outcome. The decisive one is that this train is a **compatible patch release**: `try_recv` returning `Some` where it previously returned `None` is observable behaviour, and a change that reasonable people disagree about is by definition not an obvious bug fix. It does not belong in 0.8.3 regardless of which side is right.

The remaining asymmetry is real but out of scope here: `get_current` also hands the caller the value and does *not* spend the allowance — and cannot, since it takes `&self`. Making the two getters agree needs a signature change, so it belongs to the 0.9.0 discussion about whether the first-read allowance should exist at all.

### Verified locally on rustc 1.97.1 (matching CI)

142 tests pass across all feature legs; clippy `--all-targets --all-features` clean; fmt clean; `cargo doc` with `-D warnings` clean. `git diff main -- actify/src/cache.rs` contains only tests and doc comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)