### PR TITLE
Publish from CI on a version tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  # release.yml runs this same gate against the tagged commit before publishing.
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,86 @@
+name: Release
+
+on:
+  push:
+    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
+
+permissions:
+  contents: read
+
+# Third-party actions are pinned by commit SHA. A tag can be repointed by
+# whoever controls the action repository.
+jobs:
+  versions:
+    name: Versions
+    runs-on: ubuntu-latest
+    outputs:
+      macros: ${{ steps.read.outputs.macros }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
+      - id: read
+        run: |
+          set -euo pipefail
+          meta=$(cargo metadata --no-deps --format-version 1)
+          actify=$(jq -r '.packages[] | select(.name == "actify") | .version' <<<"$meta")
+          macros=$(jq -r '.packages[] | select(.name == "actify-macros") | .version' <<<"$meta")
+          req=$(jq -r '.packages[] | select(.name == "actify") | .dependencies[] | select(.name == "actify-macros") | .req' <<<"$meta")
+
+          if [ "${GITHUB_REF_NAME#v}" != "$actify" ]; then
+            echo "::error::tag ${GITHUB_REF_NAME} does not match actify version ${actify}"
+            exit 1
+          fi
+          if [ "${req#^}" != "$macros" ]; then
+            echo "::error::actify requires actify-macros ${req}, workspace has ${macros}"
+            exit 1
+          fi
+
+          echo "macros=${macros}" >> "$GITHUB_OUTPUT"
+
+  ci:
+    uses: ./.github/workflows/ci.yml
+
+  publish:
+    name: Publish
+    needs: [versions, ci]
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      # Mints a short-lived crates.io token through trusted publishing.
+      id-token: write
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
+      - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1
+        id: auth
+
+      # actify requires an exact actify-macros version, so the macro crate has to
+      # reach the index first. A release that only changes actify reuses the
+      # macro version that is already published.
+      #
+      # The registry index is not cached in this job: a cached index predates the
+      # macro release below, and actify would fail to resolve it.
+      - name: Publish actify-macros
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+          MACROS: ${{ needs.versions.outputs.macros }}
+        run: |
+          set -euo pipefail
+          status=$(curl -sS -o /dev/null -w '%{http_code}' \
+            -A "actify release workflow" \
+            "https://crates.io/api/v1/crates/actify-macros/${MACROS}")
+          if [ "$status" = "200" ]; then
+            echo "actify-macros ${MACROS} is already published"
+          else
+            cargo publish -p actify-macros
+          fi
+
+      - name: Publish actify
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish -p actify

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+# Contributing
+
+## Building and testing
+
+The MSRV is 1.85. CI runs the following, and all of it must pass locally before
+pushing:
+
+```sh
+cargo test --workspace
+cargo test -p actify                                                  # default features
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo fmt --all --check
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+```
+
+Workspace feature unification builds actify with the `profiler` feature whenever
+`actify-test` is in the graph, so `cargo test -p actify` is the only run that
+covers the default build.
+
+Documentation is checked twice because feature-gated items cannot be linked from
+text that is always compiled.
+
+## Compile-fail snapshots
+
+`actify-test/tests/compile_fail/` holds trybuild cases with committed `.stderr`
+files. They are skipped unless `TRYBUILD_TESTS` is set, because they assert exact
+rustc diagnostics and only match the toolchain in `TRYBUILD_TOOLCHAIN`
+(`.github/workflows/ci.yml`).
+
+Run them, and regenerate the snapshots after changing a macro diagnostic:
+
+```sh
+TRYBUILD_TESTS=1 cargo test -p actify-test --test unsupported_arg_types
+TRYBUILD=overwrite TRYBUILD_TESTS=1 cargo test -p actify-test --test unsupported_arg_types
+```
+
+Regenerate with the pinned toolchain, otherwise the committed output will not
+match what CI produces.
+
+## Releasing
+
+Publishing runs on GitHub Actions (`.github/workflows/release.yml`), triggered by
+a version tag. Local publishing is not part of the process.
+
+1. Update `CHANGELOG.md`.
+2. Bump `actify/Cargo.toml`. Bump `actify-macros/Cargo.toml` if the macro crate
+   changed, and update actify's dependency requirement to match.
+3. Merge to `main`.
+4. Tag the merge commit and push it:
+
+   ```sh
+   git tag v0.8.3
+   git push origin v0.8.3
+   ```
+
+The workflow asserts that the tag matches actify's version and that actify's
+requirement on actify-macros matches the workspace, runs the full CI gate, then
+publishes actify-macros followed by actify. actify-macros is skipped when that
+version is already on crates.io.
+
+Publishing is irreversible. crates.io allows yanking, never deletion or version
+reuse.
+
+### One-time setup
+
+The `publish` job authenticates through crates.io trusted publishing, so no token
+is stored in the repository. Both crates need a trusted publisher registered at
+`https://crates.io/crates/<crate>/settings`, with:
+
+| Field | Value |
+| --- | --- |
+| Repository owner | `AvalorAI` |
+| Repository name | `actify` |
+| Workflow filename | `release.yml` |
+| Environment | `release` |
+
+The `release` GitHub environment gates the publish step. Add required reviewers to
+it to approve each release before it is pushed to crates.io.


### PR DESCRIPTION
Local `cargo publish` cannot work in our development environment. Registry access there goes through a proxy that serves downloads only, and cargo's source replacement does not redirect publishing: `cargo publish` uploads to the crates.io API. GitHub runners reach crates.io directly, which is why CI is green today, so publishing moves there.

## What this does

`release.yml` triggers on a `v*.*.*` tag and runs three jobs:

1. **versions** asserts the tag matches actify's version, and that actify's requirement on actify-macros matches the workspace version.
2. **ci** calls `ci.yml` as a reusable workflow, so the tagged commit passes the same gate as every PR. The only change to `ci.yml` is adding `workflow_call:`.
3. **publish** mints a short-lived crates.io token via trusted publishing, then publishes actify-macros followed by actify.

actify-macros is skipped when that version is already on crates.io, so a release that only bumps actify works without touching the macro crate.

The publish job deliberately does not use `Swatinem/rust-cache`: a cached registry index predates the macro release in the step above it, and actify would fail to resolve it.

Third-party actions are pinned by commit SHA. `ci.yml` still pins by tag; worth a separate cleanup.

## Setup required before the first release

Trusted publishing must be registered for **both** crates at `https://crates.io/crates/<crate>/settings`, with owner `AvalorAI`, repo `actify`, workflow `release.yml`, environment `release`. Details are in `CONTRIBUTING.md`.

The `release` environment gates the publish job. Adding required reviewers to it turns each release into an explicit approval.

## Also here

`CONTRIBUTING.md`, which `ci.yml` already referenced but did not exist. Covers the local gate, the trybuild snapshot flow, and the release process.

## Testing

No red test: this is CI configuration, and nothing in the test suite can exercise it. What was verified locally:

- `cargo metadata --no-deps` succeeds without resolving the unpublished actify-macros 0.5.0, which is what the version job depends on.
- Both assertions produce the right answer against the current manifests: tag `v0.8.3` matches actify `0.8.3`, and `^0.5.0` matches macros `0.5.0`.

The publish path itself is only exercised by the first real tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
