### PR TITLE
Stop requiring a nightly rustdoc feature to build the docs

### DIFF
--- a/actify/Cargo.toml
+++ b/actify/Cargo.toml
@@ -23,7 +23,5 @@ default = []
 profiler = []
 
 [package.metadata.docs.rs]
-# Build with every feature so `profiler` items appear, tagged with the feature
-# they need.
+# Build with every feature so the profiler items are documented.
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/actify/src/lib.rs
+++ b/actify/src/lib.rs
@@ -1,5 +1,4 @@
 #![warn(missing_docs, missing_debug_implementations, unreachable_pub)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(unused_must_use)]
 //! An intuitive actor model for Rust with minimal boilerplate, no manual messages and typed arguments.
 //!


### PR DESCRIPTION
**Blocks the 0.8.3 publish.** Found by testing the release against a docs.rs-shaped build.

### The problem

`actify/src/lib.rs:2` carried `#![cfg_attr(docsrs, feature(doc_auto_cfg))]`, and `Cargo.toml` passed `--cfg docsrs` via `rustdoc-args`. `doc_auto_cfg` was removed in Rust 1.92 (folded into `doc_cfg`). docs.rs builds on current nightly, so the documentation build would have failed with `E0557: feature has been removed`, and **0.8.3 would have published with no documentation on docs.rs at all**.

Both the attribute and the `[package.metadata.docs.rs]` block are new in this release, so this is introduced by 0.8.3 rather than pre-existing.

### Why nothing caught it

`docsrs` is set only by docs.rs. Every local build and every CI job leaves it unset, so that line is skipped and all 150 tests pass without ever compiling it. The `docs` CI job does not set it either.

Confirmed locally: the installed nightly is **1.89.0-nightly (2025-05-27)**, which predates the removal, so even `cargo +nightly doc --cfg docsrs` succeeded here and masked it. Current nightly is 1.99.0.

### The fix

Removed the attribute and the `--cfg docsrs` flag. `all-features = true` is kept, so the `profiler` items are still documented.

Switching to `feature(doc_cfg)` was the alternative. I chose removal because the whole construct is a nightly-feature dependency that can break again on any rustdoc reorganisation, and the only thing lost is the "available on crate feature `profiler`" badge on two functions, whose feature is already named and explained in the crate's Feature flags section. One badge is not worth a recurring risk of publishing a crate with no documentation.

If you would rather keep the badges, `#![cfg_attr(docsrs, feature(doc_cfg))]` plus the `rustdoc-args` line restores them. I cannot verify that against current nightly from here without updating the local toolchain; say the word and I will.

### Verified

- `RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features` clean, so nothing else depends on that cfg
- 150 tests pass; clippy, fmt, and docs clean on both default and all features

No version bump: 0.8.3 is not published yet, so this lands in the same release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)