### PR TITLE
Add take and replace to OptionHandle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 
 ## [Unreleased]
 
+### Added
+
+- `OptionHandle::take` and `OptionHandle::replace`, mirroring
+  `std::option::Option::take` and `std::option::Option::replace` in both
+  signature and behaviour.
+
 ### Changed
 
 - **Breaking:** methods taking `&self` no longer broadcast. Broadcasting follows

--- a/actify/src/extensions/option.rs
+++ b/actify/src/extensions/option.rs
@@ -5,6 +5,10 @@ trait ActorOption<T> {
     fn is_some(&self) -> bool;
 
     fn is_none(&self) -> bool;
+
+    fn take(&mut self) -> Option<T>;
+
+    fn replace(&mut self, value: T) -> Option<T>;
 }
 
 /// An implementation of the ActorOption extension trait for the standard [`Option`].
@@ -48,5 +52,67 @@ where
     /// ```
     fn is_none(&self) -> bool {
         self.is_none()
+    }
+
+    /// Takes the value out of the option, leaving a None in its place.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, OptionHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(Some(42));
+    /// assert_eq!(handle.take().await, Some(42));
+    /// assert!(handle.is_none().await);
+    /// # }
+    /// ```
+    fn take(&mut self) -> Option<T> {
+        self.take()
+    }
+
+    /// Replaces the value in the option, returning the old value if present.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, OptionHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(Some(1));
+    /// assert_eq!(handle.replace(2).await, Some(1));
+    /// assert_eq!(handle.get().await, Some(2));
+    /// # }
+    /// ```
+    fn replace(&mut self, value: T) -> Option<T> {
+        self.replace(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Handle;
+
+    /// Both methods take `&mut self`, so each call reaches subscribers.
+    #[tokio::test]
+    async fn test_take_and_replace_broadcast() {
+        let handle = Handle::new(Some(1));
+        let mut rx = handle.subscribe();
+
+        assert_eq!(handle.replace(2).await, Some(1));
+        assert_eq!(rx.recv().await.unwrap(), Some(2));
+
+        assert_eq!(handle.take().await, Some(2));
+        assert_eq!(rx.recv().await.unwrap(), None);
+    }
+
+    /// `take` on a None option is not an error, and it still reports the state.
+    #[tokio::test]
+    async fn test_take_when_none() {
+        let handle = Handle::new(Option::<i32>::None);
+
+        assert_eq!(handle.take().await, None);
+        assert!(handle.is_none().await);
     }
 }


### PR DESCRIPTION
Item 2 of the 0.9.0 train. Settles the `set_some` versus `replace` question from #57.

## The change

`OptionHandle` gains `take` and `replace`, both mirroring `std::option::Option` in signature and behaviour:

```rust
let handle = Handle::new(Some(1));
assert_eq!(handle.replace(2).await, Some(1));  // returns the old value
assert_eq!(handle.take().await, Some(2));
assert!(handle.is_none().await);
```

`replace` is strictly more capable than the `set_some` proposed in #57: it returns the previous value, which the caller can use or ignore. Matching std also means users do not have to learn an actify-specific name for a standard operation. **#57 is closed** with that reasoning.

Both take `&mut self`, so both broadcast under the rules from #83.

## Scope

`enhancement/more-extensions` carries roughly eight Option methods. This PR takes only `take` and `replace`, the mutating pair that `set_some` was competing with.

The rest (`unwrap_or`, `unwrap_or_default`, `unwrap_or_else`, `filter`, `map`) are deferred to the split-up item 12. Several take closures with `FnOnce` bounds that get boxed and sent to the actor, which is a different design question from a plain method and deserves its own review rather than riding along here.

## Testing

No red commit is possible: the methods do not exist on main, so a test calling them fails to compile rather than failing. Coverage added with the implementation:

- Doc examples for both methods, which run as doctests
- `test_take_and_replace_broadcast`: asserts `replace` returns the old value and that both calls reach a subscriber
- `test_take_when_none`: `take` on a `None` is not an error

The unit test also rules out infinite recursion. Inside the impl, `self.replace(value)` has to resolve to the inherent `Option::replace` rather than back into the trait method, which is the same pattern the existing `is_some` and `is_none` rely on.

## Verification

`cargo test --workspace` (44 lib + 8 + 24 + 84 doctests, all pass), `cargo test -p actify`, clippy `-D warnings`, `cargo fmt --check`, and `cargo doc` with default and all features under `RUSTDOCFLAGS="-D warnings"`.

## Follow-up, not in this PR

The `enhancement/option-extensions` branch behind #57 can be deleted once you are happy this supersedes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
