### PR TITLE
A cloned cache starts from a snapshot, and clone_newest to sync first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 - `OptionHandle::take` and `OptionHandle::replace`, mirroring
   `std::option::Option::take` and `std::option::Option::replace` in both
   signature and behaviour.
+- `Cache::clone_newest`, which reads the updates queued in a cache before
+  cloning it, so both caches start from the newest broadcast value. A plain
+  clone leaves those updates with the original.
 - `Throttle::abort` and `Throttle::is_finished`. A throttle spawned by
   `Throttle::spawn_interval` has no actor attached, so before this nothing could
   stop it short of shutting down the runtime.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
   receiving those updates: a later receive on the cache returns only updates
   broadcast after this call.
 
+- **Breaking:** cloning a `Cache` now yields a fresh cache: the clone delivers
+  the original's current value on its first read and receives broadcasts made
+  after its creation. Previously a clone copied the original's first-read
+  state, so a clone taken after that read delivered nothing until the next
+  broadcast. Updates already queued in the original's receiver stay with the
+  original in both the old and the new behaviour.
+
 - **Breaking:** methods taking `&self` no longer broadcast. Broadcasting follows
   the receiver: `&mut self` broadcasts, `&self` does not. Previously every
   method broadcast regardless of receiver, so read-only calls woke every

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -13,6 +13,16 @@ use crate::{Frequency, Throttle, Throttled};
 /// current actor value), [`Handle::create_cache_from`](crate::Handle::create_cache_from) (custom
 /// initial value), or [`Handle::create_cache_from_default`](crate::Handle::create_cache_from_default)
 /// (starts from `T::default()`).
+///
+/// # Cloning
+///
+/// A clone is a fresh cache initialized with the original's current value:
+/// its first read delivers that snapshot, and it receives every broadcast
+/// made after its creation. Updates already queued in the original's
+/// receiver but not yet read stay with the original; they exist nowhere the
+/// clone can reach, since a new subscription starts at the channel tail. To
+/// start from the actor's actual current value instead of the original's
+/// last known one, use [`Handle::create_cache`](crate::Handle::create_cache).
 #[derive(Debug)]
 pub struct Cache<T> {
     inner: T,
@@ -25,10 +35,12 @@ where
     T: Clone + Send + Sync + 'static,
 {
     fn clone(&self) -> Self {
+        // The clone cannot inherit the original's queue position, so it gets
+        // the same contract as a fresh cache: snapshot first, updates after.
         Cache {
             inner: self.inner.clone(),
             rx: self.rx.resubscribe(),
-            first_request: self.first_request,
+            first_request: true,
         }
     }
 }

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -16,10 +16,16 @@ use crate::{Frequency, Throttle, Throttled};
 ///
 /// # Cloning
 ///
-/// A clone behaves like a new cache created from the original's last known
-/// value: the first read returns that value, and broadcasts after the clone
-/// are received. Updates queued in the original but not yet read stay with
-/// the original. Use [`clone_newest`](Self::clone_newest) to include them:
+/// A cache reads from its own receiver on the actor's broadcast channel. That
+/// receiver's position in the channel cannot be copied, so `clone` opens a new
+/// subscription, which starts at the most recently broadcast value. Values
+/// broadcast earlier and not yet read by the original sit before that position
+/// and never arrive at the clone.
+///
+/// So a clone holds the value the original read last, returns it on the first
+/// read, and from then on receives what the actor broadcasts after the clone
+/// was made. [`clone_newest`](Self::clone_newest) reads the waiting values
+/// into the cache first, so the clone starts at the newest one:
 ///
 /// ```
 /// # use actify::Handle;
@@ -28,10 +34,10 @@ use crate::{Frequency, Throttle, Throttled};
 /// let handle = Handle::new(1);
 /// let mut cache = handle.create_cache().await;
 ///
-/// handle.set(2).await; // Queued, not yet read by the cache
+/// handle.set(2).await; // Broadcast, not yet read by the cache
 ///
-/// let stale = cache.clone(); // Starts from 1, the update stays behind
-/// let synced = cache.clone_newest(); // Starts from 2
+/// let stale = cache.clone(); // Holds 1: the 2 is behind its subscription
+/// let synced = cache.clone_newest(); // Reads the 2 first, so it holds 2
 ///
 /// assert_eq!(stale.get_current(), &1);
 /// assert_eq!(synced.get_current(), &2);
@@ -49,8 +55,9 @@ where
     T: Clone + Send + Sync + 'static,
 {
     fn clone(&self) -> Self {
-        // The clone cannot inherit the original's queue position, so it gets
-        // the same contract as a fresh cache: snapshot first, updates after.
+        // resubscribe starts after the values this cache has not read yet, so
+        // the clone cannot reach them. first_request is set so its first read
+        // returns the value carried over here, as a new cache does.
         Cache {
             inner: self.inner.clone(),
             rx: self.rx.resubscribe(),
@@ -104,12 +111,17 @@ where
         }
     }
 
-    /// Returns a clone starting from the newest broadcast value.
+    /// Reads every value waiting in this cache, keeps the newest, and returns a
+    /// clone holding it. Both caches then hold that value.
     ///
-    /// Reads the updates queued in this cache first, so both caches start from
-    /// the same value. That read counts as receiving them: a later receive on
-    /// this cache returns only updates broadcast after this call. A plain
-    /// [`clone`](Clone::clone) leaves them with this cache instead.
+    /// Reading takes the waiting values out of this cache's receiver, which is
+    /// what `&mut self` is for. They are delivered by this call and not again:
+    /// the next [`recv`](Self::recv) here returns a value the actor broadcasts
+    /// after it, and the values passed over on the way to the newest are
+    /// dropped, as in [`get_newest`](Self::get_newest).
+    ///
+    /// [`clone`](Clone::clone) cannot read them, since it takes `&self`, and
+    /// the subscription it opens starts after them.
     ///
     /// # Examples
     ///
@@ -124,16 +136,16 @@ where
     /// let mut synced = cache.clone_newest();
     /// assert_eq!(synced.get_current(), &2);
     ///
-    /// // The queued update was read here too, so only later ones remain
+    /// // The 2 was read out of this cache as well, so nothing is left waiting
     /// assert_eq!(cache.get_current(), &2);
     /// assert_eq!(cache.try_recv().unwrap(), Some(&2)); // Its first read
     /// assert_eq!(cache.try_recv().unwrap(), None);
     /// # }
     /// ```
     pub fn clone_newest(&mut self) -> Self {
-        // Subscribe before draining, so an update arriving in between reaches
-        // the clone instead of being lost. It may then be part of the initial
-        // value and still be delivered, which a first read absorbs.
+        // Resubscribe first: a value broadcast between these two lines then
+        // lands both in the new subscription and in the drain, rather than
+        // after the one and before the other, which would drop it.
         let rx = self.rx.resubscribe();
         _ = self.drain_to_newest();
         Cache {

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -19,8 +19,7 @@ use crate::{Frequency, Throttle, Throttled};
 /// A clone behaves like a new cache created from the original's last known
 /// value: the first read returns that value, and broadcasts after the clone
 /// are received. Updates queued in the original but not yet read stay with
-/// the original. To include them in the clone's starting value, read them
-/// first with [`get_newest`](Self::get_newest):
+/// the original. Use [`clone_newest`](Self::clone_newest) to include them:
 ///
 /// ```
 /// # use actify::Handle;
@@ -32,8 +31,7 @@ use crate::{Frequency, Throttle, Throttled};
 /// handle.set(2).await; // Queued, not yet read by the cache
 ///
 /// let stale = cache.clone(); // Starts from 1, the update stays behind
-/// cache.get_newest(); // Reads the queued update first
-/// let synced = cache.clone(); // Starts from 2
+/// let synced = cache.clone_newest(); // Starts from 2
 ///
 /// assert_eq!(stale.get_current(), &1);
 /// assert_eq!(synced.get_current(), &2);
@@ -103,6 +101,45 @@ where
                 Err(TryRecvError::Closed) => return Err(CacheRecvNewestError::Closed),
                 Err(TryRecvError::Lagged(nr)) => log_lag::<T>(nr),
             }
+        }
+    }
+
+    /// Returns a clone starting from the newest broadcast value.
+    ///
+    /// Reads the updates queued in this cache first, so both caches start from
+    /// the same value. That read counts as receiving them: a later receive on
+    /// this cache returns only updates broadcast after this call. A plain
+    /// [`clone`](Clone::clone) leaves them with this cache instead.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::Handle;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(1);
+    /// let mut cache = handle.create_cache().await;
+    /// handle.set(2).await;
+    ///
+    /// let mut synced = cache.clone_newest();
+    /// assert_eq!(synced.get_current(), &2);
+    ///
+    /// // The queued update was read here too, so only later ones remain
+    /// assert_eq!(cache.get_current(), &2);
+    /// assert_eq!(cache.try_recv().unwrap(), Some(&2)); // Its first read
+    /// assert_eq!(cache.try_recv().unwrap(), None);
+    /// # }
+    /// ```
+    pub fn clone_newest(&mut self) -> Self {
+        // Subscribe before draining, so an update arriving in between reaches
+        // the clone instead of being lost. It may then be part of the initial
+        // value and still be delivered, which a first read absorbs.
+        let rx = self.rx.resubscribe();
+        _ = self.drain_to_newest();
+        Cache {
+            inner: self.inner.clone(),
+            rx,
+            first_request: true,
         }
     }
 
@@ -622,6 +659,29 @@ mod tests {
         assert_eq!(clone.try_recv().unwrap(), None);
         handle.set(3).await;
         assert_eq!(clone.try_recv().unwrap(), Some(&3));
+    }
+
+    /// clone_newest reads the queued updates before cloning, so the clone
+    /// starts from them rather than from the value the original last saw.
+    #[tokio::test(start_paused = true)]
+    async fn test_clone_newest_includes_queued_updates() {
+        let handle = Handle::new(1);
+        let mut cache = handle.create_cache().await;
+        assert_eq!(cache.recv().await.unwrap(), &1); // Consume first request
+
+        handle.set(2).await; // Queued in the original's receiver
+        let mut clone = cache.clone_newest();
+
+        assert_eq!(clone.try_recv().unwrap(), Some(&2));
+
+        // Reading counts for the original too, so the update is not served again
+        assert_eq!(cache.get_current(), &2);
+        assert_eq!(cache.try_recv().unwrap(), None);
+
+        // Both caches receive what the actor broadcasts from here on
+        handle.set(3).await;
+        assert_eq!(clone.try_recv().unwrap(), Some(&3));
+        assert_eq!(cache.try_recv().unwrap(), Some(&3));
     }
 
     #[tokio::test(start_paused = true)]

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -16,13 +16,29 @@ use crate::{Frequency, Throttle, Throttled};
 ///
 /// # Cloning
 ///
-/// A clone is a fresh cache initialized with the original's current value:
-/// its first read delivers that snapshot, and it receives every broadcast
-/// made after its creation. Updates already queued in the original's
-/// receiver but not yet read stay with the original; they exist nowhere the
-/// clone can reach, since a new subscription starts at the channel tail. To
-/// start from the actor's actual current value instead of the original's
-/// last known one, use [`Handle::create_cache`](crate::Handle::create_cache).
+/// A clone behaves like a new cache created from the original's last known
+/// value: the first read returns that value, and broadcasts after the clone
+/// are received. Updates queued in the original but not yet read stay with
+/// the original. To include them in the clone's starting value, read them
+/// first with [`get_newest`](Self::get_newest):
+///
+/// ```
+/// # use actify::Handle;
+/// # #[tokio::main]
+/// # async fn main() {
+/// let handle = Handle::new(1);
+/// let mut cache = handle.create_cache().await;
+///
+/// handle.set(2).await; // Queued, not yet read by the cache
+///
+/// let stale = cache.clone(); // Starts from 1, the update stays behind
+/// cache.get_newest(); // Reads the queued update first
+/// let synced = cache.clone(); // Starts from 2
+///
+/// assert_eq!(stale.get_current(), &1);
+/// assert_eq!(synced.get_current(), &2);
+/// # }
+/// ```
 #[derive(Debug)]
 pub struct Cache<T> {
     inner: T,

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -570,6 +570,32 @@ mod tests {
         assert_eq!(cache.get_newest(), &2);
     }
 
+    /// A clone is a fresh cache initialized with the original's current
+    /// value: its first read delivers that snapshot, and updates queued in
+    /// the original's receiver stay with the original. A new subscription
+    /// starts at the channel tail, so the queued updates cannot follow the
+    /// clone; the snapshot on first read is what the clone can guarantee.
+    #[tokio::test(start_paused = true)]
+    async fn test_clone_is_a_snapshot() {
+        let handle = Handle::new(1);
+        let mut cache = handle.create_cache().await;
+        assert_eq!(cache.recv().await.unwrap(), &1); // Consume first request
+
+        handle.set(2).await; // Queued in the original's receiver
+        let mut clone = cache.clone();
+
+        // The clone delivers its snapshot on first read
+        assert_eq!(clone.try_recv().unwrap(), Some(&1));
+
+        // The queued update belongs to the original
+        assert_eq!(cache.try_recv().unwrap(), Some(&2));
+
+        // The clone sees only broadcasts made after its creation
+        assert_eq!(clone.try_recv().unwrap(), None);
+        handle.set(3).await;
+        assert_eq!(clone.try_recv().unwrap(), Some(&3));
+    }
+
     #[tokio::test(start_paused = true)]
     async fn test_recv_waits_for_update() {
         let handle = Handle::new(2);


### PR DESCRIPTION
The sibling of #91, from the same audit of the update-loss class fixed in 0.8.2, resolved as discussed: a clone is defined as a snapshot, and a new `clone_newest` covers the case where the queued updates should come along.

## The bug

`Cache::clone` copied `first_request` and called `resubscribe()`, which starts at the channel tail. A clone taken after the original's first read therefore returned `None` from every receive until the actor happened to broadcast again, and updates already queued in the original's receiver never reached the clone at all: they were in neither the cloned snapshot nor the new subscription.

## The fix

A clone is now a fresh cache initialized with the original's current value: `first_request` is reset, so the clone delivers its snapshot on the first read and receives every broadcast made after its creation. This is the same contract as `create_cache_from`.

Marked **breaking** because a clone's first read now returns the snapshot where it previously returned nothing.

## `Cache::clone_newest`

`Clone::clone` takes `&self`, so it cannot read the queued updates: draining consumes them from the receiver and needs `&mut`. A clone that silently did so would also mutate the cache it was taken from without saying so in its signature.

`clone_newest(&mut self)` is that operation, stated: it reads the queued updates into the cache, then clones, so both caches start from the newest broadcast value. The read counts as receiving, exactly as `Cache::spawn_throttle` now behaves after #91, so a later receive on either cache returns only updates broadcast after the call.

The subscription is taken before the read, mirroring the ordering from the 0.8.2 fix and #91: an update racing with the call reaches the clone rather than falling between the drained value and the new subscription. Nothing can interleave between those two lines today, so this is structural rather than test-covered.

## Tests

TDD for the fix: the first commit adds `test_clone_is_a_snapshot`, which fails on main with `None` where the snapshot is expected, and also pins that queued updates belong to the original and that the clone sees later broadcasts.

`clone_newest` is new API, so it has no red commit that compiles. Its test was verified instead by mutation: removing the drain makes `test_clone_newest_includes_queued_updates` fail with `Some(1)` where `Some(2)` is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)