### PR TITLE
Require documentation on public items, and describe what panics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,12 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo doc --workspace --no-deps --all-features
+      - name: Docs with every feature
+        run: cargo doc --workspace --no-deps --all-features
+      # Feature-gated items cannot be linked from text that is always compiled,
+      # so the default build has to be checked separately.
+      - name: Docs with default features
+        run: cargo doc --workspace --no-deps
 
   msrv:
     runs-on: ubuntu-latest

--- a/actify-macros/src/lib.rs
+++ b/actify-macros/src/lib.rs
@@ -11,10 +11,6 @@ use proc_macro::TokenStream;
 
 /// Marks a method inside an `#[actify]` impl block as not broadcasting.
 ///
-/// Broadcasting is the default, so this is only meaningful on a block that has
-/// not already opted out with `#[actify(skip_broadcast)]` — applying both is an
-/// error rather than a silent no-op.
-///
 /// ```ignore
 /// #[actify]
 /// impl Counter {
@@ -23,18 +19,13 @@ use proc_macro::TokenStream;
 /// }
 /// ```
 ///
-/// This expands to nothing: the `#[actify]` macro reads it while processing the
-/// block and strips it from the output.
+/// Expands to nothing: `#[actify]` reads it and strips it from the output.
 #[proc_macro_attribute]
 pub fn skip_broadcast(_args: TokenStream, input: TokenStream) -> TokenStream {
     input
 }
 
-/// Marks a method as broadcasting inside an `#[actify(skip_broadcast)]` block.
-///
-/// The counterpart to [`macro@skip_broadcast`]: it restores the default for one
-/// method of a block that opted out of broadcasting wholesale. On a block that
-/// already broadcasts it is an error rather than a silent no-op.
+/// Restores broadcasting for one method of an `#[actify(skip_broadcast)]` block.
 ///
 /// ```ignore
 /// #[actify(skip_broadcast)]
@@ -44,8 +35,7 @@ pub fn skip_broadcast(_args: TokenStream, input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// This expands to nothing: the `#[actify]` macro reads it while processing the
-/// block and strips it from the output.
+/// Expands to nothing: `#[actify]` reads it and strips it from the output.
 #[proc_macro_attribute]
 pub fn broadcast(_args: TokenStream, input: TokenStream) -> TokenStream {
     input

--- a/actify-macros/src/lib.rs
+++ b/actify-macros/src/lib.rs
@@ -1,13 +1,51 @@
+//! Procedural macros for the [actify](https://docs.rs/actify) crate.
+//!
+//! Depend on `actify` rather than this crate: everything here is re-exported
+//! from there, and the generated code refers to `actify`'s types.
+#![warn(missing_docs)]
+
 mod codegen;
 mod parse;
 
 use proc_macro::TokenStream;
 
+/// Marks a method inside an `#[actify]` impl block as not broadcasting.
+///
+/// Broadcasting is the default, so this is only meaningful on a block that has
+/// not already opted out with `#[actify(skip_broadcast)]` — applying both is an
+/// error rather than a silent no-op.
+///
+/// ```ignore
+/// #[actify]
+/// impl Counter {
+///     #[actify::skip_broadcast]
+///     fn bump_quietly(&mut self) { self.count += 1 }
+/// }
+/// ```
+///
+/// This expands to nothing: the `#[actify]` macro reads it while processing the
+/// block and strips it from the output.
 #[proc_macro_attribute]
 pub fn skip_broadcast(_args: TokenStream, input: TokenStream) -> TokenStream {
     input
 }
 
+/// Marks a method as broadcasting inside an `#[actify(skip_broadcast)]` block.
+///
+/// The counterpart to [`macro@skip_broadcast`]: it restores the default for one
+/// method of a block that opted out of broadcasting wholesale. On a block that
+/// already broadcasts it is an error rather than a silent no-op.
+///
+/// ```ignore
+/// #[actify(skip_broadcast)]
+/// impl Counter {
+///     #[actify::broadcast]
+///     fn bump_loudly(&mut self) { self.count += 1 }
+/// }
+/// ```
+///
+/// This expands to nothing: the `#[actify]` macro reads it while processing the
+/// block and strips it from the output.
 #[proc_macro_attribute]
 pub fn broadcast(_args: TokenStream, input: TokenStream) -> TokenStream {
     input

--- a/actify-macros/src/parse.rs
+++ b/actify-macros/src/parse.rs
@@ -255,7 +255,7 @@ fn is_propagated_attribute(attr: &Attribute) -> bool {
 /// Keep only whitelisted built-in attributes for generated code.
 ///
 /// Proc-macro attributes (e.g. `#[instrument]`) and actify-specific attributes
-/// (e.g. `#[skip_broadcast]`) are stripped — the former because they transform
+/// (e.g. `#[skip_broadcast]`) are stripped. The former transforms
 /// function bodies and are semantically wrong on generated plumbing code, the
 /// latter because they are consumed during parsing.
 fn filter_attributes(attrs: &[Attribute]) -> Vec<Attribute> {

--- a/actify-test/Cargo.toml
+++ b/actify-test/Cargo.toml
@@ -15,6 +15,7 @@ tracing = "0.1"
 
 [dev-dependencies]
 trybuild = "1"
+tokio = { version = "1.15", features = ["test-util"] }
 
 [features]
 default = []

--- a/actify-test/src/main.rs
+++ b/actify-test/src/main.rs
@@ -1,6 +1,6 @@
 //! This workspace is used to test the functionalities of actify as would any user that imports the library
 
-use actify::actify;
+use actify::{Handle, actify};
 use std::{collections::HashMap, fmt::Debug};
 
 fn main() {}
@@ -544,6 +544,26 @@ mod tests {
         assert!(cache_3.try_recv_newest().is_err());
     }
 
+    /// An actor runs one job at a time, so a method calling its own handle
+    /// waits for a reply only this actor can produce. The crate docs state
+    /// this; the test keeps that statement true.
+    #[tokio::test(start_paused = true)]
+    async fn test_calling_own_handle_never_completes() {
+        let handle = Handle::new(SelfCaller {
+            own: None,
+            value: 7,
+        });
+        handle
+            .set(SelfCaller {
+                own: Some(handle.clone()),
+                value: 7,
+            })
+            .await;
+
+        let outcome = tokio::time::timeout(Duration::from_secs(60), handle.call_self()).await;
+        assert!(outcome.is_err(), "the self-call returned {outcome:?}");
+    }
+
     #[tokio::test]
     async fn test_drain_vec() {
         let actor_handle = Handle::new(vec![1, 2, 3]);
@@ -943,5 +963,20 @@ mod tests {
             after_handle_drop, baseline,
             "All tasks should exit after Handle is dropped"
         );
+    }
+}
+
+/// An actor holding a handle to itself, which is the shape that deadlocks.
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
+struct SelfCaller {
+    own: Option<Handle<SelfCaller>>,
+    value: i32,
+}
+
+#[actify]
+impl SelfCaller {
+    async fn call_self(&self) -> i32 {
+        self.own.as_ref().unwrap().get().await.value
     }
 }

--- a/actify-test/src/main.rs
+++ b/actify-test/src/main.rs
@@ -560,8 +560,10 @@ mod tests {
             })
             .await;
 
-        let outcome = tokio::time::timeout(Duration::from_secs(60), handle.call_self()).await;
-        assert!(outcome.is_err(), "the self-call returned {outcome:?}");
+        assert!(
+            never_resolves(handle.call_self()).await,
+            "the self-call returned instead of blocking"
+        );
     }
 
     #[tokio::test]
@@ -646,6 +648,18 @@ mod tests {
     }
 
     /// Helper to get current number of alive tasks in the runtime
+    /// Returns whether a future is still pending once nothing else can make
+    /// progress.
+    ///
+    /// The tests using this run on a paused clock, where tokio advances time
+    /// as soon as every task is idle, so the timeout elapses immediately and
+    /// its length is irrelevant.
+    async fn never_resolves<F: std::future::Future>(future: F) -> bool {
+        tokio::time::timeout(Duration::from_secs(1), future)
+            .await
+            .is_err()
+    }
+
     fn alive_tasks() -> usize {
         tokio::runtime::Handle::current()
             .metrics()

--- a/actify-test/src/main.rs
+++ b/actify-test/src/main.rs
@@ -544,25 +544,28 @@ mod tests {
         assert!(cache_3.try_recv_newest().is_err());
     }
 
-    /// An actor runs one job at a time, so a method calling its own handle
-    /// waits for a reply only this actor can produce. The crate docs state
+    /// An actor runs one job at a time, so two actors calling each other each
+    /// wait for a reply the other cannot produce yet. The crate docs state
     /// this; the test keeps that statement true.
     #[tokio::test(start_paused = true)]
-    async fn test_calling_own_handle_never_completes() {
-        let handle = Handle::new(SelfCaller {
-            own: None,
-            value: 7,
-        });
-        handle
-            .set(SelfCaller {
-                own: Some(handle.clone()),
-                value: 7,
+    async fn test_actors_calling_each_other_never_complete() {
+        let parser = Handle::new(Parser { store: None });
+        let store = Handle::new(Store { parser: None });
+
+        parser
+            .set(Parser {
+                store: Some(store.clone()),
+            })
+            .await;
+        store
+            .set(Store {
+                parser: Some(parser.clone()),
             })
             .await;
 
         assert!(
-            never_resolves(handle.call_self()).await,
-            "the self-call returned instead of blocking"
+            never_resolves(parser.parse()).await,
+            "the cycle returned instead of blocking"
         );
     }
 
@@ -980,17 +983,33 @@ mod tests {
     }
 }
 
-/// An actor holding a handle to itself, which is the shape that deadlocks.
+/// Two actors holding handles to each other, which is the shape that deadlocks.
 #[allow(dead_code)]
 #[derive(Clone, Debug)]
-struct SelfCaller {
-    own: Option<Handle<SelfCaller>>,
-    value: i32,
+struct Parser {
+    store: Option<Handle<Store>>,
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
+struct Store {
+    parser: Option<Handle<Parser>>,
 }
 
 #[actify]
-impl SelfCaller {
-    async fn call_self(&self) -> i32 {
-        self.own.as_ref().unwrap().get().await.value
+impl Parser {
+    async fn parse(&self) {
+        self.store.as_ref().unwrap().save().await;
+    }
+
+    async fn is_ready(&self) -> bool {
+        true
+    }
+}
+
+#[actify]
+impl Store {
+    async fn save(&self) {
+        self.parser.as_ref().unwrap().is_ready().await;
     }
 }

--- a/actify/Cargo.toml
+++ b/actify/Cargo.toml
@@ -21,3 +21,9 @@ tokio = { version = "1.44.1", features = ["test-util"] }
 [features]
 default = []
 profiler = []
+
+[package.metadata.docs.rs]
+# Build with every feature so `profiler` items appear, tagged with the feature
+# they need.
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/actify/src/actor.rs
+++ b/actify/src/actor.rs
@@ -37,7 +37,7 @@ pub(crate) type BroadcastFn<T> = Box<dyn Fn(&T, &str) + Send + Sync>;
 
 /// The internal actor wrapper that runs in a separate task.
 ///
-/// You do not create this directly — it is spawned by [`Handle::new`](super::Handle::new).
+/// You do not create this directly. It is spawned by [`Handle::new`](super::Handle::new).
 /// The `inner` field holds the wrapped value.
 #[doc(hidden)]
 pub struct Actor<T> {

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -59,10 +59,9 @@ where
     /// Drains all buffered messages from the channel, keeping only the newest value.
     /// Returns `true` if any value was stored.
     ///
-    /// A closed channel is only reported once its queue is exhausted: an actor
-    /// that broadcasts a final update and then stops leaves that update behind,
-    /// and it is usually the one worth having. Closing is permanent, so the
-    /// next call reports it.
+    /// A closed channel is only reported once its queue is exhausted, so a final
+    /// update broadcast before the actor stopped is still returned. Closing is
+    /// permanent, so the next call reports it.
     fn drain_to_newest(&mut self) -> Result<bool, CacheRecvNewestError> {
         let mut received = false;
         loop {
@@ -313,7 +312,7 @@ where
     ///
     /// // Returns the default, not the actor's actual value (5)
     /// assert_eq!(cache.try_recv_newest().unwrap(), Some(&0));
-    /// // No broadcasts arrived, so None — the actor's value (5) is never seen
+    /// // No broadcasts arrived, so None. The actor's value (5) is never seen
     /// assert_eq!(cache.try_recv_newest().unwrap(), None);
     /// # }
     /// ```
@@ -376,7 +375,7 @@ where
     ///
     /// // Returns the default, not the actor's actual value (5)
     /// assert_eq!(cache.try_recv().unwrap(), Some(&0));
-    /// // No broadcasts arrived, so None — the actor's value (5) is never seen
+    /// // No broadcasts arrived, so None. The actor's value (5) is never seen
     /// assert_eq!(cache.try_recv().unwrap(), None);
     /// # }
     /// ```
@@ -513,12 +512,10 @@ fn log_lag<T>(nr: u64) {
 #[derive(Error, Debug, PartialEq, Clone)]
 pub enum CacheRecvError {
     /// The actor has stopped and every update it broadcast has been delivered.
-    /// No further values will arrive.
     #[error("Cache channel closed")]
     Closed,
-    /// The cache fell too far behind and the channel dropped the given number
-    /// of updates to catch up. The cached value is unchanged; the next receive
-    /// resumes from the oldest update still held.
+    /// The cache fell behind and the channel dropped the given number of
+    /// updates. The cached value is unchanged.
     #[error("Cache channel lagged by {0}")]
     Lagged(u64),
 }
@@ -536,10 +533,6 @@ impl From<RecvError> for CacheRecvError {
 #[derive(Error, Debug, PartialEq, Clone)]
 pub enum CacheRecvNewestError {
     /// The actor has stopped and every update it broadcast has been delivered.
-    /// No further values will arrive.
-    ///
-    /// Lagging has no variant here: these methods skip to the newest value, so
-    /// dropped updates are exactly what they were going to discard anyway.
     #[error("Cache channel closed")]
     Closed,
 }

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -512,8 +512,13 @@ fn log_lag<T>(nr: u64) {
 /// Error returned by [`Cache::recv`] and [`Cache::try_recv`].
 #[derive(Error, Debug, PartialEq, Clone)]
 pub enum CacheRecvError {
+    /// The actor has stopped and every update it broadcast has been delivered.
+    /// No further values will arrive.
     #[error("Cache channel closed")]
     Closed,
+    /// The cache fell too far behind and the channel dropped the given number
+    /// of updates to catch up. The cached value is unchanged; the next receive
+    /// resumes from the oldest update still held.
     #[error("Cache channel lagged by {0}")]
     Lagged(u64),
 }
@@ -530,6 +535,11 @@ impl From<RecvError> for CacheRecvError {
 /// Error returned by [`Cache::recv_newest`] and [`Cache::try_recv_newest`].
 #[derive(Error, Debug, PartialEq, Clone)]
 pub enum CacheRecvNewestError {
+    /// The actor has stopped and every update it broadcast has been delivered.
+    /// No further values will arrive.
+    ///
+    /// Lagging has no variant here: these methods skip to the newest value, so
+    /// dropped updates are exactly what they were going to discard anyway.
     #[error("Cache channel closed")]
     Closed,
 }

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -41,6 +41,10 @@ const DOWNCAST_FAIL: &str =
 /// }
 /// ```
 pub trait BroadcastAs<V> {
+    /// Produces the value to broadcast to subscribers.
+    ///
+    /// Called on the actor's own value after every broadcasting method, so it
+    /// runs on the actor task and should stay cheap.
     fn to_broadcast(&self) -> V;
 }
 
@@ -288,6 +292,12 @@ impl<T: Send + Sync + 'static, V> Handle<T, V> {
     /// assert_eq!(handle.get().await, Some(1));
     /// # }
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the actor has stopped, either because one of its methods
+    /// panicked or because its runtime shut down. See [Actor lifetime and
+    /// panics](crate#actor-lifetime-and-panics).
     pub async fn set(&self, val: T) {
         self.run(val, |s, val| {
             s.inner = val;
@@ -311,6 +321,12 @@ impl<T: Send + Sync + 'static, V> Handle<T, V> {
     /// assert_eq!(rx.recv().await.unwrap(), 2);
     /// # }
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the actor has stopped, either because one of its methods
+    /// panicked or because its runtime shut down. See [Actor lifetime and
+    /// panics](crate#actor-lifetime-and-panics).
     pub async fn set_if_changed(&self, val: T)
     where
         T: PartialEq,
@@ -346,6 +362,12 @@ impl<T: Send + Sync + 'static, V> Handle<T, V> {
     /// assert_eq!(first, Some(1));
     /// # }
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the actor has stopped, either because one of its methods
+    /// panicked or because its runtime shut down. See [Actor lifetime and
+    /// panics](crate#actor-lifetime-and-panics).
     pub async fn with<R, F>(&self, f: F) -> R
     where
         F: FnOnce(&T) -> R + Send + 'static,
@@ -381,6 +403,12 @@ impl<T: Send + Sync + 'static, V> Handle<T, V> {
     /// assert!(rx.try_recv().is_ok());
     /// # }
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the actor has stopped, either because one of its methods
+    /// panicked or because its runtime shut down. See [Actor lifetime and
+    /// panics](crate#actor-lifetime-and-panics).
     pub async fn with_mut<R, F>(&self, f: F) -> R
     where
         F: FnOnce(&mut T) -> R + Send + 'static,
@@ -410,6 +438,12 @@ impl<T: Clone + Send + Sync + 'static, V> Handle<T, V> {
     /// assert_eq!(result, 1);
     /// # }
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the actor has stopped, either because one of its methods
+    /// panicked or because its runtime shut down. See [Actor lifetime and
+    /// panics](crate#actor-lifetime-and-panics).
     pub async fn get(&self) -> T {
         self.run((), |s, _| s.inner.clone()).await
     }
@@ -463,6 +497,12 @@ where
     /// As it is initialized with the current value, any updates before or during construction are included.
     ///
     /// See also [`Handle::create_cache_from_default`] for a cache that starts from `V::default()`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the actor has stopped, either because one of its methods
+    /// panicked or because its runtime shut down. See [Actor lifetime and
+    /// panics](crate#actor-lifetime-and-panics).
     pub async fn create_cache(&self) -> Cache<V> {
         // Subscribe before get, so an update arriving in between is queued rather than lost.
         let rx = self.subscribe();
@@ -497,6 +537,12 @@ where
     /// assert_eq!(*values.lock().unwrap(), vec![1, 2]);
     /// # }
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the actor has stopped, either because one of its methods
+    /// panicked or because its runtime shut down. See [Actor lifetime and
+    /// panics](crate#actor-lifetime-and-panics).
     pub async fn spawn_throttle<C, F>(&self, client: C, call: fn(&C, F), freq: Frequency)
     where
         C: Send + Sync + 'static,

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -43,8 +43,7 @@ const DOWNCAST_FAIL: &str =
 pub trait BroadcastAs<V> {
     /// Produces the value to broadcast to subscribers.
     ///
-    /// Called on the actor's own value after every broadcasting method, so it
-    /// runs on the actor task and should stay cheap.
+    /// Runs on the actor task after every broadcasting method.
     fn to_broadcast(&self) -> V;
 }
 
@@ -119,7 +118,7 @@ where
 {
     /// Creates a new [`Handle`] and spawns the corresponding [`Actor`].
     ///
-    /// For `Clone` types, `V` defaults to `T` — the actor broadcasts clones of
+    /// For `Clone` types, `V` defaults to `T`: the actor broadcasts clones of
     /// itself and you can simply write `Handle::new(val)`.
     ///
     /// For non-Clone types (or to broadcast a lightweight summary), implement

--- a/actify/src/handles/read_handle.rs
+++ b/actify/src/handles/read_handle.rs
@@ -85,6 +85,12 @@ impl<T: Send + Sync + 'static, V> ReadHandle<T, V> {
     /// assert_eq!(first, "sword");
     /// # }
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the actor has stopped, either because one of its methods
+    /// panicked or because its runtime shut down. See [Actor lifetime and
+    /// panics](crate#actor-lifetime-and-panics).
     pub async fn with<R, F>(&self, f: F) -> R
     where
         F: FnOnce(&T) -> R + Send + 'static,
@@ -109,6 +115,12 @@ impl<T: Clone + Send + Sync + 'static, V> ReadHandle<T, V> {
     /// assert_eq!(result, 1);
     /// # }
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the actor has stopped, either because one of its methods
+    /// panicked or because its runtime shut down. See [Actor lifetime and
+    /// panics](crate#actor-lifetime-and-panics).
     pub async fn get(&self) -> T {
         self.0.get().await
     }
@@ -137,6 +149,12 @@ where
 {
     /// Creates an initialized [`Cache`] that locally synchronizes with the remote actor.
     /// As it is initialized with the current value, any updates before construction are included.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the actor has stopped, either because one of its methods
+    /// panicked or because its runtime shut down. See [Actor lifetime and
+    /// panics](crate#actor-lifetime-and-panics).
     pub async fn create_cache(&self) -> Cache<V> {
         self.0.create_cache().await
     }

--- a/actify/src/handles/read_handle.rs
+++ b/actify/src/handles/read_handle.rs
@@ -62,7 +62,7 @@ impl<T: Send + Sync + 'static, V> ReadHandle<T, V> {
     /// # use actify::{Handle, BroadcastAs};
     /// # #[tokio::main]
     /// # async fn main() {
-    /// // A non-Clone type — get() is not available on ReadHandle
+    /// // A non-Clone type, so get() is not available on ReadHandle
     /// struct Inventory { items: Vec<String> }
     ///
     /// #[derive(Clone, Debug)]

--- a/actify/src/lib.rs
+++ b/actify/src/lib.rs
@@ -336,21 +336,38 @@
 //!
 //! Jobs queue in a bounded channel, so callers wait when it is full.
 //!
-//! A method that calls its own handle never returns: it waits for a reply that
-//! only this actor can produce, and this actor is busy running the method. Two
-//! actors calling each other block the same way.
+//! Two actors that call each other never return: each waits for a reply the
+//! other can only produce once it is free. The same holds for a method calling
+//! its own handle.
 //!
 //! ```no_run
 //! # use actify::{Handle, actify};
 //! #[derive(Clone, Debug)]
-//! struct Counter {
-//!     own: Option<Handle<Counter>>,
+//! struct Parser {
+//!     store: Option<Handle<Store>>,
+//! }
+//!
+//! #[derive(Clone, Debug)]
+//! struct Store {
+//!     parser: Option<Handle<Parser>>,
 //! }
 //!
 //! #[actify]
-//! impl Counter {
-//!     async fn deadlocks(&self) {
-//!         self.own.as_ref().unwrap().get().await;
+//! impl Parser {
+//!     async fn parse(&self) {
+//!         self.store.as_ref().unwrap().save().await;
+//!     }
+//!
+//!     async fn is_ready(&self) -> bool {
+//!         true
+//!     }
+//! }
+//!
+//! #[actify]
+//! impl Store {
+//!     async fn save(&self) {
+//!         // Parser is still inside parse, so this call is never served
+//!         self.parser.as_ref().unwrap().is_ready().await;
 //!     }
 //! }
 //! ```

--- a/actify/src/lib.rs
+++ b/actify/src/lib.rs
@@ -329,29 +329,31 @@
 //!
 //! # Execution model
 //!
-//! Each actor is one Tokio task that runs one job at a time, taking the next
-//! only after the current one returns. Calls never interleave, so `&mut self`
-//! methods need no lock. A slow method blocks every other caller of that actor.
+//! Each actor is one Tokio task. It runs one job at a time and takes the next
+//! only after the current one returns, so calls never interleave and
+//! `&mut self` methods need no lock. A slow method delays every other call to
+//! that actor.
 //!
-//! An actor method that calls its own handle deadlocks: the reply can only be
-//! produced by the actor, which is busy inside the method. The same applies to
-//! two actors that call each other.
+//! Jobs queue in a bounded channel, so callers wait when it is full.
+//!
+//! A method that calls its own handle never returns: it waits for a reply that
+//! only this actor can produce, and this actor is busy running the method. Two
+//! actors calling each other block the same way.
 //!
 //! ```no_run
 //! # use actify::{Handle, actify};
-//! # #[derive(Clone, Debug)]
-//! # struct Counter { handle: Option<Handle<i32>> }
+//! #[derive(Clone, Debug)]
+//! struct Counter {
+//!     own: Option<Handle<Counter>>,
+//! }
+//!
 //! #[actify]
 //! impl Counter {
 //!     async fn deadlocks(&self) {
-//!         // The actor is inside this method, so nothing can serve the call
-//!         self.handle.as_ref().unwrap().get().await;
+//!         self.own.as_ref().unwrap().get().await;
 //!     }
 //! }
 //! ```
-//!
-//! Jobs queue in a bounded channel, so callers wait once enough calls are
-//! outstanding.
 //!
 //! # Actor lifetime and panics
 //!

--- a/actify/src/lib.rs
+++ b/actify/src/lib.rs
@@ -1,4 +1,5 @@
-#![warn(missing_debug_implementations, unreachable_pub)]
+#![warn(missing_docs, missing_debug_implementations, unreachable_pub)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(unused_must_use)]
 //! An intuitive actor model for Rust with minimal boilerplate, no manual messages and typed arguments.
 //!
@@ -205,9 +206,14 @@
 //! updated value to all subscribers after execution. This allows [`Cache`]s and
 //! [`Throttle`]s to stay synchronized with the actor.
 //!
+//! This applies to every method in the block, including those taking `&self`:
+//! broadcasting follows the attributes below, not the receiver. Annotate
+//! read-only methods with `skip_broadcast` if you do not want them waking
+//! subscribers.
+//!
 //! You can control broadcasting with these attributes:
 //!
-//! - `#[actify::skip_broadcast]` — skip broadcasting for a single `&mut self` method
+//! - `#[actify::skip_broadcast]` — skip broadcasting for a single method
 //! - `#[actify(skip_broadcast)]` — skip broadcasting for all methods in the impl block
 //! - `#[actify::broadcast]` — force broadcasting for a method in a `skip_broadcast` block
 //!
@@ -309,10 +315,10 @@
 //! Actify ships with extension traits that add convenience methods to handles
 //! wrapping common standard library types:
 //!
-//! - [`OptionHandle`] — `is_some`, `is_none` for `Handle<Option<T>>`
-//! - [`VecHandle`] — `push`, `is_empty`, `drain` for `Handle<Vec<T>>`
-//! - [`HashMapHandle`] — `get_key`, `insert`, `is_empty` for `Handle<HashMap<K, V>>`
-//! - [`HashSetHandle`] — `insert`, `is_empty` for `Handle<HashSet<K>>`
+//! - [`OptionHandle`] for `Handle<Option<T>>`
+//! - [`VecHandle`] for `Handle<Vec<T>>`
+//! - [`HashMapHandle`] for `Handle<HashMap<K, V>>`
+//! - [`HashSetHandle`] for `Handle<HashSet<K>>`
 //!
 //! # Non-Clone types
 //!
@@ -320,6 +326,58 @@
 //! For non-Clone types, implement [`BroadcastAs<V>`] for a Clone-able summary
 //! type `V` and specify it explicitly: `Handle::<MyType, Summary>::new(val)`.
 //! Your `#[actify]` methods work normally either way.
+//!
+//! # Execution model
+//!
+//! Each actor runs as one Tokio task that handles **one job at a time**, taking
+//! the next only after the current one returns. Calls from different tasks
+//! therefore never interleave, which is what makes `&mut self` methods safe
+//! without a lock — but a slow method blocks every other caller of that actor,
+//! so long waits belong outside the actor.
+//!
+//! This has one sharp consequence. An actor method that calls back into its own
+//! handle **deadlocks**: the actor is busy inside the method, and the reply can
+//! only be produced by the actor. The same applies to a cycle between two
+//! actors that call each other.
+//!
+//! ```no_run
+//! # use actify::{Handle, actify};
+//! # #[derive(Clone, Debug)]
+//! # struct Counter { handle: Option<Handle<i32>> }
+//! #[actify]
+//! impl Counter {
+//!     async fn deadlocks(&self) {
+//!         // The actor is inside this method, so nothing can serve the call
+//!         self.handle.as_ref().unwrap().get().await;
+//!     }
+//! }
+//! ```
+//!
+//! Jobs are queued in a channel of bounded size, so callers wait once enough
+//! calls are outstanding rather than growing memory without limit.
+//!
+//! # Actor lifetime and panics
+//!
+//! An actor runs until every [`Handle`] to it is dropped, at which point its
+//! task ends. A [`ReadHandle`] counts here too: it holds a full handle
+//! internally, so it keeps the actor alive. A [`Cache`] does not — it only
+//! receives broadcasts.
+//!
+//! An actor stops permanently if one of its methods panics; there is no
+//! restart. Every later call on **any** handle to it then panics, reporting
+//! that the actor panicked. The original panic is printed by Rust with its own
+//! message and backtrace, so the failing method and line are already visible.
+//!
+//! Calls also panic once the actor's runtime has shut down, which reports that
+//! the actor is no longer running rather than blaming a panic. This is worth
+//! knowing at teardown, where a handle can outlive the runtime that served it.
+//!
+//! # Feature flags
+//!
+//! - `profiler` — counts broadcasts per method, readable through
+//!   `get_broadcast_counts` and `get_sorted_broadcast_counts`. The counters
+//!   are process-wide and never reset, so treat them as a development aid
+//!   rather than a metric source.
 
 mod actor;
 mod cache;

--- a/actify/src/lib.rs
+++ b/actify/src/lib.rs
@@ -193,12 +193,12 @@
 //!
 //! Every [`Handle`] provides a set of built-in methods that work without the macro:
 //!
-//! - [`Handle::get`] — returns a clone of the current actor value (does not broadcast)
-//! - [`Handle::set`] — overwrites the actor value (broadcasts the change)
-//! - [`Handle::set_if_changed`] — only broadcasts when the new value differs (requires `PartialEq`)
-//! - [`Handle::subscribe`] — returns a [`tokio::sync::broadcast::Receiver`] for change notifications
-//! - [`Handle::with`] — runs a read-only closure on `&T` (does not broadcast)
-//! - [`Handle::with_mut`] — runs a mutable closure on `&mut T` (broadcasts the change)
+//! - [`Handle::get`]: returns a clone of the current actor value (does not broadcast)
+//! - [`Handle::set`]: overwrites the actor value (broadcasts the change)
+//! - [`Handle::set_if_changed`]: only broadcasts when the new value differs (requires `PartialEq`)
+//! - [`Handle::subscribe`]: returns a [`tokio::sync::broadcast::Receiver`] for change notifications
+//! - [`Handle::with`]: runs a read-only closure on `&T` (does not broadcast)
+//! - [`Handle::with_mut`]: runs a mutable closure on `&mut T` (broadcasts the change)
 //!
 //! # Broadcasting
 //!
@@ -213,9 +213,9 @@
 //!
 //! You can control broadcasting with these attributes:
 //!
-//! - `#[actify::skip_broadcast]` — skip broadcasting for a single method
-//! - `#[actify(skip_broadcast)]` — skip broadcasting for all methods in the impl block
-//! - `#[actify::broadcast]` — force broadcasting for a method in a `skip_broadcast` block
+//! - `#[actify::skip_broadcast]`: skip broadcasting for a single method
+//! - `#[actify(skip_broadcast)]`: skip broadcasting for all methods in the impl block
+//! - `#[actify::broadcast]`: force broadcasting for a method in a `skip_broadcast` block
 //!
 //! ```
 //! # use actify::{Handle, actify, skip_broadcast, broadcast};
@@ -303,9 +303,9 @@
 //! A [`Throttle`] rate-limits broadcasted updates before forwarding them to a callback.
 //! Configure the rate with [`Frequency`]:
 //!
-//! - [`Frequency::OnEvent`] — fires on every broadcast
-//! - [`Frequency::Interval`] — fires at a fixed interval
-//! - [`Frequency::OnEventWhen`] — fires for an event only after an interval has passed
+//! - [`Frequency::OnEvent`]: fires on every broadcast
+//! - [`Frequency::Interval`]: fires at a fixed interval
+//! - [`Frequency::OnEventWhen`]: fires for an event only after an interval has passed
 //!
 //! Use the [`Throttled`] trait to parse the actor's type into a different output type
 //! for the throttle callback.
@@ -329,16 +329,13 @@
 //!
 //! # Execution model
 //!
-//! Each actor runs as one Tokio task that handles **one job at a time**, taking
-//! the next only after the current one returns. Calls from different tasks
-//! therefore never interleave, which is what makes `&mut self` methods safe
-//! without a lock — but a slow method blocks every other caller of that actor,
-//! so long waits belong outside the actor.
+//! Each actor is one Tokio task that runs one job at a time, taking the next
+//! only after the current one returns. Calls never interleave, so `&mut self`
+//! methods need no lock. A slow method blocks every other caller of that actor.
 //!
-//! This has one sharp consequence. An actor method that calls back into its own
-//! handle **deadlocks**: the actor is busy inside the method, and the reply can
-//! only be produced by the actor. The same applies to a cycle between two
-//! actors that call each other.
+//! An actor method that calls its own handle deadlocks: the reply can only be
+//! produced by the actor, which is busy inside the method. The same applies to
+//! two actors that call each other.
 //!
 //! ```no_run
 //! # use actify::{Handle, actify};
@@ -353,31 +350,27 @@
 //! }
 //! ```
 //!
-//! Jobs are queued in a channel of bounded size, so callers wait once enough
-//! calls are outstanding rather than growing memory without limit.
+//! Jobs queue in a bounded channel, so callers wait once enough calls are
+//! outstanding.
 //!
 //! # Actor lifetime and panics
 //!
-//! An actor runs until every [`Handle`] to it is dropped, at which point its
-//! task ends. A [`ReadHandle`] counts here too: it holds a full handle
-//! internally, so it keeps the actor alive. A [`Cache`] does not — it only
-//! receives broadcasts.
+//! An actor runs until every [`Handle`] to it is dropped. A [`ReadHandle`]
+//! holds a handle internally and keeps the actor alive. A [`Cache`] does not,
+//! since it only receives broadcasts.
 //!
-//! An actor stops permanently if one of its methods panics; there is no
-//! restart. Every later call on **any** handle to it then panics, reporting
-//! that the actor panicked. The original panic is printed by Rust with its own
-//! message and backtrace, so the failing method and line are already visible.
+//! A panicking method stops the actor permanently. There is no restart, and
+//! every later call on any handle to it panics, reporting that the actor
+//! panicked. Rust prints the original panic with its message and backtrace.
 //!
-//! Calls also panic once the actor's runtime has shut down, which reports that
-//! the actor is no longer running rather than blaming a panic. This is worth
-//! knowing at teardown, where a handle can outlive the runtime that served it.
+//! Calls after the actor's runtime has shut down panic too, reporting that the
+//! actor is no longer running.
 //!
 //! # Feature flags
 //!
-//! - `profiler` — counts broadcasts per method, readable through
-//!   `get_broadcast_counts` and `get_sorted_broadcast_counts`. The counters
-//!   are process-wide and never reset, so treat them as a development aid
-//!   rather than a metric source.
+//! - `profiler`: counts broadcasts per method, readable through
+//!   `get_broadcast_counts` and `get_sorted_broadcast_counts`. Counters are
+//!   process-wide and never reset.
 
 mod actor;
 mod cache;

--- a/actify/src/throttle.rs
+++ b/actify/src/throttle.rs
@@ -66,14 +66,13 @@ where
     /// Spawns a throttle that forwards an actor's broadcasts to `call` at the
     /// given [`Frequency`].
     ///
-    /// `init` is the value to fire with immediately, before any broadcast
-    /// arrives; pass `None` to wait for the first update instead.
+    /// `init` fires immediately, before any broadcast arrives. Pass `None` to
+    /// wait for the first update.
     ///
-    /// The task stops on its own once the actor does, because its receiver
-    /// closes with the actor's broadcast channel. Prefer
-    /// [`Handle::spawn_throttle`](crate::Handle::spawn_throttle) or
-    /// [`Cache::spawn_throttle`](crate::Cache::spawn_throttle), which obtain
-    /// the receiver for you without losing updates during setup.
+    /// The task stops when the actor does.
+    /// [`Handle::spawn_throttle`](crate::Handle::spawn_throttle) and
+    /// [`Cache::spawn_throttle`](crate::Cache::spawn_throttle) take the
+    /// receiver without losing updates during setup.
     pub fn spawn_from_receiver(
         client: C,
         call: fn(&C, F),
@@ -93,9 +92,8 @@ where
 
     /// Spawns a throttle that fires `call` with a fixed value on every interval.
     ///
-    /// Unlike [`spawn_from_receiver`](Self::spawn_from_receiver) this is not
-    /// attached to an actor, so nothing ever closes it: the task fires until
-    /// the runtime shuts down, and there is currently no way to stop it sooner.
+    /// Not attached to an actor, so nothing closes it: the task fires until the
+    /// runtime shuts down.
     pub fn spawn_interval(client: C, call: fn(&C, F), interval: Duration, val: T) {
         let mut throttle = Throttle {
             frequency: Frequency::Interval(interval),

--- a/actify/src/throttle.rs
+++ b/actify/src/throttle.rs
@@ -63,6 +63,17 @@ where
     T: Clone + Throttled<F> + Send + Sync + 'static,
     F: Send + Sync + 'static,
 {
+    /// Spawns a throttle that forwards an actor's broadcasts to `call` at the
+    /// given [`Frequency`].
+    ///
+    /// `init` is the value to fire with immediately, before any broadcast
+    /// arrives; pass `None` to wait for the first update instead.
+    ///
+    /// The task stops on its own once the actor does, because its receiver
+    /// closes with the actor's broadcast channel. Prefer
+    /// [`Handle::spawn_throttle`](crate::Handle::spawn_throttle) or
+    /// [`Cache::spawn_throttle`](crate::Cache::spawn_throttle), which obtain
+    /// the receiver for you without losing updates during setup.
     pub fn spawn_from_receiver(
         client: C,
         call: fn(&C, F),
@@ -80,6 +91,11 @@ where
         tokio::spawn(async move { throttle.tick().await });
     }
 
+    /// Spawns a throttle that fires `call` with a fixed value on every interval.
+    ///
+    /// Unlike [`spawn_from_receiver`](Self::spawn_from_receiver) this is not
+    /// attached to an actor, so nothing ever closes it: the task fires until
+    /// the runtime shuts down, and there is currently no way to stop it sooner.
     pub fn spawn_interval(client: C, call: fn(&C, F), interval: Duration, val: T) {
         let mut throttle = Throttle {
             frequency: Frequency::Interval(interval),


### PR DESCRIPTION
Seventeenth PR of the 0.8.3 release train. **Docs, lints and CI — no behaviour change.** Deliberately sequenced last among code-adjacent work, since it documents the panic messages settled in #74 and the API surface #75 pulled back.

### missing_docs

Enabled in both crates. It found six items — a short tail, so all six are documented rather than any being suppressed: the three `Cache` error variants, `BroadcastAs::to_broadcast`, and both `Throttle` spawners.

The re-exported `broadcast` / `skip_broadcast` attributes were the audit's other finding. `missing_docs` in `actify` cannot see them, because the lint applies where an item is *defined* — so they are documented in `actify-macros`, which now carries the lint and a crate-level doc of its own.

### # Panics

The crate had zero `# Panics` sections against roughly twenty panicking methods. Every method that reaches the actor now carries one, pointing at a new crate-level section rather than restating the contract ten times.

### Crate-level sections

- **Actor lifetime and panics** — what keeps an actor alive (including that a `ReadHandle` does and a `Cache` does not), that a panicking method stops it permanently with no restart, and that later calls report *panicked* versus *no longer running*.
- **Execution model** — one job at a time, so `&mut self` needs no lock but a slow method blocks every caller. Includes the deadlock: an actor method calling back into its own handle waits for a reply only it can produce. That was written down nowhere.
- **Feature flags** — what `profiler` does, and that its counters are process-wide and never reset.

### Two claims that were wrong

Broadcasting was documented as applying to `&mut self` methods. It actually follows the attributes and fires for `&self` methods too — the mismatch the audit found. Whether that behaviour changes is a 0.9.0 decision; **the docs now describe what the code does**, and say to annotate read-only methods you do not want broadcasting. The extension-trait method lists had also gone stale, so they now link to the traits instead of duplicating their contents.

### A gap in the CI gate

`[package.metadata.docs.rs]` with `all-features = true` plus `doc_auto_cfg` makes the `profiler` items visible on docs.rs with a feature badge.

Adding the feature-flags section then broke `cargo doc` **with default features**, because it linked to two `#[cfg(feature = "profiler")]` functions from always-compiled text. The `docs` CI job passes `--all-features`, so it stayed green and this would have shipped — every user running plain `cargo doc` would have hit it. The links are now plain code spans, and CI gained a second leg that builds docs with default features.

### Verified locally on rustc 1.97.1 (matching CI)

147 tests pass across all feature legs; clippy `--all-targets --all-features` clean; fmt clean; `cargo doc` clean with **both** default and all features; MSRV check passes. The new `crate#actor-lifetime-and-panics` anchor was confirmed present in the generated HTML, since rustdoc validates the item path but not the fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)