### PR TITLE
Extract ThrottleState from the throttle loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 - Extension getters such as `VecHandle::is_empty` and `HashMapHandle::keys` no
   longer broadcast.
 
+### Documentation
+
+- `Frequency::OnEventWhen` said it "fires for an event only after the interval
+  has passed", which reads as a per-event delay. It sends at most once per
+  interval, and only when a value arrived since the last send. The interval runs
+  from startup and is not restarted by a send, so the wait after a value is
+  anything from nothing to a full interval.
+
 ### Internal
 
 - The throttle loop's interval, receiver and event bookkeeping moved into a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 - Extension getters such as `VecHandle::is_empty` and `HashMapHandle::keys` no
   longer broadcast.
 
+### Internal
+
+- The throttle loop's interval, receiver and event bookkeeping moved into a
+  private `ThrottleState`, which made the lagging-receiver path testable. It had
+  never been executed by a test.
+
 ## [0.8.3] - 2026-08-08
 
 Bug fixes, macro diagnostics and documentation. No API changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 - The throttle loop's interval, receiver and event bookkeeping moved into a
   private `ThrottleState`, which made the lagging-receiver path testable. It had
   never been executed by a test.
+- `test_exit_on_shutdown` asserted `0 == 0`, because the throttle it built had
+  no initial value and so never fired.
 
 ## [0.8.3] - 2026-08-08
 

--- a/actify/src/throttle.rs
+++ b/actify/src/throttle.rs
@@ -29,18 +29,76 @@ impl<T: Clone> Throttled<T> for T {
     }
 }
 
-/// Owns the broadcast receiver, the interval timer and the `event_processed`
-/// flag used by [`Frequency::OnEventWhen`].
-///
-/// Drive it with [`Self::first_tick`], which consumes the immediate initial
-/// interval tick, then [`Self::next`], which awaits the next timer or event and
-/// reports whether the callback should fire.
+/// The runtime half of a [`Frequency`]: the [`Interval`] where the frequency
+/// has one, and the pending-event flag where it needs one.
+enum Timing {
+    OnEvent,
+    Interval(Interval),
+    OnEventWhen {
+        interval: Interval,
+        event_pending: bool,
+    },
+}
+
+impl Timing {
+    fn new(frequency: Frequency) -> Self {
+        match frequency {
+            Frequency::OnEvent => Timing::OnEvent,
+            Frequency::Interval(duration) => Timing::Interval(interval_after(duration)),
+            Frequency::OnEventWhen(duration) => Timing::OnEventWhen {
+                interval: interval_after(duration),
+                event_pending: false,
+            },
+        }
+    }
+
+    /// Waits for the next tick, or forever when the frequency has no interval.
+    async fn tick(&mut self) {
+        match self {
+            Timing::OnEvent => std::future::pending().await,
+            Timing::Interval(interval) | Timing::OnEventWhen { interval, .. } => {
+                interval.tick().await;
+            }
+        }
+    }
+
+    fn record_event(&mut self) {
+        if let Timing::OnEventWhen { event_pending, .. } = self {
+            *event_pending = true;
+        }
+    }
+
+    /// Whether the callback fires, given whether this wake-up carried an event.
+    fn should_fire(&mut self, received_event: bool) -> bool {
+        match self {
+            Timing::OnEvent => received_event,
+            Timing::Interval(_) => !received_event,
+            Timing::OnEventWhen { event_pending, .. } => {
+                let fire = !received_event && *event_pending;
+                if fire {
+                    *event_pending = false;
+                }
+                fire
+            }
+        }
+    }
+}
+
+/// `tokio::time::interval` fires its first tick immediately, and the throttle
+/// already fires once on startup. Resetting moves the first tick a full period
+/// out so the two do not land together.
+fn interval_after(duration: Duration) -> Interval {
+    let mut interval = time::interval(duration);
+    interval.reset();
+    interval
+}
+
+/// Owns the broadcast receiver and the timing, so the loop in
+/// [`Throttle::run`] is only a call to [`Self::next`] and a callback.
 struct ThrottleState<T> {
-    frequency: Frequency,
+    timing: Timing,
     val_rx: Option<broadcast::Receiver<T>>,
     current_val: Option<T>,
-    interval: Option<Interval>,
-    event_processed: bool,
 }
 
 impl<T: Clone> ThrottleState<T> {
@@ -49,26 +107,10 @@ impl<T: Clone> ThrottleState<T> {
         val_rx: Option<broadcast::Receiver<T>>,
         current_val: Option<T>,
     ) -> Self {
-        let interval = match frequency {
-            Frequency::OnEvent => None,
-            Frequency::Interval(duration) | Frequency::OnEventWhen(duration) => {
-                Some(time::interval(duration))
-            }
-        };
         Self {
-            frequency,
+            timing: Timing::new(frequency),
             val_rx,
             current_val,
-            interval,
-            event_processed: true,
-        }
-    }
-
-    /// Consumes the interval's initial tick, which completes immediately, so the
-    /// loop starts on a real wait.
-    async fn first_tick(&mut self) {
-        if let Some(interval) = &mut self.interval {
-            interval.tick().await;
         }
     }
 
@@ -76,12 +118,11 @@ impl<T: Clone> ThrottleState<T> {
     /// iteration, and `None` once the sender is gone and the loop should exit.
     async fn next(&mut self) -> Option<bool> {
         loop {
-            let received_msg = tokio::select!(
-                _ = keep_time(&mut self.interval) => false,
+            let received_event = tokio::select!(
+                _ = self.timing.tick() => false,
                 res = check_value(&mut self.val_rx) => {
                     match res {
                         Ok(val) => {
-                            self.event_processed = false;
                             self.current_val = Some(val);
                             true
                         }
@@ -103,18 +144,11 @@ impl<T: Clone> ThrottleState<T> {
                 },
             );
 
-            let should_fire = match self.frequency {
-                Frequency::OnEvent => received_msg,
-                Frequency::Interval(_) => !received_msg,
-                Frequency::OnEventWhen(_) => !received_msg && !self.event_processed,
-            };
-
-            // Only OnEventWhen reads this flag, and only it clears the event.
-            if should_fire && matches!(self.frequency, Frequency::OnEventWhen(_)) {
-                self.event_processed = true;
+            if received_event {
+                self.timing.record_event();
             }
 
-            return Some(should_fire);
+            return Some(self.timing.should_fire(received_event));
         }
     }
 
@@ -125,14 +159,6 @@ impl<T: Clone> ThrottleState<T> {
         T: Throttled<F>,
     {
         self.current_val.as_ref().map(|val| val.parse())
-    }
-}
-
-async fn keep_time(interval: &mut Option<Interval>) {
-    if let Some(interval) = interval {
-        interval.tick().await;
-    } else {
-        std::future::pending::<()>().await;
     }
 }
 
@@ -232,7 +258,6 @@ where
         } = self;
 
         let mut state = ThrottleState::new(frequency, val_rx, current_val);
-        state.first_tick().await;
 
         // Always execute the call once in case it was initialized
         if let Some(val) = state.current::<F>() {
@@ -267,7 +292,6 @@ mod tests {
         async fn test_on_event_fires_on_message() {
             let (tx, rx) = broadcast::channel(8);
             let mut state = ThrottleState::<i32>::new(Frequency::OnEvent, Some(rx), None);
-            state.first_tick().await;
 
             tx.send(42).unwrap();
             assert_eq!(state.next().await, Some(true));
@@ -282,7 +306,6 @@ mod tests {
                 Some(rx),
                 Some(1),
             );
-            state.first_tick().await;
 
             assert_eq!(state.next().await, Some(true));
             assert_eq!(state.next().await, Some(true));
@@ -298,7 +321,6 @@ mod tests {
                 Some(rx),
                 Some(1),
             );
-            state.first_tick().await;
 
             tx.send(42).unwrap();
             assert_eq!(state.next().await, Some(false));
@@ -313,7 +335,6 @@ mod tests {
                 Some(rx),
                 None,
             );
-            state.first_tick().await;
 
             tx.send(42).unwrap();
             assert_eq!(state.next().await, Some(false)); // event stored, interval not elapsed
@@ -325,7 +346,6 @@ mod tests {
         async fn test_exits_when_sender_is_dropped() {
             let (tx, rx) = broadcast::channel::<i32>(8);
             let mut state = ThrottleState::new(Frequency::OnEvent, Some(rx), None);
-            state.first_tick().await;
 
             drop(tx);
             assert_eq!(state.next().await, None);
@@ -337,7 +357,6 @@ mod tests {
         async fn test_continues_after_lagging() {
             let (tx, rx) = broadcast::channel(2);
             let mut state = ThrottleState::<i32>::new(Frequency::OnEvent, Some(rx), None);
-            state.first_tick().await;
 
             for i in 0..10 {
                 tx.send(i).unwrap();
@@ -425,22 +444,26 @@ mod tests {
             CounterClient::call,
             Frequency::Interval(Duration::from_millis(100)),
             receiver,
-            None,
+            Some(1),
         );
 
         sleep(Duration::from_millis(500)).await;
 
-        let count_before_drop = *counter.count.lock().unwrap();
+        // An uninitialised throttle never fires, which would leave the
+        // comparison below reading zero against zero.
+        assert!(*counter.count.lock().unwrap() > 0);
 
         // The throttle will stop, as no handles are present anymore
         drop(handle);
 
+        // A closed receiver and a due interval tick can be ready in the same
+        // select, so one further call may still land. Everything after it must
+        // stop.
         sleep(Duration::from_millis(500)).await;
+        let settled = *counter.count.lock().unwrap();
 
-        let count_after_drop = *counter.count.lock().unwrap();
-
-        // No updates have arrived even though the frequency is a constant interval, as the throttle has exited
-        assert_eq!(count_before_drop, count_after_drop);
+        sleep(Duration::from_millis(500)).await;
+        assert_eq!(settled, *counter.count.lock().unwrap());
     }
 
     #[tokio::test(start_paused = true)]

--- a/actify/src/throttle.rs
+++ b/actify/src/throttle.rs
@@ -258,6 +258,112 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use tokio::time::{Duration, Instant, sleep};
 
+    /// Driving `ThrottleState` directly reaches the receiver outcomes that a
+    /// spawned throttle hides: a closed sender and a lagging one.
+    mod state {
+        use super::*;
+
+        #[tokio::test(start_paused = true)]
+        async fn test_on_event_fires_on_message() {
+            let (tx, rx) = broadcast::channel(8);
+            let mut state = ThrottleState::<i32>::new(Frequency::OnEvent, Some(rx), None);
+            state.first_tick().await;
+
+            tx.send(42).unwrap();
+            assert_eq!(state.next().await, Some(true));
+            assert_eq!(state.current::<i32>(), Some(42));
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn test_interval_fires_without_events() {
+            let (_tx, rx) = broadcast::channel::<i32>(8);
+            let mut state = ThrottleState::new(
+                Frequency::Interval(Duration::from_millis(100)),
+                Some(rx),
+                Some(1),
+            );
+            state.first_tick().await;
+
+            assert_eq!(state.next().await, Some(true));
+            assert_eq!(state.next().await, Some(true));
+        }
+
+        /// Under Interval the event itself does not fire the callback, but the
+        /// value it carried is what the next tick sends.
+        #[tokio::test(start_paused = true)]
+        async fn test_interval_stores_event_without_firing() {
+            let (tx, rx) = broadcast::channel(8);
+            let mut state = ThrottleState::new(
+                Frequency::Interval(Duration::from_millis(100)),
+                Some(rx),
+                Some(1),
+            );
+            state.first_tick().await;
+
+            tx.send(42).unwrap();
+            assert_eq!(state.next().await, Some(false));
+            assert_eq!(state.current::<i32>(), Some(42));
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn test_on_event_when_fires_after_the_interval() {
+            let (tx, rx) = broadcast::channel(8);
+            let mut state = ThrottleState::new(
+                Frequency::OnEventWhen(Duration::from_millis(100)),
+                Some(rx),
+                None,
+            );
+            state.first_tick().await;
+
+            tx.send(42).unwrap();
+            assert_eq!(state.next().await, Some(false)); // event stored, interval not elapsed
+            assert_eq!(state.next().await, Some(true)); // interval elapsed
+            assert_eq!(state.next().await, Some(false)); // no new event since firing
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn test_exits_when_sender_is_dropped() {
+            let (tx, rx) = broadcast::channel::<i32>(8);
+            let mut state = ThrottleState::new(Frequency::OnEvent, Some(rx), None);
+            state.first_tick().await;
+
+            drop(tx);
+            assert_eq!(state.next().await, None);
+        }
+
+        /// Overflowing the channel makes the receiver report Lagged. The state
+        /// swallows it and delivers the next value rather than exiting.
+        #[tokio::test(start_paused = true)]
+        async fn test_continues_after_lagging() {
+            let (tx, rx) = broadcast::channel(2);
+            let mut state = ThrottleState::<i32>::new(Frequency::OnEvent, Some(rx), None);
+            state.first_tick().await;
+
+            for i in 0..10 {
+                tx.send(i).unwrap();
+            }
+
+            assert_eq!(state.next().await, Some(true));
+            assert_eq!(state.current::<i32>(), Some(8));
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn test_current_applies_parse() {
+            let (_tx, rx) = broadcast::channel::<A>(8);
+            let state = ThrottleState::new(Frequency::OnEvent, Some(rx), Some(A {}));
+
+            let _: B = state.current::<B>().expect("A parses into B");
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn test_current_is_none_without_a_value() {
+            let (_tx, rx) = broadcast::channel::<i32>(8);
+            let state = ThrottleState::<i32>::new(Frequency::OnEvent, Some(rx), None);
+
+            assert_eq!(state.current::<i32>(), None);
+        }
+    }
+
     #[tokio::test(start_paused = true)]
     async fn test_first_shot() {
         let handle = Handle::new(1);

--- a/actify/src/throttle.rs
+++ b/actify/src/throttle.rs
@@ -29,6 +29,123 @@ impl<T: Clone> Throttled<T> for T {
     }
 }
 
+/// Owns the broadcast receiver, the interval timer and the `event_processed`
+/// flag used by [`Frequency::OnEventWhen`].
+///
+/// Drive it with [`Self::first_tick`], which consumes the immediate initial
+/// interval tick, then [`Self::next`], which awaits the next timer or event and
+/// reports whether the callback should fire.
+struct ThrottleState<T> {
+    frequency: Frequency,
+    val_rx: Option<broadcast::Receiver<T>>,
+    current_val: Option<T>,
+    interval: Option<Interval>,
+    event_processed: bool,
+}
+
+impl<T: Clone> ThrottleState<T> {
+    fn new(
+        frequency: Frequency,
+        val_rx: Option<broadcast::Receiver<T>>,
+        current_val: Option<T>,
+    ) -> Self {
+        let interval = match frequency {
+            Frequency::OnEvent => None,
+            Frequency::Interval(duration) | Frequency::OnEventWhen(duration) => {
+                Some(time::interval(duration))
+            }
+        };
+        Self {
+            frequency,
+            val_rx,
+            current_val,
+            interval,
+            event_processed: true,
+        }
+    }
+
+    /// Consumes the interval's initial tick, which completes immediately, so the
+    /// loop starts on a real wait.
+    async fn first_tick(&mut self) {
+        if let Some(interval) = &mut self.interval {
+            interval.tick().await;
+        }
+    }
+
+    /// Returns `Some(true)` to fire the callback, `Some(false)` to skip this
+    /// iteration, and `None` once the sender is gone and the loop should exit.
+    async fn next(&mut self) -> Option<bool> {
+        loop {
+            let received_msg = tokio::select!(
+                _ = keep_time(&mut self.interval) => false,
+                res = check_value(&mut self.val_rx) => {
+                    match res {
+                        Ok(val) => {
+                            self.event_processed = false;
+                            self.current_val = Some(val);
+                            true
+                        }
+                        Err(RecvError::Closed) => {
+                            log::debug!(
+                                "Attached actor of type {} closed - exiting throttle",
+                                std::any::type_name::<T>()
+                            );
+                            return None;
+                        }
+                        Err(RecvError::Lagged(nr)) => {
+                            log::debug!(
+                                "Throttle of type {} lagged {nr} messages",
+                                std::any::type_name::<T>()
+                            );
+                            continue;
+                        }
+                    }
+                },
+            );
+
+            let should_fire = match self.frequency {
+                Frequency::OnEvent => received_msg,
+                Frequency::Interval(_) => !received_msg,
+                Frequency::OnEventWhen(_) => !received_msg && !self.event_processed,
+            };
+
+            // Only OnEventWhen reads this flag, and only it clears the event.
+            if should_fire && matches!(self.frequency, Frequency::OnEventWhen(_)) {
+                self.event_processed = true;
+            }
+
+            return Some(should_fire);
+        }
+    }
+
+    /// Parses the stored value into the callback's argument type, or `None` when
+    /// no value has arrived yet.
+    fn current<F>(&self) -> Option<F>
+    where
+        T: Throttled<F>,
+    {
+        self.current_val.as_ref().map(|val| val.parse())
+    }
+}
+
+async fn keep_time(interval: &mut Option<Interval>) {
+    if let Some(interval) = interval {
+        interval.tick().await;
+    } else {
+        std::future::pending::<()>().await;
+    }
+}
+
+async fn check_value<T: Clone>(
+    val_rx: &mut Option<broadcast::Receiver<T>>,
+) -> Result<T, RecvError> {
+    if let Some(rx) = val_rx {
+        rx.recv().await
+    } else {
+        std::future::pending::<Result<T, RecvError>>().await
+    }
+}
+
 /// Rate-limits broadcasted updates from a [`Handle`](crate::Handle) or [`Cache`](crate::Cache)
 /// before forwarding them to a callback.
 ///
@@ -80,14 +197,14 @@ where
         receiver: Receiver<T>,
         init: Option<T>,
     ) {
-        let mut throttle = Throttle {
+        let throttle = Throttle {
             frequency,
             client,
             call,
             val_rx: Some(receiver),
             current_val: init,
         };
-        tokio::spawn(async move { throttle.tick().await });
+        tokio::spawn(throttle.run());
     }
 
     /// Spawns a throttle that fires `call` with a fixed value on every interval.
@@ -95,91 +212,40 @@ where
     /// Not attached to an actor, so nothing closes it: the task fires until the
     /// runtime shuts down.
     pub fn spawn_interval(client: C, call: fn(&C, F), interval: Duration, val: T) {
-        let mut throttle = Throttle {
+        let throttle = Throttle {
             frequency: Frequency::Interval(interval),
             client,
             call,
             val_rx: None,
             current_val: Some(val),
         };
-        tokio::spawn(async move { throttle.tick().await });
+        tokio::spawn(throttle.run());
     }
 
-    async fn tick(&mut self) {
-        let mut interval = match self.frequency {
-            Frequency::OnEvent => None,
-            Frequency::Interval(duration) => Some(time::interval(duration)),
-            Frequency::OnEventWhen(duration) => Some(time::interval(duration)),
-        };
+    async fn run(self) {
+        let Throttle {
+            frequency,
+            client,
+            call,
+            val_rx,
+            current_val,
+        } = self;
 
-        if let Some(iv) = &mut interval {
-            iv.tick().await; // First tick completes immediately, so ignore by calling prior
+        let mut state = ThrottleState::new(frequency, val_rx, current_val);
+        state.first_tick().await;
+
+        // Always execute the call once in case it was initialized
+        if let Some(val) = state.current::<F>() {
+            call(&client, val);
         }
 
-        self.execute_call(); // Always execute the call once in case it was initialized
-
-        let mut event_processed = true;
-        loop {
-            // Wait or update cache
-            let received_msg = tokio::select!(
-                _ = Throttle::<C, T, F>::keep_time(&mut interval) => false,
-                res = Throttle::<C, T, F>::check_value(&mut self.val_rx) => {
-                    match res {
-                        Ok(val) => {
-                            event_processed = false;
-                            self.current_val = Some(val);
-                            true
-                        }
-                        Err(RecvError::Closed) => {
-                            log::debug!("Attached actor of type {} closed - exiting throttle", std::any::type_name::<T>());
-                            break
-                        }
-                        Err(RecvError::Lagged(nr)) => {
-                            log::debug!("Throttle of type {} lagged {nr} messages", std::any::type_name::<T>());
-                            continue
-                        }
-                    }
-
-                },
-            );
-
-            match self.frequency {
-                Frequency::OnEvent if received_msg => self.execute_call(),
-                Frequency::Interval(_) if !received_msg => self.execute_call(),
-                Frequency::OnEventWhen(_) if !received_msg && !event_processed => {
-                    event_processed = true;
-                    self.execute_call()
-                }
-                _ => continue,
+        while let Some(should_fire) = state.next().await {
+            if !should_fire {
+                continue;
             }
-        }
-    }
-
-    fn execute_call(&self) {
-        // Either parse the value to a different type F, or to itself when T = F
-        let val = if let Some(inner) = &self.current_val {
-            inner.parse()
-        } else {
-            return; // If cache empty, skip call
-        };
-
-        // Perform the call
-        (self.call)(&self.client, val);
-    }
-
-    async fn keep_time(interval: &mut Option<Interval>) {
-        if let Some(interval) = interval {
-            interval.tick().await;
-        } else {
-            std::future::pending::<()>().await;
-        }
-    }
-
-    async fn check_value(val_rx: &mut Option<broadcast::Receiver<T>>) -> Result<T, RecvError> {
-        if let Some(rx) = val_rx {
-            rx.recv().await
-        } else {
-            std::future::pending::<Result<T, RecvError>>().await
+            if let Some(val) = state.current::<F>() {
+                call(&client, val);
+            }
         }
     }
 }

--- a/actify/src/throttle.rs
+++ b/actify/src/throttle.rs
@@ -6,12 +6,12 @@ use tokio::time::{self, Duration, Interval};
 /// The Frequency is used to tune the speed of a [`Throttle`].
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Frequency {
-    /// Fires any time an event arrives. Designed for infrequent but important events.
+    /// Sends every value as it arrives.
     OnEvent,
-    /// Fires every interval, regardless of incoming events.
+    /// Sends the current value every interval, whether or not a new one arrived.
     Interval(Duration),
     /// Sends at most once per interval, and only when a new value arrived since
-    /// the last send. Designed for high-throughput types.
+    /// the last send.
     OnEventWhen(Duration),
 }
 

--- a/actify/src/throttle.rs
+++ b/actify/src/throttle.rs
@@ -29,8 +29,12 @@ impl<T: Clone> Throttled<T> for T {
     }
 }
 
-/// The runtime half of a [`Frequency`]: the [`Interval`] where the frequency
-/// has one, and the pending-event flag where it needs one.
+/// Holds the running [`Interval`], and for [`Frequency::OnEventWhen`] whether
+/// an event is waiting for the next tick.
+///
+/// [`Frequency`] is public configuration and stays a plain value. An
+/// [`Interval`] carries a schedule that has to survive across iterations, so
+/// the loop keeps this beside it.
 enum Timing {
     OnEvent,
     Interval(Interval),
@@ -62,35 +66,53 @@ impl Timing {
         }
     }
 
-    fn record_event(&mut self) {
-        if let Timing::OnEventWhen { event_pending, .. } = self {
-            *event_pending = true;
+    /// A value arrived. Returns whether to send it now.
+    fn on_value(&mut self) -> bool {
+        match self {
+            Timing::OnEvent => true,
+            Timing::Interval(_) => false,
+            Timing::OnEventWhen { event_pending, .. } => {
+                *event_pending = true;
+                false
+            }
         }
     }
 
-    /// Whether the callback fires, given whether this wake-up carried an event.
-    fn should_fire(&mut self, received_event: bool) -> bool {
+    /// The interval elapsed. Returns whether to send the stored value.
+    ///
+    /// Reaching this is itself the duration check: the tick only completes once
+    /// the period has passed, so `OnEventWhen` needs no comparison beyond
+    /// whether an event came in since the last send.
+    fn on_tick(&mut self) -> bool {
         match self {
-            Timing::OnEvent => received_event,
-            Timing::Interval(_) => !received_event,
-            Timing::OnEventWhen { event_pending, .. } => {
-                let fire = !received_event && *event_pending;
-                if fire {
-                    *event_pending = false;
-                }
-                fire
-            }
+            Timing::OnEvent => false,
+            Timing::Interval(_) => true,
+            Timing::OnEventWhen { event_pending, .. } => std::mem::take(event_pending),
         }
     }
 }
 
-/// `tokio::time::interval` fires its first tick immediately, and the throttle
-/// already fires once on startup. Resetting moves the first tick a full period
-/// out so the two do not land together.
+/// Moves the first tick a full period out.
+///
+/// `tokio::time::interval` completes its first tick immediately, and
+/// [`Throttle::run`] already sends the initial value before entering the loop,
+/// so without this an interval frequency sends twice at startup.
 fn interval_after(duration: Duration) -> Interval {
     let mut interval = time::interval(duration);
     interval.reset();
     interval
+}
+
+/// Why [`ThrottleState::next`] woke up.
+enum Wake {
+    /// The interval elapsed.
+    Tick,
+    /// A value arrived and is now stored.
+    Value,
+    /// Values were dropped. The next receive succeeds.
+    Lagged,
+    /// Every sender is gone.
+    Closed,
 }
 
 /// Owns the broadcast receiver and the timing, so the loop in
@@ -114,42 +136,45 @@ impl<T: Clone> ThrottleState<T> {
         }
     }
 
-    /// Returns `Some(true)` to fire the callback, `Some(false)` to skip this
-    /// iteration, and `None` once the sender is gone and the loop should exit.
+    /// Returns `Some(true)` to send the current value, `Some(false)` to skip
+    /// this iteration, and `None` once the sender is gone and the loop exits.
     async fn next(&mut self) -> Option<bool> {
         loop {
-            let received_event = tokio::select!(
-                _ = self.timing.tick() => false,
-                res = check_value(&mut self.val_rx) => {
-                    match res {
-                        Ok(val) => {
-                            self.current_val = Some(val);
-                            true
-                        }
-                        Err(RecvError::Closed) => {
-                            log::debug!(
-                                "Attached actor of type {} closed - exiting throttle",
-                                std::any::type_name::<T>()
-                            );
-                            return None;
-                        }
-                        Err(RecvError::Lagged(nr)) => {
-                            log::debug!(
-                                "Throttle of type {} lagged {nr} messages",
-                                std::any::type_name::<T>()
-                            );
-                            continue;
-                        }
-                    }
-                },
-            );
-
-            if received_event {
-                self.timing.record_event();
+            match self.wake().await {
+                Wake::Tick => return Some(self.timing.on_tick()),
+                Wake::Value => return Some(self.timing.on_value()),
+                Wake::Lagged => continue,
+                Wake::Closed => return None,
             }
-
-            return Some(self.timing.should_fire(received_event));
         }
+    }
+
+    /// Waits for whichever comes first, the interval or the next value, and
+    /// stores the value if that is what arrived.
+    async fn wake(&mut self) -> Wake {
+        tokio::select!(
+            _ = self.timing.tick() => Wake::Tick,
+            res = check_value(&mut self.val_rx) => match res {
+                Ok(val) => {
+                    self.current_val = Some(val);
+                    Wake::Value
+                }
+                Err(RecvError::Closed) => {
+                    log::debug!(
+                        "Attached actor of type {} closed - exiting throttle",
+                        std::any::type_name::<T>()
+                    );
+                    Wake::Closed
+                }
+                Err(RecvError::Lagged(nr)) => {
+                    log::debug!(
+                        "Throttle of type {} lagged {nr} messages",
+                        std::any::type_name::<T>()
+                    );
+                    Wake::Lagged
+                }
+            },
+        )
     }
 
     /// Parses the stored value into the callback's argument type, or `None` when
@@ -259,7 +284,8 @@ where
 
         let mut state = ThrottleState::new(frequency, val_rx, current_val);
 
-        // Always execute the call once in case it was initialized
+        // Send the initial value before the loop. Frequency::OnEvent has no
+        // interval, so a timer tick cannot cover this for every frequency.
         if let Some(val) = state.current::<F>() {
             call(&client, val);
         }

--- a/actify/src/throttle.rs
+++ b/actify/src/throttle.rs
@@ -10,7 +10,8 @@ pub enum Frequency {
     OnEvent,
     /// Fires every interval, regardless of incoming events.
     Interval(Duration),
-    /// Fires for an event only after the interval has passed. Designed for high-throughput types.
+    /// Sends at most once per interval, and only when a new value arrived since
+    /// the last send. Designed for high-throughput types.
     OnEventWhen(Duration),
 }
 
@@ -29,12 +30,8 @@ impl<T: Clone> Throttled<T> for T {
     }
 }
 
-/// Holds the running [`Interval`], and for [`Frequency::OnEventWhen`] whether
-/// an event is waiting for the next tick.
-///
-/// [`Frequency`] is public configuration and stays a plain value. An
-/// [`Interval`] carries a schedule that has to survive across iterations, so
-/// the loop keeps this beside it.
+/// The interval a [`Frequency`] runs on, and for [`Frequency::OnEventWhen`]
+/// whether a value arrived since the last send.
 enum Timing {
     OnEvent,
     Interval(Interval),
@@ -136,44 +133,37 @@ impl<T: Clone> ThrottleState<T> {
         }
     }
 
-    /// Returns `Some(true)` to send the current value, `Some(false)` to skip
-    /// this iteration, and `None` once the sender is gone and the loop exits.
-    async fn next(&mut self) -> Option<bool> {
+    /// Waits until there is a value to send, and returns it. Returns `None`
+    /// once every sender is gone, which ends the throttle.
+    async fn next<F>(&mut self) -> Option<F>
+    where
+        T: Throttled<F>,
+    {
         loop {
-            match self.wake().await {
-                Wake::Tick => return Some(self.timing.on_tick()),
-                Wake::Value => return Some(self.timing.on_value()),
-                Wake::Lagged => continue,
+            let ready = match self.wake().await {
+                Wake::Tick => self.timing.on_tick(),
+                Wake::Value => self.timing.on_value(),
+                Wake::Lagged => false,
                 Wake::Closed => return None,
+            };
+
+            if !ready {
+                continue;
+            }
+
+            // An interval keeps ticking before the first value arrives, and
+            // there is nothing to send until it does.
+            if let Some(value) = self.current::<F>() {
+                return Some(value);
             }
         }
     }
 
-    /// Waits for whichever comes first, the interval or the next value, and
-    /// stores the value if that is what arrived.
+    /// Waits for whichever comes first, the interval or the next value.
     async fn wake(&mut self) -> Wake {
         tokio::select!(
             _ = self.timing.tick() => Wake::Tick,
-            res = check_value(&mut self.val_rx) => match res {
-                Ok(val) => {
-                    self.current_val = Some(val);
-                    Wake::Value
-                }
-                Err(RecvError::Closed) => {
-                    log::debug!(
-                        "Attached actor of type {} closed - exiting throttle",
-                        std::any::type_name::<T>()
-                    );
-                    Wake::Closed
-                }
-                Err(RecvError::Lagged(nr)) => {
-                    log::debug!(
-                        "Throttle of type {} lagged {nr} messages",
-                        std::any::type_name::<T>()
-                    );
-                    Wake::Lagged
-                }
-            },
+            received = recv_value(&mut self.val_rx) => store(&mut self.current_val, received),
         )
     }
 
@@ -187,13 +177,37 @@ impl<T: Clone> ThrottleState<T> {
     }
 }
 
-async fn check_value<T: Clone>(
-    val_rx: &mut Option<broadcast::Receiver<T>>,
-) -> Result<T, RecvError> {
+/// Waits for the next broadcast value, or forever when the throttle has no
+/// receiver, as [`Throttle::spawn_interval`] does.
+async fn recv_value<T: Clone>(val_rx: &mut Option<broadcast::Receiver<T>>) -> Result<T, RecvError> {
     if let Some(rx) = val_rx {
         rx.recv().await
     } else {
         std::future::pending::<Result<T, RecvError>>().await
+    }
+}
+
+/// Records a received value, or reports why none arrived.
+fn store<T>(current: &mut Option<T>, received: Result<T, RecvError>) -> Wake {
+    match received {
+        Ok(value) => {
+            *current = Some(value);
+            Wake::Value
+        }
+        Err(RecvError::Closed) => {
+            log::debug!(
+                "Attached actor of type {} closed - exiting throttle",
+                std::any::type_name::<T>()
+            );
+            Wake::Closed
+        }
+        Err(RecvError::Lagged(nr)) => {
+            log::debug!(
+                "Throttle of type {} lagged {nr} messages",
+                std::any::type_name::<T>()
+            );
+            Wake::Lagged
+        }
     }
 }
 
@@ -286,17 +300,12 @@ where
 
         // Send the initial value before the loop. Frequency::OnEvent has no
         // interval, so a timer tick cannot cover this for every frequency.
-        if let Some(val) = state.current::<F>() {
-            call(&client, val);
+        if let Some(value) = state.current::<F>() {
+            call(&client, value);
         }
 
-        while let Some(should_fire) = state.next().await {
-            if !should_fire {
-                continue;
-            }
-            if let Some(val) = state.current::<F>() {
-                call(&client, val);
-            }
+        while let Some(value) = state.next::<F>().await {
+            call(&client, value);
         }
     }
 }
@@ -306,8 +315,17 @@ mod tests {
     use crate::Handle;
 
     use super::*;
+    use std::future::Future;
     use std::sync::{Arc, Mutex};
-    use tokio::time::{Duration, Instant, sleep};
+    use tokio::time::{Duration, Instant, sleep, timeout};
+
+    const PERIOD: Duration = Duration::from_millis(100);
+
+    /// Whether the future is still waiting after several periods. The clock is
+    /// paused in these tests, so the wait costs no real time.
+    async fn still_waiting<T>(future: impl Future<Output = T>) -> bool {
+        timeout(PERIOD * 10, future).await.is_err()
+    }
 
     /// Driving `ThrottleState` directly reaches the receiver outcomes that a
     /// spawned throttle hides: a closed sender and a lagging one.
@@ -315,57 +333,63 @@ mod tests {
         use super::*;
 
         #[tokio::test(start_paused = true)]
-        async fn test_on_event_fires_on_message() {
+        async fn test_on_event_sends_the_value_immediately() {
             let (tx, rx) = broadcast::channel(8);
             let mut state = ThrottleState::<i32>::new(Frequency::OnEvent, Some(rx), None);
 
             tx.send(42).unwrap();
-            assert_eq!(state.next().await, Some(true));
-            assert_eq!(state.current::<i32>(), Some(42));
+            let start = Instant::now();
+
+            assert_eq!(state.next::<i32>().await, Some(42));
+            assert_eq!(start.elapsed(), Duration::ZERO);
         }
 
         #[tokio::test(start_paused = true)]
-        async fn test_interval_fires_without_events() {
+        async fn test_interval_repeats_the_value_without_events() {
             let (_tx, rx) = broadcast::channel::<i32>(8);
-            let mut state = ThrottleState::new(
-                Frequency::Interval(Duration::from_millis(100)),
-                Some(rx),
-                Some(1),
-            );
+            let mut state = ThrottleState::new(Frequency::Interval(PERIOD), Some(rx), Some(1));
 
-            assert_eq!(state.next().await, Some(true));
-            assert_eq!(state.next().await, Some(true));
+            assert_eq!(state.next::<i32>().await, Some(1));
+            assert_eq!(state.next::<i32>().await, Some(1));
         }
 
-        /// Under Interval the event itself does not fire the callback, but the
-        /// value it carried is what the next tick sends.
+        /// The ticks still happen, but there is nothing to send until a value
+        /// arrives, so nothing reaches the callback.
         #[tokio::test(start_paused = true)]
-        async fn test_interval_stores_event_without_firing() {
+        async fn test_interval_sends_nothing_before_the_first_value() {
+            let (_tx, rx) = broadcast::channel::<i32>(8);
+            let mut state = ThrottleState::new(Frequency::Interval(PERIOD), Some(rx), None);
+
+            assert!(still_waiting(state.next::<i32>()).await);
+        }
+
+        /// An event does not send under Interval. The value it carried waits
+        /// for the next tick, one full period away.
+        #[tokio::test(start_paused = true)]
+        async fn test_interval_holds_an_event_until_the_tick() {
             let (tx, rx) = broadcast::channel(8);
-            let mut state = ThrottleState::new(
-                Frequency::Interval(Duration::from_millis(100)),
-                Some(rx),
-                Some(1),
-            );
+            let mut state = ThrottleState::new(Frequency::Interval(PERIOD), Some(rx), None);
 
             tx.send(42).unwrap();
-            assert_eq!(state.next().await, Some(false));
-            assert_eq!(state.current::<i32>(), Some(42));
+            let start = Instant::now();
+
+            assert_eq!(state.next::<i32>().await, Some(42));
+            assert_eq!(start.elapsed(), PERIOD);
         }
 
         #[tokio::test(start_paused = true)]
-        async fn test_on_event_when_fires_after_the_interval() {
+        async fn test_on_event_when_sends_on_the_tick_after_an_event() {
             let (tx, rx) = broadcast::channel(8);
-            let mut state = ThrottleState::new(
-                Frequency::OnEventWhen(Duration::from_millis(100)),
-                Some(rx),
-                None,
-            );
+            let mut state = ThrottleState::new(Frequency::OnEventWhen(PERIOD), Some(rx), None);
 
             tx.send(42).unwrap();
-            assert_eq!(state.next().await, Some(false)); // event stored, interval not elapsed
-            assert_eq!(state.next().await, Some(true)); // interval elapsed
-            assert_eq!(state.next().await, Some(false)); // no new event since firing
+            let start = Instant::now();
+
+            assert_eq!(state.next::<i32>().await, Some(42));
+            assert_eq!(start.elapsed(), PERIOD);
+
+            // Nothing new arrived, so the following ticks send nothing.
+            assert!(still_waiting(state.next::<i32>()).await);
         }
 
         #[tokio::test(start_paused = true)]
@@ -374,22 +398,30 @@ mod tests {
             let mut state = ThrottleState::new(Frequency::OnEvent, Some(rx), None);
 
             drop(tx);
-            assert_eq!(state.next().await, None);
+            assert_eq!(state.next::<i32>().await, None);
         }
 
-        /// Overflowing the channel makes the receiver report Lagged. The state
-        /// swallows it and delivers the next value rather than exiting.
+        /// A broadcast channel keeps only its last `capacity` values. Sending
+        /// more than that without receiving drops the rest and the next receive
+        /// reports [`RecvError::Lagged`] instead of a value.
+        ///
+        /// The state swallows that and receives again, which yields the oldest
+        /// value the channel still holds. Here 10 values are sent into a
+        /// channel holding 2, so 8 and 9 survive and 8 comes out first.
         #[tokio::test(start_paused = true)]
         async fn test_continues_after_lagging() {
-            let (tx, rx) = broadcast::channel(2);
+            const CAPACITY: usize = 2;
+            const SENT: i32 = 10;
+
+            let (tx, rx) = broadcast::channel(CAPACITY);
             let mut state = ThrottleState::<i32>::new(Frequency::OnEvent, Some(rx), None);
 
-            for i in 0..10 {
-                tx.send(i).unwrap();
+            for value in 0..SENT {
+                tx.send(value).unwrap();
             }
 
-            assert_eq!(state.next().await, Some(true));
-            assert_eq!(state.current::<i32>(), Some(8));
+            let oldest_kept = SENT - CAPACITY as i32;
+            assert_eq!(state.next::<i32>().await, Some(oldest_kept));
         }
 
         #[tokio::test(start_paused = true)]
@@ -406,6 +438,54 @@ mod tests {
             let state = ThrottleState::<i32>::new(Frequency::OnEvent, Some(rx), None);
 
             assert_eq!(state.current::<i32>(), None);
+        }
+    }
+
+    /// The startup send and the interval's first tick both want to happen at
+    /// t=0. A refactor that drops the reset in `interval_after` sends the
+    /// initial value twice, which these pin down per frequency.
+    mod initial_value {
+        use super::*;
+
+        #[tokio::test(start_paused = true)]
+        async fn test_interval_sends_it_once_then_resumes_on_the_period() {
+            let counter = CounterClient::new();
+            Throttle::spawn_interval(counter.clone(), CounterClient::call, PERIOD, 1);
+
+            sleep(PERIOD / 2).await;
+            assert_eq!(*counter.count.lock().unwrap(), 1, "startup send duplicated");
+
+            sleep(PERIOD).await;
+            assert_eq!(*counter.count.lock().unwrap(), 2, "first tick missing");
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn test_on_event_when_sends_it_once_and_stays_quiet() {
+            let handle = Handle::new(1);
+            let counter = CounterClient::new();
+            handle
+                .spawn_throttle(
+                    counter.clone(),
+                    CounterClient::call,
+                    Frequency::OnEventWhen(PERIOD),
+                )
+                .await;
+
+            // Several ticks pass with no value arriving after the startup send.
+            sleep(PERIOD * 3).await;
+            assert_eq!(*counter.count.lock().unwrap(), 1);
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn test_on_event_sends_it_once_and_stays_quiet() {
+            let handle = Handle::new(1);
+            let counter = CounterClient::new();
+            handle
+                .spawn_throttle(counter.clone(), CounterClient::call, Frequency::OnEvent)
+                .await;
+
+            sleep(PERIOD * 3).await;
+            assert_eq!(*counter.count.lock().unwrap(), 1);
         }
     }
 

--- a/actify/src/throttle.rs
+++ b/actify/src/throttle.rs
@@ -327,8 +327,6 @@ mod tests {
         timeout(PERIOD * 10, future).await.is_err()
     }
 
-    /// Driving `ThrottleState` directly reaches the receiver outcomes that a
-    /// spawned throttle hides: a closed sender and a lagging one.
     mod state {
         use super::*;
 
@@ -353,8 +351,6 @@ mod tests {
             assert_eq!(state.next::<i32>().await, Some(1));
         }
 
-        /// The ticks still happen, but there is nothing to send until a value
-        /// arrives, so nothing reaches the callback.
         #[tokio::test(start_paused = true)]
         async fn test_interval_sends_nothing_before_the_first_value() {
             let (_tx, rx) = broadcast::channel::<i32>(8);
@@ -363,8 +359,6 @@ mod tests {
             assert!(still_waiting(state.next::<i32>()).await);
         }
 
-        /// An event does not send under Interval. The value it carried waits
-        /// for the next tick, one full period away.
         #[tokio::test(start_paused = true)]
         async fn test_interval_holds_an_event_until_the_tick() {
             let (tx, rx) = broadcast::channel(8);
@@ -441,9 +435,6 @@ mod tests {
         }
     }
 
-    /// The startup send and the interval's first tick both want to happen at
-    /// t=0. A refactor that drops the reset in `interval_after` sends the
-    /// initial value twice, which these pin down per frequency.
     mod initial_value {
         use super::*;
 


### PR DESCRIPTION
Item 3 of the 0.9.0 train. Internal only, no public API change. Groundwork for items 4 to 6, which reuse this loop.

## Purpose

Two concrete things, not elegance for its own sake:

1. **Items 4 to 6 need this loop twice.** Item 6 adds an async throttle running the same timer/receiver/dedup logic with an async callback. Both existing branches that attempted it got the loop wrong. Sharing one `ThrottleState` means fixing it once.
2. **Two receiver outcomes were untestable.** `Lagged` and `Closed` only happen inside a spawned task, so no test had ever executed either arm.

## The shape

`Timing` is the runtime half of a `Frequency`. It holds the `Interval` where the frequency has one, and the pending-event flag where it needs one:

```rust
enum Timing {
    OnEvent,
    Interval(Interval),
    OnEventWhen { interval: Interval, event_pending: bool },
}
```

This replaces a `Frequency` plus a separate `Option<Interval>` plus an `event_processed: bool`, which carried two unchecked invariants: the option is `Some` exactly when the frequency is not `OnEvent`, and the flag is meaningful only for `OnEventWhen`. Both are now unrepresentable rather than merely maintained.

It also deletes a guard whose only purpose was to keep the flag mutation matching the old code's shape. The flag now lives in the one variant that reads it, so there is nothing to guard.

`ThrottleState` holds the timing, the receiver and the current value. `Throttle::run` is a call to `next` and a callback.

## `first_tick` is gone

`tokio::time::interval` fires its first tick immediately, and `run` already fires once on startup, so without intervention `Frequency::Interval` produces two calls at t=0. That was handled by a separate `first_tick().await` the caller had to remember, which is exactly the kind of two-step protocol worth deleting.

`Interval::reset()` moves the first tick a full period out, synchronously, at construction. So the interval is correct the moment it exists and there is no second step. `test_interval`, which asserts 6 calls across 5 periods, passes unchanged, confirming the timing is identical.

## A vacuous test, found and fixed

`test_exit_on_shutdown` passed `init: None`, so the throttle never fired and the test asserted `0 == 0`. Setting an initial value made it fail immediately:

```
assertion `left == right` failed
  left: 5
 right: 6
```

That is real behaviour, not a regression. A due interval tick and a closed receiver can be ready in the same `select!`, which picks randomly, so exactly one further call can land after the actor is gone. The test now asserts the throttle was firing before the drop, then samples twice afterwards and requires the count to be identical across both. It tolerates the one straggler and rejects anything after it. Stable over repeated runs.

Worth noting for later: `biased;` would make shutdown deterministic, but it would also let a steady stream of events starve the interval branch, so it is the wrong trade here.

## Tests

Eight unit tests drive `ThrottleState` directly:

- `test_continues_after_lagging` overflows a capacity-2 channel with 10 sends, then asserts the state swallows `Lagged` and delivers `Some(8)`, the oldest still buffered. Through a `Handle` this needs more than 100 unread updates, since the channel capacity is 100.
- `test_exits_when_sender_is_dropped` covers `Closed`.
- The rest cover the frequency matrix: `OnEvent` fires on a message, `Interval` fires on the timer and stores an event's value without firing, `OnEventWhen` suppresses an early event, fires once the interval elapses, then stays quiet.

The lag test is mutation-verified. Turning the `Lagged` arm into an exit gives `7 passed; 1 failed`, and the failure is that test alone.

All ten pre-existing throttle tests pass untouched.

## Verification

`cargo test --workspace`, `cargo test -p actify`, clippy `-D warnings`, `cargo fmt --check`, and `cargo doc` with default and all features under `RUSTDOCFLAGS="-D warnings"`.

The loop avoids let-chains, which need Rust 1.88 and would break the 1.85 MSRV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
