### PR TITLE
Cover receiver lag in the cache and the throttle

### DIFF
--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -762,12 +762,16 @@ mod tests {
         assert_eq!(cache.recv_newest().await, Err(CacheRecvNewestError::Closed));
     }
 
-    /// Fills the broadcast channel far enough past its capacity of 100 that
-    /// the cache's receiver is guaranteed to have missed updates.
-    async fn overflow(handle: &Handle<i32>) {
-        for i in 1..=150 {
+    /// Fills the broadcast channel past its capacity, so the cache's receiver
+    /// is guaranteed to have missed updates. The channel may round its
+    /// capacity up internally, so twice the configured size is sent.
+    /// Returns the last value sent, which the channel always retains.
+    async fn overflow(handle: &Handle<i32>) -> i32 {
+        let last = (2 * crate::handles::CHANNEL_SIZE) as i32;
+        for i in 1..=last {
             handle.set(i).await;
         }
+        last
     }
 
     /// The FIFO receives report lag as an error, and the error leaves the
@@ -809,9 +813,9 @@ mod tests {
         let mut cache = handle.create_cache().await;
         cache.try_recv_newest().unwrap(); // Consume first request
 
-        overflow(&handle).await;
+        let last = overflow(&handle).await;
 
-        assert_eq!(cache.try_recv_newest().unwrap(), Some(&150));
+        assert_eq!(cache.try_recv_newest().unwrap(), Some(&last));
     }
 
     #[tokio::test(start_paused = true)]
@@ -820,9 +824,9 @@ mod tests {
         let mut cache = handle.create_cache().await;
         cache.recv_newest().await.unwrap(); // Consume first request
 
-        overflow(&handle).await;
+        let last = overflow(&handle).await;
 
-        assert_eq!(cache.recv_newest().await.unwrap(), &150);
+        assert_eq!(cache.recv_newest().await.unwrap(), &last);
     }
 
     #[tokio::test(start_paused = true)]

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -762,6 +762,69 @@ mod tests {
         assert_eq!(cache.recv_newest().await, Err(CacheRecvNewestError::Closed));
     }
 
+    /// Fills the broadcast channel far enough past its capacity of 100 that
+    /// the cache's receiver is guaranteed to have missed updates.
+    async fn overflow(handle: &Handle<i32>) {
+        for i in 1..=150 {
+            handle.set(i).await;
+        }
+    }
+
+    /// The FIFO receives report lag as an error, and the error leaves the
+    /// cached value untouched, as the [`CacheRecvError::Lagged`] docs state.
+    #[tokio::test(start_paused = true)]
+    async fn test_try_recv_reports_lag_and_keeps_the_value() {
+        let handle = Handle::new(0);
+        let mut cache = handle.create_cache().await;
+        cache.try_recv().unwrap(); // Consume first request
+
+        overflow(&handle).await;
+
+        let err = cache.try_recv().unwrap_err();
+        assert!(matches!(err, CacheRecvError::Lagged(n) if n > 0));
+        assert_eq!(cache.get_current(), &0);
+
+        // Reporting the lag repositions the receiver, so the cache keeps working
+        assert!(matches!(cache.try_recv(), Ok(Some(_))));
+    }
+
+    /// The awaiting FIFO variant reports the same error.
+    #[tokio::test(start_paused = true)]
+    async fn test_recv_reports_lag() {
+        let handle = Handle::new(0);
+        let mut cache = handle.create_cache().await;
+        cache.recv().await.unwrap(); // Consume first request
+
+        overflow(&handle).await;
+
+        let err = cache.recv().await.unwrap_err();
+        assert!(matches!(err, CacheRecvError::Lagged(n) if n > 0));
+    }
+
+    /// The newest variants exist for consumers too slow to keep up, so lag is
+    /// not an error there: they skip what was dropped and deliver the newest.
+    #[tokio::test(start_paused = true)]
+    async fn test_try_recv_newest_recovers_from_lag() {
+        let handle = Handle::new(0);
+        let mut cache = handle.create_cache().await;
+        cache.try_recv_newest().unwrap(); // Consume first request
+
+        overflow(&handle).await;
+
+        assert_eq!(cache.try_recv_newest().unwrap(), Some(&150));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_recv_newest_recovers_from_lag() {
+        let handle = Handle::new(0);
+        let mut cache = handle.create_cache().await;
+        cache.recv_newest().await.unwrap(); // Consume first request
+
+        overflow(&handle).await;
+
+        assert_eq!(cache.recv_newest().await.unwrap(), &150);
+    }
+
     #[tokio::test(start_paused = true)]
     async fn test_blocking_recv() {
         let handle = Handle::new(1);

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -8,7 +8,7 @@ use crate::actor::{Actor, ActorExit, ActorMethod, BroadcastFn, ExitState, Job, s
 use crate::throttle::Throttle;
 use crate::{Cache, Frequency, Throttled};
 
-const CHANNEL_SIZE: usize = 100;
+pub(crate) const CHANNEL_SIZE: usize = 100;
 const DOWNCAST_FAIL: &str =
     "Actify Macro error: failed to downcast arguments to their concrete type";
 

--- a/actify/src/handles/mod.rs
+++ b/actify/src/handles/mod.rs
@@ -1,5 +1,7 @@
 mod handle;
 mod read_handle;
 
+#[cfg(test)]
+pub(crate) use handle::CHANNEL_SIZE;
 pub use handle::{BroadcastAs, Handle};
 pub use read_handle::ReadHandle;

--- a/actify/src/throttle.rs
+++ b/actify/src/throttle.rs
@@ -439,6 +439,44 @@ mod tests {
         assert_eq!(time, 0);
     }
 
+    /// A lagging receiver reports the dropped messages once and then serves
+    /// the retained ones, so the throttle must treat lag as a hiccup rather
+    /// than a reason to stop.
+    #[tokio::test(start_paused = true)]
+    async fn test_throttle_survives_lag() {
+        let (tx, rx) = broadcast::channel(1);
+        let counter = CounterClient::new();
+
+        Throttle::spawn_from_receiver(
+            counter.clone(),
+            CounterClient::call,
+            Frequency::OnEvent,
+            rx,
+            None,
+        );
+
+        // The sends are synchronous, so the receiver holds only the newest
+        // message and reports the rest as lag
+        for i in 1..=5 {
+            tx.send(i).unwrap();
+        }
+        sleep(Duration::from_millis(10)).await;
+
+        let after_flood = *counter.count.lock().unwrap();
+        assert!(after_flood >= 1, "the retained message was not delivered");
+
+        // The throttle is still running and picks up the next event
+        tx.send(6).unwrap();
+        sleep(Duration::from_millis(10)).await;
+
+        let after_next = *counter.count.lock().unwrap();
+        assert_eq!(
+            after_next,
+            after_flood + 1,
+            "the throttle stopped after lagging"
+        );
+    }
+
     #[tokio::test(start_paused = true)]
     async fn test_throttle_parsing() {
         // Parsing to self should succeed


### PR DESCRIPTION
Gap 1 from the coverage analysis: no test anywhere lagged a broadcast receiver. A `panic!` planted in the cache's lag path (`log_lag`) left the entire workspace suite green, so every lag arm in `Cache` and `Throttle` was unverified. Lag is the exact scenario the `*_newest` methods exist for.

## What this covers

- `try_recv` and `recv` report `CacheRecvError::Lagged(n)`, and the error leaves the cached value untouched, as the error's docs promise.
- `try_recv_newest` and `recv_newest` treat lag as expected operation: they skip what was dropped and deliver the newest retained value.
- A lagged `try_recv` repositions the receiver, so the cache keeps working after reporting the error.
- The throttle logs a lagged receiver and keeps running, instead of exiting.

## Red verification

Each test was verified to fail against a targeted mutation of its arm before committing green:

- `drain_to_newest`, `recv_newest`: `Lagged` mapped to `Err(Closed)` fails both recovery tests.
- `try_recv` and the `From<RecvError>` impl: `Lagged` mapped to `Closed` fails both error tests.
- Throttle: `continue` replaced with `break` on `Lagged` fails `test_throttle_survives_lag`.

All five mutations together fail exactly the five new tests and nothing else.

The lag assertions use `matches!(.., Lagged(n) if n > 0)` rather than an exact count, since the dropped-message count depends on tokio's channel capacity rounding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)