### PR TITLE
Broadcast follows the receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ Entries before 0.8.3 were reconstructed from the git history after the fact, so
 they record what changed rather than why, and are not exhaustive. 0.8.0 through
 0.8.2 were released without tags; their dates are those of the version bump.
 
+## [Unreleased]
+
+### Changed
+
+- **Breaking:** methods taking `&self` no longer broadcast. Broadcasting follows
+  the receiver: `&mut self` broadcasts, `&self` does not. Previously every
+  method broadcast regardless of receiver, so read-only calls woke every
+  subscriber, cache and throttle.
+
+  This changes runtime behaviour without breaking compilation. A `&self` method
+  that relied on broadcasting keeps compiling and stops broadcasting. Add
+  `#[actify::broadcast]` to it to restore the old behaviour.
+
+  `#[actify::skip_broadcast]` now applies only to `&mut self` methods, and
+  `#[actify::broadcast]` only to `&self` methods. Applying either where it has
+  no effect is a compile error naming the reason.
+
+### Fixed
+
+- Extension getters such as `VecHandle::is_empty` and `HashMapHandle::keys` no
+  longer broadcast.
+
 ## [0.8.3] - 2026-08-08
 
 Bug fixes, macro diagnostics and documentation. No API changes.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ By generating the boilerplate code for you, a few key benefits are provided:
 - Typed arguments and return values on the methods from your actor, exposed through each handle.
 - No need to manually define message structs or enums!
 - Built-in methods like `get()`, `set()`, `set_if_changed()`, and `subscribe()` even without using the macro.
-- Automatic broadcasting of state changes to subscribers, with `#[actify::skip_broadcast]` and `#[actify::broadcast]` controls.
+- Automatic broadcasting to subscribers from methods taking `&mut self`, with `#[actify::broadcast]` and `#[actify::skip_broadcast]` overrides.
 - Local synchronization through `Cache`, with `recv`, `recv_newest`, and non-blocking variants.
 - Rate-limited updates through `Throttle` with configurable `Frequency`.
 - Generic type parameters supported in both actor types and method arguments.

--- a/actify-macros/src/codegen/handle.rs
+++ b/actify-macros/src/codegen/handle.rs
@@ -109,10 +109,10 @@ fn method_body(
         None
     };
 
-    let broadcast = if method.skip_broadcast {
-        None
-    } else {
+    let broadcast = if method.broadcasts {
         Some(quote! { __actify_s.broadcast(#ident_string); })
+    } else {
+        None
     };
 
     // The __actify_ prefix prevents collisions with user argument names, which

--- a/actify-macros/src/lib.rs
+++ b/actify-macros/src/lib.rs
@@ -65,7 +65,7 @@ impl syn::parse::Parse for ActifyArgs {
             } else if ident == "broadcast" {
                 return Err(syn::Error::new_spanned(
                     ident,
-                    "methods already broadcast by default; `#[actify(broadcast)]` is unnecessary",
+                    "`#[actify(broadcast)]` is not supported; methods taking &mut self broadcast by default, and a method taking &self opts in with `#[actify::broadcast]`",
                 ));
             } else {
                 return Err(syn::Error::new_spanned(

--- a/actify-macros/src/parse.rs
+++ b/actify-macros/src/parse.rs
@@ -99,8 +99,8 @@ pub struct MethodInfo {
     pub is_mutable: bool,
     /// Whether the method is async.
     pub is_async: bool,
-    /// Whether `#[actify::skip_broadcast]` is present.
-    pub skip_broadcast: bool,
+    /// Whether the generated method broadcasts after calling the actor method.
+    pub broadcasts: bool,
     /// Argument identifiers. For destructuring patterns a positional name is generated.
     pub arg_names: Punctuated<Ident, Comma>,
     /// Argument types.
@@ -134,7 +134,10 @@ impl MethodInfo {
 
         let mut errors = None;
 
-        if skip_all_broadcasts {
+        // A `&self` method cannot change the state, so it only broadcasts when
+        // asked to. Interior mutability and a custom `to_broadcast` are the
+        // cases where that is meaningful.
+        let broadcasts = if skip_all_broadcasts {
             if let Some(attr) = skip_attr {
                 accumulate(
                     &mut errors,
@@ -144,20 +147,29 @@ impl MethodInfo {
                     ),
                 );
             }
-        } else if let Some(attr) = broadcast_attr {
-            accumulate(
-                &mut errors,
-                Error::new(
-                    attr.span(),
-                    "#[broadcast] is superfluous: methods already broadcast by default; use #[actify(skip_broadcast)] on the impl block to change the default",
-                ),
-            );
-        }
-
-        let skip_broadcast = if skip_all_broadcasts {
-            broadcast_attr.is_none()
+            broadcast_attr.is_some()
+        } else if is_mutable {
+            if let Some(attr) = broadcast_attr {
+                accumulate(
+                    &mut errors,
+                    Error::new(
+                        attr.span(),
+                        "#[broadcast] is superfluous: methods taking &mut self broadcast by default",
+                    ),
+                );
+            }
+            skip_attr.is_none()
         } else {
-            skip_attr.is_some()
+            if let Some(attr) = skip_attr {
+                accumulate(
+                    &mut errors,
+                    Error::new(
+                        attr.span(),
+                        "#[skip_broadcast] is superfluous: methods taking &self do not broadcast; use #[actify::broadcast] to opt in",
+                    ),
+                );
+            }
+            broadcast_attr.is_some()
         };
 
         if let Err(error) = validate_signature_modifiers(method) {
@@ -195,7 +207,7 @@ impl MethodInfo {
             ident,
             is_mutable,
             is_async,
-            skip_broadcast,
+            broadcasts,
             arg_names,
             arg_types,
             output_type,

--- a/actify-test/src/main.rs
+++ b/actify-test/src/main.rs
@@ -1,7 +1,7 @@
 //! This workspace is used to test the functionalities of actify as would any user that imports the library
 
-use actify::{Handle, actify};
-use std::{collections::HashMap, fmt::Debug};
+use actify::{BroadcastAs, Handle, actify};
+use std::{collections::HashMap, fmt::Debug, sync::Mutex};
 
 fn main() {}
 
@@ -316,6 +316,33 @@ impl SkipMultipleBroadcastsActor {
     fn broadcast_method(&mut self, x: i32) -> i32 {
         self.value = x;
         x * 2
+    }
+}
+
+/// Interior mutability lets a `&self` method change what subscribers observe,
+/// which is the case `#[actify::broadcast]` exists for.
+#[derive(Debug)]
+struct InteriorMutabilityActor {
+    value: Mutex<i32>,
+}
+
+impl BroadcastAs<i32> for InteriorMutabilityActor {
+    fn to_broadcast(&self) -> i32 {
+        *self.value.lock().unwrap()
+    }
+}
+
+#[actify]
+impl InteriorMutabilityActor {
+    #[actify::broadcast]
+    fn increment(&self) -> i32 {
+        let mut value = self.value.lock().unwrap();
+        *value += 1;
+        *value
+    }
+
+    fn peek(&self) -> i32 {
+        *self.value.lock().unwrap()
     }
 }
 
@@ -641,6 +668,20 @@ mod tests {
         // broadcast_method has #[broadcast], overriding the block default
         handle.broadcast_method(20).await;
         assert!(rx.try_recv().is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_ref_self_broadcast_opt_in() {
+        let handle: Handle<InteriorMutabilityActor, i32> = Handle::new(InteriorMutabilityActor {
+            value: Mutex::new(0),
+        });
+        let mut rx = handle.subscribe();
+
+        assert_eq!(handle.peek().await, 0);
+        assert!(rx.try_recv().is_err());
+
+        assert_eq!(handle.increment().await, 1);
+        assert_eq!(rx.try_recv().unwrap(), 1);
     }
 
     #[allow(dead_code)]

--- a/actify-test/tests/compile_fail/superfluous_broadcast.rs
+++ b/actify-test/tests/compile_fail/superfluous_broadcast.rs
@@ -1,4 +1,4 @@
-// EXPECTED: #[broadcast] on a method without #[actify(skip_broadcast)] on impl is superfluous.
+// EXPECTED: #[broadcast] on a &mut self method is superfluous, it broadcasts by default.
 use actify::actify;
 
 #[derive(Clone, Debug)]
@@ -7,7 +7,7 @@ struct MyActor;
 #[actify]
 impl MyActor {
     #[actify::broadcast]
-    fn already_broadcasts(&self) {}
+    fn already_broadcasts(&mut self) {}
 }
 
 fn main() {}

--- a/actify-test/tests/compile_fail/superfluous_broadcast.stderr
+++ b/actify-test/tests/compile_fail/superfluous_broadcast.stderr
@@ -1,4 +1,4 @@
-error: #[broadcast] is superfluous: methods already broadcast by default; use #[actify(skip_broadcast)] on the impl block to change the default
+error: #[broadcast] is superfluous: methods taking &mut self broadcast by default
  --> tests/compile_fail/superfluous_broadcast.rs:9:5
   |
 9 |     #[actify::broadcast]

--- a/actify-test/tests/compile_fail/superfluous_skip_broadcast_ref_self.rs
+++ b/actify-test/tests/compile_fail/superfluous_skip_broadcast_ref_self.rs
@@ -1,0 +1,13 @@
+// EXPECTED: #[skip_broadcast] on a &self method is superfluous, it never broadcasts.
+use actify::actify;
+
+#[derive(Clone, Debug)]
+struct MyActor;
+
+#[actify]
+impl MyActor {
+    #[actify::skip_broadcast]
+    fn never_broadcasts(&self) {}
+}
+
+fn main() {}

--- a/actify-test/tests/compile_fail/superfluous_skip_broadcast_ref_self.stderr
+++ b/actify-test/tests/compile_fail/superfluous_skip_broadcast_ref_self.stderr
@@ -1,0 +1,5 @@
+error: #[skip_broadcast] is superfluous: methods taking &self do not broadcast; use #[actify::broadcast] to opt in
+ --> tests/compile_fail/superfluous_skip_broadcast_ref_self.rs:9:5
+  |
+9 |     #[actify::skip_broadcast]
+  |     ^

--- a/actify-test/tests/compile_fail/unnecessary_block_broadcast.stderr
+++ b/actify-test/tests/compile_fail/unnecessary_block_broadcast.stderr
@@ -1,4 +1,4 @@
-error: methods already broadcast by default; `#[actify(broadcast)]` is unnecessary
+error: `#[actify(broadcast)]` is not supported; methods taking &mut self broadcast by default, and a method taking &self opts in with `#[actify::broadcast]`
  --> tests/compile_fail/unnecessary_block_broadcast.rs:7:10
   |
 7 | #[actify(broadcast)]

--- a/actify-test/tests/unsupported_arg_types.rs
+++ b/actify-test/tests/unsupported_arg_types.rs
@@ -32,6 +32,7 @@ fn compile_fail_tests() {
 
     // Superfluous broadcast attributes
     t.compile_fail("tests/compile_fail/superfluous_skip_broadcast.rs");
+    t.compile_fail("tests/compile_fail/superfluous_skip_broadcast_ref_self.rs");
     t.compile_fail("tests/compile_fail/superfluous_broadcast.rs");
     t.compile_fail("tests/compile_fail/unnecessary_block_broadcast.rs");
 

--- a/actify/src/extensions/vec.rs
+++ b/actify/src/extensions/vec.rs
@@ -74,3 +74,24 @@ where
         self.drain(range).collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Handle;
+
+    /// Reading the length leaves the vector untouched. The `push` afterwards
+    /// proves the subscription is live and the first assertion did not pass by
+    /// accident.
+    #[tokio::test]
+    async fn test_getter_does_not_broadcast() {
+        let handle = Handle::new(vec![1, 2, 3]);
+        let mut rx = handle.subscribe();
+
+        assert!(!handle.is_empty().await);
+        assert!(rx.try_recv().is_err());
+
+        handle.push(4).await;
+        assert_eq!(rx.recv().await.unwrap(), vec![1, 2, 3, 4]);
+    }
+}

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -794,6 +794,21 @@ mod tests {
         }
     }
 
+    /// A `&self` method cannot change the state, so there is nothing for
+    /// subscribers to observe. The `&mut self` call afterwards proves the
+    /// subscription is live and the first assertion did not pass by accident.
+    #[tokio::test]
+    async fn test_ref_self_method_does_not_broadcast() {
+        let handle: Handle<NonCloneActor, i32> = Handle::new(NonCloneActor { value: 42 });
+        let mut rx = handle.subscribe();
+
+        assert_eq!(handle.get_value().await, 42);
+        assert!(rx.try_recv().is_err());
+
+        handle.set_value(100).await;
+        assert_eq!(rx.recv().await.unwrap(), 100);
+    }
+
     #[tokio::test]
     async fn test_with_does_not_broadcast() {
         let handle = Handle::new(vec![1, 2, 3]);

--- a/actify/src/lib.rs
+++ b/actify/src/lib.rs
@@ -201,38 +201,22 @@
 //!
 //! # Broadcasting
 //!
-//! By default, any method on an actified type automatically broadcasts the
-//! updated value to all subscribers after execution. This allows [`Cache`]s and
-//! [`Throttle`]s to stay synchronized with the actor.
-//!
-//! This applies to every method in the block, including those taking `&self`:
-//! broadcasting follows the attributes below, not the receiver. Annotate
-//! read-only methods with `skip_broadcast` if you do not want them waking
-//! subscribers.
-//!
-//! You can control broadcasting with these attributes:
-//!
-//! - `#[actify::skip_broadcast]`: skip broadcasting for a single method
-//! - `#[actify(skip_broadcast)]`: skip broadcasting for all methods in the impl block
-//! - `#[actify::broadcast]`: force broadcasting for a method in a `skip_broadcast` block
+//! A method taking `&mut self` broadcasts the updated value to all subscribers
+//! after it returns. This keeps [`Cache`]s and [`Throttle`]s synchronized with
+//! the actor. A method taking `&self` does not broadcast.
 //!
 //! ```
-//! # use actify::{Handle, actify, skip_broadcast, broadcast};
-//! # use std::fmt::Debug;
+//! # use actify::{Handle, actify};
 //! # #[derive(Clone, Debug)]
 //! # struct Counter { value: i32 }
-//! #[actify(skip_broadcast)]
+//! #[actify]
 //! impl Counter {
-//!     /// Does not broadcast (block default).
 //!     fn increment(&mut self) -> i32 {
 //!         self.value += 1;
 //!         self.value
 //!     }
 //!
-//!     /// Overrides the block default to broadcast.
-//!     #[actify::broadcast]
-//!     fn reset(&mut self) -> i32 {
-//!         self.value = 0;
+//!     fn value(&self) -> i32 {
 //!         self.value
 //!     }
 //! }
@@ -242,11 +226,49 @@
 //!     let handle = Handle::new(Counter { value: 0 });
 //!     let mut rx = handle.subscribe();
 //!
-//!     handle.increment().await; // No broadcast
+//!     handle.value().await;
 //!     assert!(rx.try_recv().is_err());
 //!
-//!     handle.reset().await; // Broadcasts
-//!     assert!(rx.try_recv().is_ok());
+//!     handle.increment().await;
+//!     assert_eq!(rx.try_recv().unwrap().value, 1);
+//! }
+//! ```
+//!
+//! Three attributes override the receiver:
+//!
+//! - `#[actify::broadcast]`: broadcast from a method taking `&self`
+//! - `#[actify::skip_broadcast]`: do not broadcast from a method taking `&mut self`
+//! - `#[actify(skip_broadcast)]`: no method in the impl block broadcasts unless it
+//!   carries `#[actify::broadcast]`
+//!
+//! `#[actify::broadcast]` applies where a `&self` method changes what subscribers
+//! observe, which requires interior mutability:
+//!
+//! ```
+//! # use actify::{Handle, actify, BroadcastAs};
+//! # use std::sync::Mutex;
+//! # #[derive(Debug)]
+//! # struct Counter { value: Mutex<i32> }
+//! # impl BroadcastAs<i32> for Counter {
+//! #     fn to_broadcast(&self) -> i32 { *self.value.lock().unwrap() }
+//! # }
+//! #[actify]
+//! impl Counter {
+//!     #[actify::broadcast]
+//!     fn increment(&self) -> i32 {
+//!         let mut value = self.value.lock().unwrap();
+//!         *value += 1;
+//!         *value
+//!     }
+//! }
+//!
+//! #[tokio::main]
+//! async fn main() {
+//!     let handle: Handle<Counter, i32> = Handle::new(Counter { value: Mutex::new(0) });
+//!     let mut rx = handle.subscribe();
+//!
+//!     assert_eq!(handle.increment().await, 1);
+//!     assert_eq!(rx.try_recv().unwrap(), 1);
 //! }
 //! ```
 //!
@@ -266,7 +288,7 @@
 //!     fn increment(&mut self) { self.value += 1; }
 //! }
 //!
-//! #[actify(name = "CounterGetters", skip_broadcast)]
+//! #[actify(name = "CounterGetters")]
 //! impl Counter {
 //!     fn value(&self) -> i32 { self.value }
 //! }


### PR DESCRIPTION
First PR of the 0.9.0 train, and the one everything else waits on: item 12's ~50 new extension methods would multiply this problem roughly fivefold.

## The change

A method taking `&mut self` broadcasts. A method taking `&self` does not. Previously every method broadcast regardless of receiver, so a read woke every subscriber, cache and throttle.

The receiver already states whether the state can change, so the macro no longer needs an attribute to know. The attributes now cover only the cases the receiver cannot express:

| Attribute | Applies to | Effect |
|---|---|---|
| `#[actify::broadcast]` | `&self` | broadcast anyway (interior mutability, custom `to_broadcast`) |
| `#[actify::skip_broadcast]` | `&mut self` | do not broadcast |
| `#[actify(skip_broadcast)]` | impl block | nothing broadcasts unless it carries `#[actify::broadcast]` |

Applying either attribute where it has no effect is a compile error naming the reason, so a stale `#[skip_broadcast]` on a getter does not sit there implying it does something.

`MethodInfo` now carries `broadcasts` instead of `skip_broadcast`, keeping the policy in `parse` and leaving codegen to read the answer.

## Why this is the risky one

**It changes runtime behaviour without breaking compilation.** A `&self` method that relied on broadcasting keeps compiling and silently stops broadcasting. That is worse than a rename, which fails loudly. The migration is to add `#[actify::broadcast]` to that method.

The changelog entry says this explicitly rather than burying it in a list.

## Tests

TDD, two commits. `4c932f8` adds two tests that fail on main:

- `test_ref_self_method_does_not_broadcast`: a macro-generated `&self` getter
- `test_getter_does_not_broadcast`: the real `VecHandle::is_empty` extension getter

Both then perform a mutating call and assert it *does* broadcast, so neither can pass because the subscription died.

`e3da2d5` adds the fix plus:

- `test_ref_self_broadcast_opt_in` in `actify-test`, exercising the macro from outside the actify crate: an actor holding a `Mutex<i32>` where `#[actify::broadcast]` on `&self` broadcasts and a plain `&self` peek does not
- `superfluous_skip_broadcast_ref_self.rs`, a new compile-fail case for the new rule
- `superfluous_broadcast.rs` retargeted to `&mut self`, since `&self` is now the valid opt-in

The `#[actify::broadcast]` opt-in could not go in the red commit: it is rejected at compile time on main, which would have broken the build rather than failed a test.

## Verification

`cargo test --workspace` (42 + 8 + 24 + 78 doctests + trybuild, all pass), `cargo test -p actify`, clippy `-D warnings`, `cargo fmt --check`, and `cargo doc` with both default and all features under `RUSTDOCFLAGS="-D warnings"`.

Docs updated: the Broadcasting section in `lib.rs` (which documented the old behaviour in detail), the README feature bullet, and a `CHANGELOG.md` Unreleased entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)