### PR TITLE
Callers wait when the job channel is full

### DIFF
--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -747,6 +747,38 @@ mod tests {
         }
     }
 
+    /// Callers past the channel capacity wait for a slot instead of failing,
+    /// so every job is served. The sleep in each job holds the actor long
+    /// enough for all callers to pile up on the bounded channel.
+    #[tokio::test(start_paused = true)]
+    async fn test_callers_wait_when_the_job_channel_is_full() {
+        let handle = Handle::new(Ledger { seen: Vec::new() });
+
+        let mut calls = tokio::task::JoinSet::new();
+        for i in 0..2 * CHANNEL_SIZE {
+            let handle = handle.clone();
+            calls.spawn(async move { handle.record(i).await });
+        }
+        while calls.join_next().await.is_some() {}
+
+        let mut seen = handle.with(|ledger| ledger.seen.clone()).await;
+        seen.sort();
+        assert_eq!(seen, (0..2 * CHANNEL_SIZE).collect::<Vec<_>>());
+    }
+
+    #[derive(Debug, Clone)]
+    struct Ledger {
+        seen: Vec<usize>,
+    }
+
+    #[actify_macros::actify]
+    impl Ledger {
+        async fn record(&mut self, i: usize) {
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            self.seen.push(i);
+        }
+    }
+
     /// Payloads distinctive enough that a test can tell whose panic it caught:
     /// the actor's own, or the one the handle raises on the caller's behalf.
     const SYNC_PANIC_PAYLOAD: &str = "sync actor method blew up";


### PR DESCRIPTION
Gap 6 from the coverage analysis: the execution model docs promise that jobs queue in a bounded channel and callers wait when it is full. No test ever pushed the channel past its capacity, so a regression to lossy or failing behavior under load would go unnoticed.

## The test

`test_callers_wait_when_the_job_channel_is_full`: 200 concurrent callers (twice `CHANNEL_SIZE`) on an actor whose method sleeps, so all callers pile up while the actor works. Every job must be served exactly once. Runs on a paused clock, so the 200 sleeps cost no wall time.

## Red verification

Against a mutation replacing the awaited `tx.send` with a lossy `try_send`, the test fails with exactly the first 100 jobs served and jobs 100..199 silently dropped, which is precisely the failure mode the bounded-channel contract rules out. On unmutated code the full local gate (tests, clippy, fmt, doc builds) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)