### PR TITLE
Call actor methods once and drop the futures dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,6 @@ name = "actify"
 version = "0.8.2"
 dependencies = [
  "actify-macros",
- "futures",
  "log",
  "thiserror",
  "tokio",
@@ -153,95 +152,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
-
-[[package]]
-name = "futures-task"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-util"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "pin-utils",
- "slab",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,12 +282,6 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "portable-atomic"
@@ -511,12 +415,6 @@ checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "slab"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"

--- a/actify/Cargo.toml
+++ b/actify/Cargo.toml
@@ -13,7 +13,6 @@ readme = "../README.md"
 thiserror = "2.0.12"
 tokio = { version = "1.44.1", features = ["full"] }
 log = "0.4"
-futures = "0.3.26"
 actify-macros = { path = "../actify-macros", version = "0.5.0" }
 
 [dev-dependencies]

--- a/actify/src/actor.rs
+++ b/actify/src/actor.rs
@@ -1,7 +1,11 @@
-use futures::future::BoxFuture;
 use std::any::{Any, type_name};
 use std::fmt::{self, Debug};
+use std::future::Future;
+use std::pin::Pin;
 use tokio::sync::{mpsc, oneshot};
+
+/// A boxed future, as returned by an actor method.
+pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 #[cfg(feature = "profiler")]
 use std::collections::HashMap;
@@ -67,8 +71,14 @@ impl<T> Actor<T> {
     }
 }
 
-pub(crate) type ActorMethod<T> =
-    Box<dyn FnMut(&mut Actor<T>, Box<dyn Any + Send>) -> BoxFuture<Box<dyn Any + Send>> + Send>;
+/// A single call on an actor, sent from a handle and run once by [`serve`].
+///
+/// The lifetime is bound with `for<'a>` because the returned future borrows the
+/// actor it was handed, which `futures::BoxFuture` used to elide.
+pub(crate) type ActorMethod<T> = Box<
+    dyn for<'a> FnOnce(&'a mut Actor<T>, Box<dyn Any + Send>) -> BoxFuture<'a, Box<dyn Any + Send>>
+        + Send,
+>;
 
 pub(crate) struct Job<T> {
     pub call: ActorMethod<T>,
@@ -80,8 +90,8 @@ pub(crate) async fn serve<T: Send + Sync + 'static>(
     mut rx: mpsc::Receiver<Job<T>>,
     mut actor: Actor<T>,
 ) {
-    while let Some(mut job) = rx.recv().await {
-        let res = (*job.call)(&mut actor, job.args).await;
+    while let Some(job) = rx.recv().await {
+        let res = (job.call)(&mut actor, job.args).await;
         if job.respond_to.send(res).is_err() {
             log::debug!(
                 "Actor of type {} failed to respond as the receiver is dropped",

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -223,15 +223,9 @@ impl<T: Send + Sync + 'static, V> Handle<T, V> {
         A: Send + 'static,
         R: Send + 'static,
     {
-        // ActorMethod requires FnMut because Box<dyn FnOnce> can't be called.
-        // We wrap f in Option so we can .take() it out of the FnMut closure.
-        // The unwrap is safe: send_job sends exactly one job, and serve()
-        // calls it exactly once, but the compiler just can't prove that so we need a work-around.
-        let mut f = Some(f);
         let res = self
             .send_job(
                 Box::new(move |s: &mut Actor<T>, boxed_args: Box<dyn Any + Send>| {
-                    let f = f.take().unwrap();
                     Box::pin(async move {
                         let args = *boxed_args.downcast::<A>().expect(DOWNCAST_FAIL);
                         Box::new(f(s, args)) as Box<dyn Any + Send>


### PR DESCRIPTION
Twelfth PR of the 0.8.3 release train. **Pure refactor — no behaviour change.** There is no red-then-green pair here because there is no bug to demonstrate; the proof is that all 142 existing tests keep passing, including the trybuild suite that compiles macro-generated code.

### FnOnce

`ActorMethod` was declared `FnMut`, with this explanation at the call site:

```rust
// ActorMethod requires FnMut because Box<dyn FnOnce> can't be called.
// We wrap f in Option so we can .take() it out of the FnMut closure.
// The unwrap is safe: send_job sends exactly one job, and serve()
// calls it exactly once, but the compiler just can't prove that ...
let mut f = Some(f);
```

That limitation was lifted in **Rust 1.35**, well below the declared 1.85 MSRV. The workaround it justified — wrapping every closure in an `Option` and pulling it back out with `.take().unwrap()` — has been unnecessary for years. `FnOnce` expresses "runs exactly once" in the type, so the compiler enforces what the comment was asserting, and both the `Option` and the unwrap are gone.

### Dropping `futures`

That same alias was the only thing in the crate using `futures::future::BoxFuture` — an entire dependency for one three-line type. Since the signature was being rewritten anyway, it is now defined locally:

```rust
pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
```

One wrinkle worth flagging: `futures::BoxFuture` elides the lifetime, and the returned future borrows the `&mut Actor` it was handed. Written out, `ActorMethod` needs an explicit higher-ranked bound:

```rust
pub(crate) type ActorMethod<T> = Box<
    dyn for<'a> FnOnce(&'a mut Actor<T>, Box<dyn Any + Send>) -> BoxFuture<'a, Box<dyn Any + Send>>
        + Send,
>;
```

`futures` no longer appears in `Cargo.lock` or in `cargo tree`, so every downstream build stops paying for it.

### Why one PR rather than two

The two changes touch the same type alias — splitting them would mean writing that `for<'a>` signature twice and reverting it in between. Happy to split if you would rather review them separately.

### Verified locally on rustc 1.97.1 (matching CI)

142 tests pass across all feature legs; clippy `--all-targets --all-features` clean; fmt clean; `cargo doc` with `-D warnings` clean; MSRV 1.85 check passes. No public API change: `ActorMethod` is `pub(crate)`, and although `send_job` takes it, that method is `#[doc(hidden)]` plumbing only the macro calls — and the macro's generated closures compile unchanged, which the trybuild and integration suites exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)