### PR TITLE
Accept any Fn as a throttle callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 - Extension getters such as `VecHandle::is_empty` and `HashMapHandle::keys` no
   longer broadcast.
 
+- **Breaking:** throttle callbacks take any `Fn(&C, F) + Send + 'static` instead
+  of a `fn(&C, F)` pointer, so a closure holding captured state is accepted.
+  Method references and non-capturing closures still coerce, so existing call
+  sites are unchanged. Affects `Throttle::spawn_from_receiver`,
+  `Throttle::spawn_interval`, `Handle::spawn_throttle`, `Handle::new_throttled`
+  and `Cache::spawn_throttle`. Code naming the old type explicitly, such as a
+  struct field of type `fn(&C, F)`, needs the new parameter.
 - **Breaking:** `Throttle` is now a handle to a running throttle rather than a
   generic configuration struct, so `Throttle<C, T, F>` becomes `Throttle`. Its
   spawn functions keep their names and arguments and gained the generics, so

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -489,11 +489,12 @@ where
     /// Spawns a [`Throttle`] that fires given a specified [`Frequency`], given any broadcasted updates by the actor.
     /// Does not first update the cache to the newest value, since then the user of the cache might miss the update.
     /// See [`Handle::spawn_throttle`](crate::Handle::spawn_throttle) for an example.
-    pub fn spawn_throttle<C, F>(&self, client: C, call: fn(&C, F), freq: Frequency) -> Throttle
+    pub fn spawn_throttle<C, F, Fun>(&self, client: C, call: Fun, freq: Frequency) -> Throttle
     where
         C: Send + Sync + 'static,
         T: Throttled<F>,
         F: Send + Sync + 'static,
+        Fun: Fn(&C, F) + Send + 'static,
     {
         let current = self.inner.clone();
         let receiver = self.rx.resubscribe();

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -158,11 +158,12 @@ where
     /// Creates a new [`Handle`] and initializes a corresponding [`Throttle`].
     /// The throttle fires given a specified [`Frequency`].
     /// See [`Handle::spawn_throttle`] for an example.
-    pub fn new_throttled<C, F>(val: T, client: C, call: fn(&C, F), freq: Frequency) -> Handle<T, V>
+    pub fn new_throttled<C, F, Fun>(val: T, client: C, call: Fun, freq: Frequency) -> Handle<T, V>
     where
         C: Send + Sync + 'static,
         V: Throttled<F>,
         F: Send + Sync + 'static,
+        Fun: Fn(&C, F) + Send + 'static,
     {
         let init = val.to_broadcast();
         let handle = Self::new(val);
@@ -514,6 +515,9 @@ where
     /// The broadcast type must implement [`Throttled<F>`](crate::Throttled) to
     /// convert the value into the callback argument.
     ///
+    /// `call` is any `Fn(&C, F)`, so it can be a method such as `Logger::log`
+    /// below, or a closure holding captured state.
+    ///
     /// # Examples
     ///
     /// ```
@@ -542,16 +546,12 @@ where
     /// Panics if the actor has stopped, either because one of its methods
     /// panicked or because its runtime shut down. See [Actor lifetime and
     /// panics](crate#actor-lifetime-and-panics).
-    pub async fn spawn_throttle<C, F>(
-        &self,
-        client: C,
-        call: fn(&C, F),
-        freq: Frequency,
-    ) -> Throttle
+    pub async fn spawn_throttle<C, F, Fun>(&self, client: C, call: Fun, freq: Frequency) -> Throttle
     where
         C: Send + Sync + 'static,
         V: Throttled<F>,
         F: Send + Sync + 'static,
+        Fun: Fn(&C, F) + Send + 'static,
     {
         // Subscribe before get, so an update arriving in between is queued rather than lost.
         let receiver = self.subscribe();

--- a/actify/src/throttle.rs
+++ b/actify/src/throttle.rs
@@ -212,27 +212,25 @@ fn store<T>(current: &mut Option<T>, received: Result<T, RecvError>) -> Wake {
 }
 
 /// The parameters a spawned throttle task owns for its lifetime.
-struct ThrottleTask<C, T, F> {
+///
+/// `F` is fixed by `Fun` rather than stored, so it is a parameter of
+/// [`Self::spawn`] instead of the struct.
+struct ThrottleTask<C, T, Fun> {
     frequency: Frequency,
     client: C,
-    call: fn(&C, F),
+    call: Fun,
     val_rx: Option<broadcast::Receiver<T>>,
     current_val: Option<T>,
 }
 
-impl<C, T, F> ThrottleTask<C, T, F>
-where
-    C: Send + Sync + 'static,
-    T: Clone + Throttled<F> + Send + Sync + 'static,
-    F: Send + Sync + 'static,
-{
-    fn spawn(self) -> Throttle {
-        Throttle {
-            task: tokio::spawn(self.run()).abort_handle(),
-        }
-    }
-
-    async fn run(self) {
+impl<C, T, Fun> ThrottleTask<C, T, Fun> {
+    fn spawn<F>(self) -> Throttle
+    where
+        C: Send + Sync + 'static,
+        T: Clone + Throttled<F> + Send + Sync + 'static,
+        F: Send + Sync + 'static,
+        Fun: Fn(&C, F) + Send + 'static,
+    {
         let ThrottleTask {
             frequency,
             client,
@@ -241,16 +239,22 @@ where
             current_val,
         } = self;
 
-        let mut state = ThrottleState::new(frequency, val_rx, current_val);
+        let task = tokio::spawn(async move {
+            let mut state = ThrottleState::new(frequency, val_rx, current_val);
 
-        // Send the initial value before the loop. Frequency::OnEvent has no
-        // interval, so a timer tick cannot cover this for every frequency.
-        if let Some(value) = state.current::<F>() {
-            call(&client, value);
-        }
+            // Send the initial value before the loop. Frequency::OnEvent has no
+            // interval, so a timer tick cannot cover this for every frequency.
+            if let Some(value) = state.current::<F>() {
+                call(&client, value);
+            }
 
-        while let Some(value) = state.next::<F>().await {
-            call(&client, value);
+            while let Some(value) = state.next::<F>().await {
+                call(&client, value);
+            }
+        });
+
+        Throttle {
+            task: task.abort_handle(),
         }
     }
 }
@@ -281,9 +285,9 @@ impl Throttle {
     /// [`Handle::spawn_throttle`](crate::Handle::spawn_throttle) and
     /// [`Cache::spawn_throttle`](crate::Cache::spawn_throttle) take the
     /// receiver without losing updates during setup.
-    pub fn spawn_from_receiver<C, T, F>(
+    pub fn spawn_from_receiver<C, T, F, Fun>(
         client: C,
-        call: fn(&C, F),
+        call: Fun,
         frequency: Frequency,
         receiver: Receiver<T>,
         init: Option<T>,
@@ -292,6 +296,7 @@ impl Throttle {
         C: Send + Sync + 'static,
         T: Clone + Throttled<F> + Send + Sync + 'static,
         F: Send + Sync + 'static,
+        Fun: Fn(&C, F) + Send + 'static,
     {
         ThrottleTask {
             frequency,
@@ -308,9 +313,9 @@ impl Throttle {
     /// No actor is attached, so nothing ends the task on its own. It runs until
     /// [`abort`](Self::abort) or the runtime shuts down.
     #[must_use = "without this handle the interval task cannot be stopped"]
-    pub fn spawn_interval<C, T, F>(
+    pub fn spawn_interval<C, T, F, Fun>(
         client: C,
-        call: fn(&C, F),
+        call: Fun,
         interval: Duration,
         val: T,
     ) -> Throttle
@@ -318,6 +323,7 @@ impl Throttle {
         C: Send + Sync + 'static,
         T: Clone + Throttled<F> + Send + Sync + 'static,
         F: Send + Sync + 'static,
+        Fun: Fn(&C, F) + Send + 'static,
     {
         ThrottleTask {
             frequency: Frequency::Interval(interval),
@@ -871,6 +877,26 @@ mod tests {
             after_flood + 1,
             "the throttle stopped after lagging"
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_a_capturing_closure_is_accepted() {
+        let handle = Handle::new(1);
+        let seen = Arc::new(Mutex::new(Vec::new()));
+
+        let captured = Arc::clone(&seen);
+        let _throttle = handle
+            .spawn_throttle(
+                (),
+                move |_: &(), value: i32| captured.lock().unwrap().push(value),
+                Frequency::OnEvent,
+            )
+            .await;
+
+        handle.set(2).await;
+        sleep(PERIOD).await;
+
+        assert_eq!(*seen.lock().unwrap(), vec![1, 2]);
     }
 
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
Item 5 of the 0.9.0 train. Widens the throttle callback from a fn pointer to any `Fn`.

## The change

Throttle callbacks took `call: fn(&C, F)`, a bare fn pointer, so the only things that fit were method references and non-capturing closures. Anything that captured was rejected:

```
error[E0308]: mismatched types
   |                 move |_: &(), value: i32| captured.lock().unwrap().push(value),
   |                 ^^^^ expected fn pointer, found closure
   = note: expected fn pointer `for<'a> fn(&'a (), i32)`
```

That forced captured state through the `client` parameter even when a closure would say it more directly. The callback is now `Fun: Fn(&C, F) + Send + 'static`, on `Throttle::spawn_from_receiver`, `Throttle::spawn_interval`, `Handle::spawn_throttle`, `Handle::new_throttled` and `Cache::spawn_throttle`.

I used `Send + 'static` rather than `Send + Sync + 'static`. The callback is moved into one task and called from one place, so `Sync` would be a bound nobody needs.

## Existing call sites are unchanged

Fn items still coerce, so every `CounterClient::call` in the suite compiles untouched, and `test_throttle_parsing` still infers `F` from the callback for all three of its output types.

The one thing that does break is code naming the old type explicitly, such as a struct field declared `fn(&C, F)`. The changelog says so.

## Where `F` went

`F` appears only in `Fun`'s bound, not in any field, so `ThrottleTask` can no longer carry it as a struct parameter. Rather than add a `PhantomData<F>`, `F` moved onto `spawn`, and `run` folded into it as an inline async block. That is one method with the bounds stated once, instead of two methods repeating four bounds each plus a phantom field.

## Tests

`test_a_capturing_closure_is_accepted` spawns a throttle whose callback captures an `Arc<Mutex<Vec<i32>>>` and takes `()` as its client, then asserts both the startup send and a later update land in the captured vector.

Verified it exercises the new capability rather than passing incidentally: reverting just `Handle::spawn_throttle` to `fn(&C, F)` fails that test with "expected fn pointer, found closure", quoted above.

No red commit is possible, since the closure form does not compile on main.

## Verification

`cargo test --workspace`, `cargo test -p actify`, clippy `-D warnings`, `cargo fmt --check`, and `cargo doc` with default and all features under `RUSTDOCFLAGS="-D warnings"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
