### PR TITLE
Report why an actor stopped instead of always blaming a panic

### DIFF
--- a/actify/src/actor.rs
+++ b/actify/src/actor.rs
@@ -2,7 +2,7 @@ use std::any::{Any, type_name};
 use std::fmt::{self, Debug};
 use std::future::Future;
 use std::pin::Pin;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, watch};
 
 /// A boxed future, as returned by an actor method.
 pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
@@ -86,10 +86,38 @@ pub(crate) struct Job<T> {
     pub respond_to: oneshot::Sender<Box<dyn Any + Send>>,
 }
 
+/// Why the actor task is no longer serving jobs.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) enum ActorExit {
+    Running,
+    Panicked,
+    Stopped,
+}
+
+/// Reports the exit reason when the actor task ends, however it ends.
+///
+/// `std::thread::panicking()` is true while a panic unwinds the task, which is
+/// what separates a panicking actor method from a runtime shutdown or a
+/// cancelled task - both of which drop the task without unwinding.
+struct ExitGuard(watch::Sender<ActorExit>);
+
+impl Drop for ExitGuard {
+    fn drop(&mut self) {
+        let reason = if std::thread::panicking() {
+            ActorExit::Panicked
+        } else {
+            ActorExit::Stopped
+        };
+        let _ = self.0.send(reason);
+    }
+}
+
 pub(crate) async fn serve<T: Send + Sync + 'static>(
     mut rx: mpsc::Receiver<Job<T>>,
     mut actor: Actor<T>,
+    exit_tx: watch::Sender<ActorExit>,
 ) {
+    let _guard = ExitGuard(exit_tx);
     while let Some(job) = rx.recv().await {
         let res = (job.call)(&mut actor, job.args).await;
         if job.respond_to.send(res).is_err() {

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -1,10 +1,10 @@
 use std::any::Any;
 use std::any::type_name;
 use std::fmt::{self, Debug};
-use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio::sync::{broadcast, mpsc, oneshot, watch};
 
 use super::read_handle::ReadHandle;
-use crate::actor::{Actor, ActorMethod, BroadcastFn, Job, serve};
+use crate::actor::{Actor, ActorExit, ActorMethod, BroadcastFn, Job, serve};
 use crate::throttle::Throttle;
 use crate::{Cache, Frequency, Throttled};
 
@@ -83,6 +83,7 @@ where
 pub struct Handle<T, V = T> {
     pub(super) tx: mpsc::Sender<Job<T>>,
     pub(super) broadcast_sender: broadcast::Sender<V>,
+    pub(super) exit_rx: watch::Receiver<ActorExit>,
 }
 
 impl<T, V> Clone for Handle<T, V> {
@@ -90,6 +91,7 @@ impl<T, V> Clone for Handle<T, V> {
         Handle {
             tx: self.tx.clone(),
             broadcast_sender: self.broadcast_sender.clone(),
+            exit_rx: self.exit_rx.clone(),
         }
     }
 }
@@ -137,13 +139,16 @@ where
     pub fn new(val: T) -> Handle<T, V> {
         let (tx, rx) = mpsc::channel(CHANNEL_SIZE);
         let (broadcast_tx, _) = broadcast::channel::<V>(CHANNEL_SIZE);
+        let (exit_tx, exit_rx) = watch::channel(ActorExit::Running);
         tokio::spawn(serve(
             rx,
             Actor::new(make_broadcast_fn(broadcast_tx.clone()), val),
+            exit_tx,
         ));
         Handle {
             tx,
             broadcast_sender: broadcast_tx,
+            exit_rx,
         }
     }
 
@@ -209,11 +214,30 @@ impl<T: Send + Sync + 'static, V> Handle<T, V> {
             args,
             respond_to,
         };
-        self.tx
-            .send(job)
-            .await
-            .expect("A panic occurred in the Actor");
-        get_result.await.expect("A panic occurred in the Actor")
+        if self.tx.send(job).await.is_err() {
+            return self.report_actor_gone().await;
+        }
+        match get_result.await {
+            Ok(res) => res,
+            Err(_) => self.report_actor_gone().await,
+        }
+    }
+
+    /// Panics with the reason the actor stopped serving jobs.
+    ///
+    /// The exit signal may not have been written yet when the channel first
+    /// reports its failure, so this waits for it rather than guessing from
+    /// scheduling order.
+    async fn report_actor_gone(&self) -> Box<dyn Any + Send> {
+        let mut exit_rx = self.exit_rx.clone();
+        if *exit_rx.borrow_and_update() == ActorExit::Running {
+            let _ = exit_rx.changed().await;
+        }
+
+        if *exit_rx.borrow() == ActorExit::Panicked {
+            panic!("A panic occurred in the Actor of type {}", type_name::<T>());
+        }
+        panic!("Actor of type {} is no longer running", type_name::<T>());
     }
 
     /// Sends a closure to the actor, handling all boxing/unboxing internally.
@@ -478,11 +502,99 @@ mod tests {
     use super::*;
     use crate as actify;
 
+    /// A panicking actor method must surface as a panic naming that cause, not
+    /// as the generic message used when the actor merely stopped.
     #[tokio::test]
-    #[should_panic]
-    async fn test_handle_panic() {
+    async fn test_actor_panic_is_reported_as_a_panic() {
         let handle = Handle::new(PanicStruct {});
-        handle.panic().await;
+        let clone = handle.clone();
+
+        let result = tokio::spawn(async move { clone.panic().await }).await;
+
+        let message = panic_message(result.unwrap_err());
+        assert!(
+            message.contains("A panic occurred"),
+            "expected an actor-panic message, got: {message}"
+        );
+    }
+
+    /// The same for a panic inside an async method, which unwinds from a
+    /// different point in the job's lifetime than a sync one.
+    #[tokio::test]
+    async fn test_async_actor_panic_is_reported_as_a_panic() {
+        let handle = Handle::new(PanicStruct {});
+        let clone = handle.clone();
+
+        let result = tokio::spawn(async move { clone.panic_async().await }).await;
+
+        let message = panic_message(result.unwrap_err());
+        assert!(
+            message.contains("A panic occurred"),
+            "expected an actor-panic message, got: {message}"
+        );
+    }
+
+    /// Every clone shares the actor, so all of them report the panic, not just
+    /// the one whose call brought the actor down.
+    #[tokio::test]
+    async fn test_actor_panic_is_reported_to_other_clones() {
+        let handle = Handle::new(PanicStruct {});
+        let victim = handle.clone();
+        let bystander = handle.clone();
+
+        let _ = tokio::spawn(async move { victim.panic().await }).await;
+
+        let result = tokio::spawn(async move { bystander.panic().await }).await;
+        let message = panic_message(result.unwrap_err());
+        assert!(
+            message.contains("A panic occurred") || message.contains("no longer running"),
+            "expected the actor to be reported as gone, got: {message}"
+        );
+    }
+
+    /// A handle outliving its runtime is a different failure from a panicking
+    /// method, and saying "a panic occurred" there sends readers hunting for a
+    /// panic that never happened.
+    #[test]
+    fn test_orphaned_handle_reports_a_stopped_actor() {
+        let actor_rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let handle = actor_rt.block_on(async {
+            let handle = Handle::new(0i32);
+            handle.set(42).await;
+            assert_eq!(handle.get().await, 42); // The actor served jobs normally
+            handle
+        });
+
+        drop(actor_rt); // Cancels the actor task without unwinding it
+
+        let caller_rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        caller_rt.block_on(async {
+            let orphaned = handle.clone();
+            let result = tokio::spawn(async move { orphaned.set(99).await }).await;
+
+            let message = panic_message(result.unwrap_err());
+            assert!(
+                message.contains("no longer running"),
+                "expected a stopped-actor message, got: {message}"
+            );
+        });
+    }
+
+    fn panic_message(error: tokio::task::JoinError) -> String {
+        let panic = error.into_panic();
+        panic
+            .downcast_ref::<String>()
+            .cloned()
+            .or_else(|| panic.downcast_ref::<&str>().map(|s| s.to_string()))
+            .expect("panic payload was neither String nor &str")
     }
 
     /// The profiler counts broadcasts per method name, so each method must
@@ -520,6 +632,10 @@ mod tests {
     #[actify_macros::actify]
     impl PanicStruct {
         fn panic(&self) {
+            panic!()
+        }
+
+        async fn panic_async(&self) {
             panic!()
         }
     }

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -504,6 +504,10 @@ mod tests {
 
     /// A panicking actor method must surface as a panic naming that cause, not
     /// as the generic message used when the actor merely stopped.
+    ///
+    /// The caller's panic is raised by the handle: the actor's own payload
+    /// unwinds the actor task and is not forwarded, which is why the assertion
+    /// checks for the handle's message and against the actor's.
     #[tokio::test]
     async fn test_actor_panic_is_reported_as_a_panic() {
         let handle = Handle::new(PanicStruct {});
@@ -512,9 +516,16 @@ mod tests {
         let result = tokio::spawn(async move { clone.panic().await }).await;
 
         let message = panic_message(result.unwrap_err());
+        assert_eq!(
+            message,
+            format!(
+                "A panic occurred in the Actor of type {}",
+                type_name::<PanicStruct>()
+            )
+        );
         assert!(
-            message.contains("A panic occurred"),
-            "expected an actor-panic message, got: {message}"
+            !message.contains(SYNC_PANIC_PAYLOAD),
+            "the actor's own payload is not forwarded to the caller: {message}"
         );
     }
 
@@ -528,27 +539,43 @@ mod tests {
         let result = tokio::spawn(async move { clone.panic_async().await }).await;
 
         let message = panic_message(result.unwrap_err());
+        assert_eq!(
+            message,
+            format!(
+                "A panic occurred in the Actor of type {}",
+                type_name::<PanicStruct>()
+            )
+        );
         assert!(
-            message.contains("A panic occurred"),
-            "expected an actor-panic message, got: {message}"
+            !message.contains(ASYNC_PANIC_PAYLOAD),
+            "the actor's own payload is not forwarded to the caller: {message}"
         );
     }
 
-    /// Every clone shares the actor, so all of them report the panic, not just
-    /// the one whose call brought the actor down.
+    /// One clone's call kills the shared actor, so every other clone is left
+    /// holding a handle to a dead actor - and learns it was a panic that
+    /// killed it, not an ordinary shutdown.
     #[tokio::test]
     async fn test_actor_panic_is_reported_to_other_clones() {
         let handle = Handle::new(PanicStruct {});
         let victim = handle.clone();
         let bystander = handle.clone();
 
+        // The same call succeeds while the actor is alive, so the failure
+        // below can only come from the actor being gone
+        assert_eq!(handle.innocent().await, 7);
+
         let _ = tokio::spawn(async move { victim.panic().await }).await;
 
-        let result = tokio::spawn(async move { bystander.panic().await }).await;
+        let result = tokio::spawn(async move { bystander.innocent().await }).await;
+
         let message = panic_message(result.unwrap_err());
-        assert!(
-            message.contains("A panic occurred") || message.contains("no longer running"),
-            "expected the actor to be reported as gone, got: {message}"
+        assert_eq!(
+            message,
+            format!(
+                "A panic occurred in the Actor of type {}",
+                type_name::<PanicStruct>()
+            )
         );
     }
 
@@ -626,17 +653,28 @@ mod tests {
         );
     }
 
+    /// Payloads distinctive enough that a test can tell whose panic it caught:
+    /// the actor's own, or the one the handle raises on the caller's behalf.
+    const SYNC_PANIC_PAYLOAD: &str = "sync actor method blew up";
+    const ASYNC_PANIC_PAYLOAD: &str = "async actor method blew up";
+
     #[derive(Debug, Clone)]
     struct PanicStruct {}
 
     #[actify_macros::actify]
     impl PanicStruct {
         fn panic(&self) {
-            panic!()
+            panic!("{SYNC_PANIC_PAYLOAD}")
         }
 
         async fn panic_async(&self) {
-            panic!()
+            panic!("{ASYNC_PANIC_PAYLOAD}")
+        }
+
+        /// A method that cannot fail on its own, so any panic it raises must
+        /// have come from the actor being gone.
+        fn innocent(&self) -> i32 {
+            7
         }
     }
 


### PR DESCRIPTION
Thirteenth PR of the 0.8.3 release train. Ported by hand from the `enhancement/panic-with-reason` branch, which was written before the `FnOnce` refactor in #73 and no longer merges cleanly.

### The problem

Every call into an actor unwrapped two channel failures with the same message:

```rust
self.tx.send(job).await.expect("A panic occurred in the Actor");
get_result.await.expect("A panic occurred in the Actor")
```

That message is right in one case and misleading in the others. A handle that outlives its runtime — a real production shape, e.g. a `Handle` stored in a struct that outlives the runtime that built it — produced:

```
A panic occurred in the Actor: SendError { .. }
```

for an actor that never panicked. Anyone reading that goes looking for a panic that does not exist, in an actor method that is fine.

### The fix

The actor task now holds a drop guard writing to a `watch` channel. `std::thread::panicking()` is true while a panic unwinds the task and false when the task is merely dropped, which is exactly the distinction needed: a panicking method reports `Panicked`, a cancelled or finished task reports `Stopped`. `send_job` waits for that signal before panicking — waiting rather than sampling, because the channel can report failure before the guard has run.

Messages are now `"A panic occurred in the Actor of type T"` and `"Actor of type T is no longer running"`.

The panic contract itself is unchanged: these methods still panic. Only the explanation improves. (`is_alive()` and `closed().await`, the non-panicking probes built on this same watch channel, follow in the next PR.)

### Tests

Four, replacing the previous bare `#[should_panic]` test that asserted nothing about the cause:

- a panicking sync method reports a panic
- **a panicking async method does the same** — an audit gap; async methods unwind from a different point in the job's lifetime and had no coverage
- **other clones of the handle also report the actor as gone**, not just the caller that killed it
- an orphaned handle after runtime shutdown reports *stopped*, not *panicked*

I verified the last one actually discriminates by temporarily restoring the old `.expect(...)` and running it: it fails with `expected a stopped-actor message, got: A panic occurred in the Actor: SendError { .. }`.

### Cost

One `watch::Receiver` per handle clone. Cheap, and it is the same channel the next PR reads for the non-panicking probes.

### Verified locally on rustc 1.97.1 (matching CI)

145 tests pass across all feature legs; clippy `--all-targets --all-features` clean; fmt clean; `cargo doc` with `-D warnings` clean; MSRV check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)