### PR TITLE
Compile the README examples and fix the attribute it recommends

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ By generating the boilerplate code for you, a few key benefits are provided:
 - Typed arguments and return values on the methods from your actor, exposed through each handle.
 - No need to manually define message structs or enums!
 - Built-in methods like `get()`, `set()`, `set_if_changed()`, and `subscribe()` even without using the macro.
-- Automatic broadcasting of state changes to subscribers, with `#[skip_broadcast]` and `#[broadcast]` controls.
+- Automatic broadcasting of state changes to subscribers, with `#[actify::skip_broadcast]` and `#[actify::broadcast]` controls.
 - Local synchronization through `Cache`, with `recv`, `recv_newest`, and non-blocking variants.
 - Rate-limited updates through `Throttle` with configurable `Frequency`.
 - Generic type parameters supported in both actor types and method arguments.
@@ -40,7 +40,7 @@ By generating the boilerplate code for you, a few key benefits are provided:
 
 Consider the following example, in which you want to turn your custom Greeter into an actor:
 
-```rust,no_run
+```rust
 use actify::{Handle, actify};
 
 #[derive(Clone, std::fmt::Debug)]
@@ -70,7 +70,7 @@ async fn main() {
 
 Actors broadcast state changes automatically. Subscribers and caches let you react to updates without polling:
 
-```rust,no_run
+```rust
 use actify::Handle;
 
 #[tokio::main]

--- a/actify/src/lib.rs
+++ b/actify/src/lib.rs
@@ -391,6 +391,14 @@
 //!   `get_broadcast_counts` and `get_sorted_broadcast_counts`. Counters are
 //!   process-wide and never reset.
 
+/// The README examples, compiled and run as part of the test suite.
+///
+/// Only present under `cfg(doctest)`, so it costs nothing when building docs.
+#[cfg(doctest)]
+mod readme {
+    #![doc = include_str!("../../README.md")]
+}
+
 mod actor;
 mod cache;
 mod extensions;


### PR DESCRIPTION
Eighteenth PR of the 0.8.3 release train, and the last before the release itself. **Docs only.**

### The README recommended code that does not compile

```md
- Automatic broadcasting of state changes to subscribers, with `#[skip_broadcast]` and `#[broadcast]` controls.
```

The bare form only works after `use actify::skip_broadcast;`. Everything else (`lib.rs`, every test) uses `#[actify::skip_broadcast]`. Verified by adding the bare form to an existing actor:

```
error: cannot find attribute `skip_broadcast` in this scope
```

Anyone following the README verbatim hits that.

### Nothing compiled the README

Which is why the above went unnoticed. A `#[cfg(doctest)]` module now includes it in the doctest run:

```rust
#[cfg(doctest)]
mod readme {
    #![doc = include_str!("../../README.md")]
}
```

`cfg(doctest)` is set only when rustdoc collects doctests, so the module does not exist while building docs. The front page stays the curated `lib.rs` one, and the README contributes no rendered output. It also sidesteps the README's `[`Handle`]` reference, which would otherwise be an unresolved intra-doc link.

Both examples also lost their `rust,no_run` fence, so their assertions now actually execute rather than only type-checking. They appear in the run as `actify/src/lib.rs - readme (line 439)` and `(line 469)`.

### Verified locally on rustc 1.97.1 (matching CI)

150 tests pass, including the two new README doctests; clippy `--all-targets --all-features` clean; fmt clean; `cargo doc` clean with both default and all features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)