### PR TITLE
Cover the throttle attached by new_throttled

### DIFF
--- a/actify/src/throttle.rs
+++ b/actify/src/throttle.rs
@@ -207,6 +207,23 @@ mod tests {
         assert_eq!(count, 1)
     }
 
+    /// The throttle attached by new_throttled fires once with the initial
+    /// value before any broadcast, and then again for each update.
+    #[tokio::test(start_paused = true)]
+    async fn test_new_throttled_fires_init_and_updates() {
+        let counter = CounterClient::new();
+        let handle: Handle<i32> =
+            Handle::new_throttled(1, counter.clone(), CounterClient::call, Frequency::OnEvent);
+        sleep(Duration::from_millis(10)).await;
+
+        assert_eq!(*counter.count.lock().unwrap(), 1);
+
+        handle.set(2).await;
+        sleep(Duration::from_millis(10)).await;
+
+        assert_eq!(*counter.count.lock().unwrap(), 2);
+    }
+
     #[tokio::test(start_paused = true)]
     async fn test_throttle_from_cache() {
         let handle = Handle::new(1);


### PR DESCRIPTION
Gap 3 from the coverage analysis: `Handle::new_throttled` had no test and no doc example. A mutation replacing its `Some(init)` with `None`, which silently changes when the callback first fires, passed the entire workspace suite.

## The test

`test_new_throttled_fires_init_and_updates`: the throttle fires once with the initial value before any broadcast arrives, and once more after `set`. Runs on a paused clock.

## Red verification

Against the `Some(init)` to `None` mutation the test fails with count 0 where 1 is expected. On unmutated code it passes, and the full local gate (tests, clippy, fmt, doc builds) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)