### PR TITLE
Return an abortable handle from the throttle spawns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 - `OptionHandle::take` and `OptionHandle::replace`, mirroring
   `std::option::Option::take` and `std::option::Option::replace` in both
   signature and behaviour.
+- `Throttle::abort` and `Throttle::is_finished`. A throttle spawned by
+  `Throttle::spawn_interval` has no actor attached, so before this nothing could
+  stop it short of shutting down the runtime.
 
 ### Changed
 
@@ -34,6 +37,15 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 
 - Extension getters such as `VecHandle::is_empty` and `HashMapHandle::keys` no
   longer broadcast.
+
+- **Breaking:** `Throttle` is now a handle to a running throttle rather than a
+  generic configuration struct, so `Throttle<C, T, F>` becomes `Throttle`. Its
+  spawn functions keep their names and arguments and gained the generics, so
+  call sites are unchanged apart from the return value.
+- **Breaking:** `Throttle::spawn_from_receiver`, `Throttle::spawn_interval`,
+  `Handle::spawn_throttle` and `Cache::spawn_throttle` return a `Throttle`
+  instead of `()`. Dropping it leaves the throttle running. `spawn_interval` is
+  `#[must_use]`, since nothing else can stop that task.
 
 ### Documentation
 

--- a/actify-test/src/main.rs
+++ b/actify-test/src/main.rs
@@ -890,15 +890,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_throttle_spawn_interval_no_cleanup() {
-        // Note: spawn_interval creates a Throttle without a receiver,
-        // so it will run forever (until the runtime shuts down).
-        // This test documents that behavior.
-
+    async fn test_spawn_interval_task_runs_until_aborted() {
         let baseline = alive_tasks();
 
         let client = TestClient::new();
-        Throttle::spawn_interval(
+        let throttle = Throttle::spawn_interval(
             client.clone(),
             TestClient::call,
             Duration::from_millis(50),
@@ -912,16 +908,25 @@ mod tests {
             "Expected one task for interval Throttle"
         );
 
-        // Verify the throttle keeps firing on its interval
+        // No receiver is attached, so nothing ends the task on its own.
         let count = client.await_count(2).await;
         assert!(
             count >= 2,
             "Interval throttle should have fired repeatedly, count: {count}"
         );
+        assert_eq!(
+            settled_alive_tasks().await,
+            baseline + 1,
+            "Interval throttle should still be running"
+        );
 
-        // Note: There's no way to stop an interval-based Throttle without a receiver.
-        // This is expected behavior - the task will run until the runtime exits.
-        // The task count will remain elevated.
+        throttle.abort();
+
+        assert_eq!(
+            await_alive_tasks(baseline).await,
+            baseline,
+            "abort should release the task"
+        );
     }
 
     #[tokio::test]

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -489,7 +489,7 @@ where
     /// Spawns a [`Throttle`] that fires given a specified [`Frequency`], given any broadcasted updates by the actor.
     /// Does not first update the cache to the newest value, since then the user of the cache might miss the update.
     /// See [`Handle::spawn_throttle`](crate::Handle::spawn_throttle) for an example.
-    pub fn spawn_throttle<C, F>(&self, client: C, call: fn(&C, F), freq: Frequency)
+    pub fn spawn_throttle<C, F>(&self, client: C, call: fn(&C, F), freq: Frequency) -> Throttle
     where
         C: Send + Sync + 'static,
         T: Throttled<F>,
@@ -497,7 +497,7 @@ where
     {
         let current = self.inner.clone();
         let receiver = self.rx.resubscribe();
-        Throttle::spawn_from_receiver(client, call, freq, receiver, Some(current));
+        Throttle::spawn_from_receiver(client, call, freq, receiver, Some(current))
     }
 }
 

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -542,7 +542,12 @@ where
     /// Panics if the actor has stopped, either because one of its methods
     /// panicked or because its runtime shut down. See [Actor lifetime and
     /// panics](crate#actor-lifetime-and-panics).
-    pub async fn spawn_throttle<C, F>(&self, client: C, call: fn(&C, F), freq: Frequency)
+    pub async fn spawn_throttle<C, F>(
+        &self,
+        client: C,
+        call: fn(&C, F),
+        freq: Frequency,
+    ) -> Throttle
     where
         C: Send + Sync + 'static,
         V: Throttled<F>,
@@ -551,7 +556,7 @@ where
         // Subscribe before get, so an update arriving in between is queued rather than lost.
         let receiver = self.subscribe();
         let current = self.get().await;
-        Throttle::spawn_from_receiver(client, call, freq, receiver, Some(current.to_broadcast()));
+        Throttle::spawn_from_receiver(client, call, freq, receiver, Some(current.to_broadcast()))
     }
 }
 

--- a/actify/src/lib.rs
+++ b/actify/src/lib.rs
@@ -324,12 +324,19 @@
 //! A [`Throttle`] rate-limits broadcasted updates before forwarding them to a callback.
 //! Configure the rate with [`Frequency`]:
 //!
-//! - [`Frequency::OnEvent`]: fires on every broadcast
-//! - [`Frequency::Interval`]: fires at a fixed interval
-//! - [`Frequency::OnEventWhen`]: fires for an event only after an interval has passed
+//! - [`Frequency::OnEvent`]: sends every value as it arrives
+//! - [`Frequency::Interval`]: sends the current value every interval
+//! - [`Frequency::OnEventWhen`]: sends at most once per interval, and only when a
+//!   value arrived since the last send
 //!
 //! Use the [`Throttled`] trait to parse the actor's type into a different output type
 //! for the throttle callback.
+//!
+//! Spawning a throttle returns a [`Throttle`] handle. Dropping it leaves the
+//! throttle running, so a throttle attached to an actor can be spawned and
+//! forgotten: it stops when the actor does. [`Throttle::spawn_interval`] has no
+//! actor attached and runs until [`Throttle::abort`] or the runtime shuts down,
+//! which is why it is the one spawn that must not have its handle discarded.
 //!
 //! # Extension traits
 //!

--- a/actify/src/throttle.rs
+++ b/actify/src/throttle.rs
@@ -1,6 +1,6 @@
-use std::fmt::{self, Debug};
 use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::broadcast::{self, Receiver};
+use tokio::task::AbortHandle;
 use tokio::time::{self, Duration, Interval};
 
 /// The Frequency is used to tune the speed of a [`Throttle`].
@@ -92,7 +92,7 @@ impl Timing {
 /// Moves the first tick a full period out.
 ///
 /// `tokio::time::interval` completes its first tick immediately, and
-/// [`Throttle::run`] already sends the initial value before entering the loop,
+/// `ThrottleTask::run` already sends the initial value before entering the loop,
 /// so without this an interval frequency sends twice at startup.
 fn interval_after(duration: Duration) -> Interval {
     let mut interval = time::interval(duration);
@@ -113,7 +113,7 @@ enum Wake {
 }
 
 /// Owns the broadcast receiver and the timing, so the loop in
-/// [`Throttle::run`] is only a call to [`Self::next`] and a callback.
+/// `ThrottleTask::run` is only a call to [`Self::next`] and a callback.
 struct ThrottleState<T> {
     timing: Timing,
     val_rx: Option<broadcast::Receiver<T>>,
@@ -211,12 +211,8 @@ fn store<T>(current: &mut Option<T>, received: Result<T, RecvError>) -> Wake {
     }
 }
 
-/// Rate-limits broadcasted updates from a [`Handle`](crate::Handle) or [`Cache`](crate::Cache)
-/// before forwarding them to a callback.
-///
-/// Configure the rate with [`Frequency`]. The actor type must implement [`Throttled<F>`](Throttled)
-/// to convert the actor value into the callback argument type `F`.
-pub struct Throttle<C, T, F> {
+/// The parameters a spawned throttle task owns for its lifetime.
+struct ThrottleTask<C, T, F> {
     frequency: Frequency,
     client: C,
     call: fn(&C, F),
@@ -224,71 +220,20 @@ pub struct Throttle<C, T, F> {
     current_val: Option<T>,
 }
 
-impl<C, T, F> fmt::Debug for Throttle<C, T, F> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Throttle")
-            .field("frequency", &self.frequency)
-            .field("client", &std::any::type_name::<C>().to_string())
-            .field("call", &std::any::type_name::<fn(&C, F)>().to_string())
-            .field("val_rx", &self.val_rx)
-            .field(
-                "current_val",
-                &std::any::type_name::<Option<T>>().to_string(),
-            )
-            .finish()
-    }
-}
-
-impl<C, T, F> Throttle<C, T, F>
+impl<C, T, F> ThrottleTask<C, T, F>
 where
     C: Send + Sync + 'static,
     T: Clone + Throttled<F> + Send + Sync + 'static,
     F: Send + Sync + 'static,
 {
-    /// Spawns a throttle that forwards an actor's broadcasts to `call` at the
-    /// given [`Frequency`].
-    ///
-    /// `init` fires immediately, before any broadcast arrives. Pass `None` to
-    /// wait for the first update.
-    ///
-    /// The task stops when the actor does.
-    /// [`Handle::spawn_throttle`](crate::Handle::spawn_throttle) and
-    /// [`Cache::spawn_throttle`](crate::Cache::spawn_throttle) take the
-    /// receiver without losing updates during setup.
-    pub fn spawn_from_receiver(
-        client: C,
-        call: fn(&C, F),
-        frequency: Frequency,
-        receiver: Receiver<T>,
-        init: Option<T>,
-    ) {
-        let throttle = Throttle {
-            frequency,
-            client,
-            call,
-            val_rx: Some(receiver),
-            current_val: init,
-        };
-        tokio::spawn(throttle.run());
-    }
-
-    /// Spawns a throttle that fires `call` with a fixed value on every interval.
-    ///
-    /// Not attached to an actor, so nothing closes it: the task fires until the
-    /// runtime shuts down.
-    pub fn spawn_interval(client: C, call: fn(&C, F), interval: Duration, val: T) {
-        let throttle = Throttle {
-            frequency: Frequency::Interval(interval),
-            client,
-            call,
-            val_rx: None,
-            current_val: Some(val),
-        };
-        tokio::spawn(throttle.run());
+    fn spawn(self) -> Throttle {
+        Throttle {
+            task: tokio::spawn(self.run()).abort_handle(),
+        }
     }
 
     async fn run(self) {
-        let Throttle {
+        let ThrottleTask {
             frequency,
             client,
             call,
@@ -310,6 +255,95 @@ where
     }
 }
 
+/// A running throttle, rate-limiting broadcasted updates from a
+/// [`Handle`](crate::Handle) or [`Cache`](crate::Cache) before forwarding them
+/// to a callback.
+///
+/// Configure the rate with [`Frequency`]. The actor type must implement
+/// [`Throttled<F>`](Throttled) to convert the actor value into the callback
+/// argument type `F`.
+///
+/// Dropping this leaves the throttle running. Call [`abort`](Self::abort) to
+/// stop it.
+#[derive(Debug)]
+pub struct Throttle {
+    task: AbortHandle,
+}
+
+impl Throttle {
+    /// Spawns a throttle that forwards an actor's broadcasts to `call` at the
+    /// given [`Frequency`].
+    ///
+    /// `init` sends immediately, before any broadcast arrives. Pass `None` to
+    /// wait for the first update.
+    ///
+    /// The task stops when the actor does.
+    /// [`Handle::spawn_throttle`](crate::Handle::spawn_throttle) and
+    /// [`Cache::spawn_throttle`](crate::Cache::spawn_throttle) take the
+    /// receiver without losing updates during setup.
+    pub fn spawn_from_receiver<C, T, F>(
+        client: C,
+        call: fn(&C, F),
+        frequency: Frequency,
+        receiver: Receiver<T>,
+        init: Option<T>,
+    ) -> Throttle
+    where
+        C: Send + Sync + 'static,
+        T: Clone + Throttled<F> + Send + Sync + 'static,
+        F: Send + Sync + 'static,
+    {
+        ThrottleTask {
+            frequency,
+            client,
+            call,
+            val_rx: Some(receiver),
+            current_val: init,
+        }
+        .spawn()
+    }
+
+    /// Spawns a throttle that sends a fixed value to `call` on every interval.
+    ///
+    /// No actor is attached, so nothing ends the task on its own. It runs until
+    /// [`abort`](Self::abort) or the runtime shuts down.
+    #[must_use = "without this handle the interval task cannot be stopped"]
+    pub fn spawn_interval<C, T, F>(
+        client: C,
+        call: fn(&C, F),
+        interval: Duration,
+        val: T,
+    ) -> Throttle
+    where
+        C: Send + Sync + 'static,
+        T: Clone + Throttled<F> + Send + Sync + 'static,
+        F: Send + Sync + 'static,
+    {
+        ThrottleTask {
+            frequency: Frequency::Interval(interval),
+            client,
+            call,
+            val_rx: None,
+            current_val: Some(val),
+        }
+        .spawn()
+    }
+
+    /// Stops the throttle.
+    ///
+    /// The task stops at its next await point, so a callback already running
+    /// finishes first.
+    pub fn abort(&self) {
+        self.task.abort();
+    }
+
+    /// Whether the task has stopped, either through [`abort`](Self::abort) or
+    /// because the actor it was attached to is gone.
+    pub fn is_finished(&self) -> bool {
+        self.task.is_finished()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::Handle;
@@ -325,6 +359,12 @@ mod tests {
     /// paused in these tests, so the wait costs no real time.
     async fn still_waiting<T>(future: impl Future<Output = T>) -> bool {
         timeout(PERIOD * 10, future).await.is_err()
+    }
+
+    fn alive_tasks() -> usize {
+        tokio::runtime::Handle::current()
+            .metrics()
+            .num_alive_tasks()
     }
 
     mod state {
@@ -441,7 +481,8 @@ mod tests {
         #[tokio::test(start_paused = true)]
         async fn test_interval_sends_it_once_then_resumes_on_the_period() {
             let counter = CounterClient::new();
-            Throttle::spawn_interval(counter.clone(), CounterClient::call, PERIOD, 1);
+            let _throttle =
+                Throttle::spawn_interval(counter.clone(), CounterClient::call, PERIOD, 1);
 
             sleep(PERIOD / 2).await;
             assert_eq!(*counter.count.lock().unwrap(), 1, "startup send duplicated");
@@ -477,6 +518,69 @@ mod tests {
 
             sleep(PERIOD * 3).await;
             assert_eq!(*counter.count.lock().unwrap(), 1);
+        }
+    }
+
+    mod lifecycle {
+        use super::*;
+
+        #[tokio::test(start_paused = true)]
+        async fn test_abort_stops_an_interval_throttle() {
+            let counter = CounterClient::new();
+            let throttle =
+                Throttle::spawn_interval(counter.clone(), CounterClient::call, PERIOD, 1);
+
+            sleep(PERIOD * 3).await;
+            let before_abort = *counter.count.lock().unwrap();
+            assert!(before_abort > 1, "the throttle must be sending before this");
+
+            throttle.abort();
+            sleep(PERIOD * 3).await;
+
+            assert_eq!(before_abort, *counter.count.lock().unwrap());
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn test_is_finished_reports_the_abort() {
+            let counter = CounterClient::new();
+            let throttle = Throttle::spawn_interval(counter, CounterClient::call, PERIOD, 1);
+            sleep(PERIOD).await;
+            assert!(!throttle.is_finished());
+
+            throttle.abort();
+            sleep(PERIOD).await;
+
+            assert!(throttle.is_finished());
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn test_is_finished_once_the_actor_is_gone() {
+            let handle = Handle::new(1);
+            let counter = CounterClient::new();
+            let throttle = handle
+                .spawn_throttle(counter, CounterClient::call, Frequency::Interval(PERIOD))
+                .await;
+            assert!(!throttle.is_finished());
+
+            drop(handle);
+            sleep(PERIOD * 3).await;
+
+            assert!(throttle.is_finished());
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn test_abort_releases_the_task() {
+            let idle = alive_tasks();
+            let counter = CounterClient::new();
+            let throttle = Throttle::spawn_interval(counter, CounterClient::call, PERIOD, 1);
+
+            sleep(PERIOD).await;
+            assert_eq!(alive_tasks(), idle + 1);
+
+            throttle.abort();
+            sleep(PERIOD).await;
+
+            assert_eq!(alive_tasks(), idle);
         }
     }
 
@@ -643,7 +747,7 @@ mod tests {
         let counter = CounterClient::new();
 
         // Spawn throttle
-        Throttle::spawn_interval(
+        let _throttle = Throttle::spawn_interval(
             counter.clone(),
             CounterClient::call,
             Duration::from_millis(timer as u64),
@@ -734,7 +838,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn test_throttle_parsing() {
         // Parsing to self should succeed
-        Throttle::spawn_interval(
+        let _ = Throttle::spawn_interval(
             DummyClient {},
             DummyClient::call_a,
             Duration::from_millis(100),
@@ -742,14 +846,14 @@ mod tests {
         );
 
         // Parsing to either B or C should be infered by the compiler
-        Throttle::spawn_interval(
+        let _ = Throttle::spawn_interval(
             DummyClient {},
             DummyClient::call_b,
             Duration::from_millis(100),
             A {},
         );
 
-        Throttle::spawn_interval(
+        let _ = Throttle::spawn_interval(
             DummyClient {},
             DummyClient::call_c,
             Duration::from_millis(100),


### PR DESCRIPTION
Item 4 of the 0.9.0 train. Makes a spawned throttle stoppable.

## The problem

`Throttle::spawn_interval` builds a throttle with no receiver, so `recv_value` waits forever and the loop has no exit. Nothing could stop that task short of shutting the runtime down. An integration test even documented the leak as intended behaviour:

```rust
// Note: There's no way to stop an interval-based Throttle without a receiver.
// This is expected behavior - the task will run until the runtime exits.
```

## The change

`Throttle` becomes a handle to a running throttle instead of a generic configuration struct:

```rust
pub struct Throttle {
    task: AbortHandle,
}

impl Throttle {
    pub fn abort(&self);
    pub fn is_finished(&self) -> bool;
}
```

The parameter bundle moved to a private `ThrottleTask<C, T, F>`, which also let its hand-written `Debug` impl go, since it only ever printed type names and the type is no longer public.

The generics moved from the type onto the spawn functions, so **call sites are unchanged apart from the return value**. `Throttle::spawn_from_receiver(client, call, freq, receiver, init)` still reads the same, and inference still works from the arguments.

`Handle::spawn_throttle` and `Cache::spawn_throttle` return the handle too.

## Dropping does not abort

Deliberately. A throttle attached to an actor already ends when the actor does, so spawn-and-forget stays valid and is what most call sites want.

That leaves `spawn_interval` as the one spawn with nothing to end it, so it is the only one marked `#[must_use]`:

```rust
#[must_use = "without this handle the interval task cannot be stopped"]
```

That attribute immediately found five call sites in this repo that were discarding the handle, which is the failure mode it exists to catch.

## Tests

No red commit is possible: `abort` does not exist on main, so a test calling it fails to compile rather than fails.

Four unit tests in `mod lifecycle`:

- `test_abort_stops_an_interval_throttle`: asserts it was sending first, then that the count is frozen after the abort
- `test_is_finished_reports_the_abort`: false while running, true after
- `test_is_finished_once_the_actor_is_gone`: the receiver-attached case still ends on its own
- `test_abort_releases_the_task`: the runtime's alive-task count returns to its baseline

The integration test that documented the leak now asserts the opposite half as well: the task stays up while the throttle is held, and `abort` returns the count to baseline.

### Mutation check

Emptying the body of `abort`:

```
lifecycle::test_is_finished_once_the_actor_is_gone ... ok
lifecycle::test_is_finished_reports_the_abort ... FAILED
lifecycle::test_abort_releases_the_task ... FAILED
lifecycle::test_abort_stops_an_interval_throttle ... FAILED
```

Three fail and the one that passes is the one that never calls `abort`, so the coverage is specific rather than incidental.

## Verification

`cargo test --workspace`, `cargo test -p actify`, clippy `-D warnings`, `cargo fmt --check`, and `cargo doc` with default and all features under `RUSTDOCFLAGS="-D warnings"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
