### PR TITLE
A ReadHandle keeps its actor alive

### DIFF
--- a/actify-test/src/main.rs
+++ b/actify-test/src/main.rs
@@ -951,6 +951,40 @@ mod tests {
         assert_eq!(await_alive_tasks(baseline).await, baseline);
     }
 
+    /// A ReadHandle holds a full handle internally, so it keeps the actor
+    /// alive after the last Handle is dropped. The crate docs state this;
+    /// the test keeps that statement true.
+    #[tokio::test]
+    async fn test_read_handle_keeps_actor_alive() {
+        let baseline = alive_tasks();
+
+        let handle = Handle::new(1);
+        let read_handle = handle.get_read_handle();
+
+        let with_handle = await_alive_tasks(baseline + 1).await;
+        assert_eq!(with_handle, baseline + 1, "Expected one task for Handle");
+
+        drop(handle);
+
+        let after_handle_drop = settled_alive_tasks().await;
+        assert_eq!(
+            after_handle_drop,
+            baseline + 1,
+            "The actor should stay alive while a ReadHandle exists"
+        );
+
+        // The actor still serves reads through the remaining ReadHandle
+        assert_eq!(read_handle.get().await, 1);
+
+        drop(read_handle);
+
+        let after_read_drop = await_alive_tasks(baseline).await;
+        assert_eq!(
+            after_read_drop, baseline,
+            "The actor should stop once the last ReadHandle is dropped"
+        );
+    }
+
     #[tokio::test]
     async fn test_cache_does_not_spawn_tasks() {
         let baseline = alive_tasks();


### PR DESCRIPTION
Gap 5 from the coverage analysis: the crate docs promise that a `ReadHandle` holds a full handle internally and keeps the actor alive, in contrast to a `Cache` which does not. The Cache half of that contrast has a task-count test (`test_handle_out_of_scope`); the ReadHandle half had none.

## The test

`test_read_handle_keeps_actor_alive`, following the existing task-count pattern in actify-test: drop the last `Handle` while a `ReadHandle` exists, assert the actor task stays alive and still serves `get()`, then drop the `ReadHandle` and assert the task exits.

## Red verification

Today the invariant is structural (`ReadHandle` wraps a `Handle` by construction), so the red state needs a wiring bug rather than a one-token change: mutating `get_read_handle` to hand out a handle whose job-channel sender points at a fresh dummy channel makes the test fail with "The actor should stay alive while a ReadHandle exists". That is the class of regression this test guards against, e.g. a future refactor that slims `ReadHandle` down to the broadcast side only.

On unmutated code the full local gate (tests, clippy, fmt, doc builds) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)