### PR TITLE
Synchronize the cache before spawning its throttle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 
 ### Changed
 
+- **Breaking:** `Cache::spawn_throttle` takes `&mut self` and first
+  synchronizes the cache to the newest broadcast value, which becomes the
+  throttle's initial fire. Previously the throttle got a fresh subscription
+  starting at the channel tail and fired with the stale snapshot, so updates
+  already queued in the cache never reached it. The synchronization counts as
+  receiving those updates: a later receive on the cache returns only updates
+  broadcast after this call.
+
 - **Breaking:** methods taking `&self` no longer broadcast. Broadcasting follows
   the receiver: `&mut self` broadcasts, `&self` does not. Previously every
   method broadcast regardless of receiver, so read-only calls woke every

--- a/actify-test/src/main.rs
+++ b/actify-test/src/main.rs
@@ -1026,7 +1026,7 @@ mod tests {
         let baseline = alive_tasks();
 
         let handle = Handle::new(42);
-        let cache = handle.create_cache().await;
+        let mut cache = handle.create_cache().await;
 
         let with_handle = await_alive_tasks(baseline + 1).await;
         assert_eq!(with_handle, baseline + 1, "Expected one task for Handle");

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -487,18 +487,29 @@ where
     }
 
     /// Spawns a [`Throttle`] that fires given a specified [`Frequency`], given any broadcasted updates by the actor.
-    /// Does not first update the cache to the newest value, since then the user of the cache might miss the update.
+    ///
+    /// First synchronizes the cache to the newest broadcast value, which
+    /// becomes the throttle's initial fire. Updates already queued in the
+    /// cache would otherwise never reach the throttle: its new subscription
+    /// starts at the channel tail. They are folded into that initial value
+    /// rather than delivered one by one, and they count as received by the
+    /// cache, so a later receive returns only updates broadcast after this
+    /// call.
+    ///
     /// See [`Handle::spawn_throttle`](crate::Handle::spawn_throttle) for an example.
-    pub fn spawn_throttle<C, F, Fun>(&self, client: C, call: Fun, freq: Frequency) -> Throttle
+    pub fn spawn_throttle<C, F, Fun>(&mut self, client: C, call: Fun, freq: Frequency) -> Throttle
     where
         C: Send + Sync + 'static,
         T: Throttled<F>,
         F: Send + Sync + 'static,
         Fun: Fn(&C, F) + Send + 'static,
     {
-        let current = self.inner.clone();
+        // Subscribe before draining, so an update arriving in between reaches
+        // the throttle instead of being lost. It may then be part of the
+        // initial value and still be delivered, which a throttle absorbs.
         let receiver = self.rx.resubscribe();
-        Throttle::spawn_from_receiver(client, call, freq, receiver, Some(current))
+        _ = self.drain_to_newest();
+        Throttle::spawn_from_receiver(client, call, freq, receiver, Some(self.inner.clone()))
     }
 }
 

--- a/actify/src/throttle.rs
+++ b/actify/src/throttle.rs
@@ -622,6 +622,29 @@ mod tests {
         assert_eq!(*counter.count.lock().unwrap(), 2);
     }
 
+    /// An update already queued in the cache's receiver but not yet consumed
+    /// must reach a throttle spawned from that cache. The cache first
+    /// synchronizes to the newest broadcast value, which becomes the
+    /// throttle's initial fire.
+    #[tokio::test(start_paused = true)]
+    async fn test_pending_update_reaches_cache_throttle() {
+        let handle = Handle::new(1);
+        let mut cache = handle.create_cache().await;
+
+        handle.set(2).await; // Queued in the cache's receiver, not yet consumed
+
+        let counter = CounterClient::new();
+        cache.spawn_throttle(counter.clone(), CounterClient::call, Frequency::OnEvent);
+        sleep(Duration::from_millis(10)).await;
+
+        // The initial fire carries the queued update, not the stale snapshot
+        assert_eq!(*counter.last.lock().unwrap(), Some(2));
+        assert_eq!(*counter.count.lock().unwrap(), 1);
+
+        // Synchronizing counts as receiving: the cache holds the value too
+        assert_eq!(cache.get_current(), &2);
+    }
+
     #[tokio::test(start_paused = true)]
     async fn test_throttle_from_cache() {
         let handle = Handle::new(1);
@@ -977,6 +1000,7 @@ mod tests {
         start: Instant,
         elapsed: Arc<Mutex<u128>>,
         count: Arc<Mutex<i32>>,
+        last: Arc<Mutex<Option<i32>>>,
     }
 
     impl CounterClient {
@@ -985,15 +1009,19 @@ mod tests {
                 start: Instant::now(),
                 elapsed: Arc::new(Mutex::new(0)),
                 count: Arc::new(Mutex::new(0)),
+                last: Arc::new(Mutex::new(None)),
             }
         }
 
-        fn call(&self, _event: i32) {
+        fn call(&self, event: i32) {
             let mut time = self.elapsed.lock().unwrap();
             *time = self.start.elapsed().as_millis();
 
             let mut count = self.count.lock().unwrap();
             *count += 1;
+
+            let mut last = self.last.lock().unwrap();
+            *last = Some(event);
         }
     }
 }

--- a/actify/src/throttle.rs
+++ b/actify/src/throttle.rs
@@ -649,7 +649,7 @@ mod tests {
     async fn test_throttle_from_cache() {
         let handle = Handle::new(1);
         let counter = CounterClient::new();
-        let cache = handle.create_cache().await;
+        let mut cache = handle.create_cache().await;
 
         // Spawn throttle that should only activate once on creation
         cache.spawn_throttle(counter.clone(), CounterClient::call, Frequency::OnEvent);


### PR DESCRIPTION
Second live instance of the update-loss class fixed in 0.8.2, found by auditing every snapshot+subscribe site. There the fix was subscribing before reading; here the queued updates exist only in the cache's own receiver, so the cache synchronizes before handing over a snapshot.

## The bug

`Cache::spawn_throttle` snapshotted the cached value and called `resubscribe()`. A new subscription starts at the channel tail, so an update already queued in the cache's receiver but not yet consumed appears in neither the snapshot nor the new subscription: the throttle fires with the stale value and never sees the update. `Frequency::OnEvent` is documented for infrequent but important events, which is exactly where a silently lost event hurts most.

## The fix

**Breaking:** `spawn_throttle` takes `&mut self` and first drains the cache to the newest broadcast value, which becomes the throttle's initial fire. Queued updates are folded into that value rather than delivered one by one, and the drain counts as receiving them: a later receive on the cache returns only updates broadcast after this call. Both effects are documented on the method, and the changelog entry is included.

The subscription is taken before draining, mirroring the ordering from the 0.8.2 fix: an update racing with the call reaches the throttle instead of being lost, at worst delivered twice, which a throttle absorbs.

An earlier version of this PR consumed the cache and handed its receiver to the throttle. That only relocated the loss: keeping the cache meant cloning, and one of the two copies still ended up on a tail subscription missing the queued updates.

## Tests

TDD, two commits. The red commit adds `test_pending_update_reaches_cache_throttle`, which fails on main with the initial fire carrying the stale value (`Some(1)` where `Some(2)` is expected) and the cache left unsynchronized. `CounterClient` gains a `last` field so the test can assert the delivered value, not just the count.

Related: the sibling instance in `Cache::clone` is addressed separately in #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)