### PR TITLE
Skip missed interval ticks and send the newest value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,16 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 
 ### Fixed
 
+- A `Throttle` on `Frequency::Interval` no longer sends a burst when a send
+  outlasts its interval. `tokio::time::interval` releases every tick that came
+  due while the loop was busy, so one send lasting three intervals was followed
+  by three sends in the same instant. The interval now skips the ticks it missed
+  and stays on its original schedule.
+- Both interval frequencies send the newest value available rather than the one
+  that was current when the tick came due. An overdue tick can win the race
+  against values already queued, and it previously sent the older value while a
+  newer one sat unread in the channel.
+
 - Extension getters such as `VecHandle::is_empty` and `HashMapHandle::keys` no
   longer broadcast.
 

--- a/actify/src/throttle.rs
+++ b/actify/src/throttle.rs
@@ -1,9 +1,14 @@
-use tokio::sync::broadcast::error::RecvError;
+use tokio::sync::broadcast::error::{RecvError, TryRecvError};
 use tokio::sync::broadcast::{self, Receiver};
 use tokio::task::AbortHandle;
 use tokio::time::{self, Duration, Interval};
 
 /// The Frequency is used to tune the speed of a [`Throttle`].
+///
+/// For the two interval variants, a send that outlasts its interval does not
+/// build up the ticks it missed. The interval keeps its original schedule and
+/// the next send happens at the next boundary, carrying the newest value
+/// received in the meantime rather than the one current when the tick came due.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Frequency {
     /// Sends every value as it arrives.
@@ -63,16 +68,17 @@ impl Timing {
         }
     }
 
+    /// Notes that a value arrived, without deciding whether to send it.
+    fn record_value(&mut self) {
+        if let Timing::OnEventWhen { event_pending, .. } = self {
+            *event_pending = true;
+        }
+    }
+
     /// A value arrived. Returns whether to send it now.
     fn on_value(&mut self) -> bool {
-        match self {
-            Timing::OnEvent => true,
-            Timing::Interval(_) => false,
-            Timing::OnEventWhen { event_pending, .. } => {
-                *event_pending = true;
-                false
-            }
-        }
+        self.record_value();
+        matches!(self, Timing::OnEvent)
     }
 
     /// The interval elapsed. Returns whether to send the stored value.
@@ -89,13 +95,20 @@ impl Timing {
     }
 }
 
-/// Moves the first tick a full period out.
+/// An interval whose first tick is a full period out, and which never releases
+/// more than one tick for a period it spent waiting.
 ///
 /// `tokio::time::interval` completes its first tick immediately, and
 /// `ThrottleTask::run` already sends the initial value before entering the loop,
-/// so without this an interval frequency sends twice at startup.
+/// so without the reset an interval frequency sends twice at startup.
+///
+/// Its default [`MissedTickBehavior::Burst`](time::MissedTickBehavior::Burst)
+/// hands over every tick that came due while the loop was busy, all at once. A
+/// throttle sends at most once per period, so it skips them and stays on the
+/// original schedule instead.
 fn interval_after(duration: Duration) -> Interval {
     let mut interval = time::interval(duration);
+    interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
     interval.reset();
     interval
 }
@@ -141,7 +154,14 @@ impl<T: Clone> ThrottleState<T> {
     {
         loop {
             let ready = match self.wake().await {
-                Wake::Tick => self.timing.on_tick(),
+                Wake::Tick => {
+                    // An overdue tick can win the select against values already
+                    // queued, which would send an older one than is available.
+                    if drain_available(&mut self.val_rx, &mut self.current_val) {
+                        self.timing.record_value();
+                    }
+                    self.timing.on_tick()
+                }
                 Wake::Value => self.timing.on_value(),
                 Wake::Lagged => false,
                 Wake::Closed => return None,
@@ -184,6 +204,35 @@ async fn recv_value<T: Clone>(val_rx: &mut Option<broadcast::Receiver<T>>) -> Re
         rx.recv().await
     } else {
         std::future::pending::<Result<T, RecvError>>().await
+    }
+}
+
+/// Takes every value already queued, keeping the newest. Returns whether any
+/// were there.
+fn drain_available<T: Clone>(
+    val_rx: &mut Option<broadcast::Receiver<T>>,
+    current: &mut Option<T>,
+) -> bool {
+    let Some(rx) = val_rx else {
+        return false;
+    };
+
+    let mut received = false;
+    loop {
+        match rx.try_recv() {
+            Ok(value) => {
+                *current = Some(value);
+                received = true;
+            }
+            Err(TryRecvError::Lagged(nr)) => {
+                log::debug!(
+                    "Throttle of type {} lagged {nr} messages",
+                    std::any::type_name::<T>()
+                );
+            }
+            // A closed channel is reported by the next receive in the loop.
+            Err(TryRecvError::Empty | TryRecvError::Closed) => return received,
+        }
     }
 }
 

--- a/actify/src/throttle.rs
+++ b/actify/src/throttle.rs
@@ -388,6 +388,60 @@ mod tests {
             assert_eq!(start.elapsed(), Duration::ZERO);
         }
 
+        /// Ticks that come due while nobody is polling must not all fire at
+        /// once when polling resumes. One send per period is the whole contract.
+        #[tokio::test(start_paused = true)]
+        async fn test_interval_does_not_burst_after_a_delay() {
+            let (_tx, rx) = broadcast::channel::<i32>(8);
+            let mut state = ThrottleState::new(Frequency::Interval(PERIOD), Some(rx), Some(1));
+
+            // Three periods pass with nobody driving the state
+            sleep(PERIOD * 3).await;
+
+            // The overdue tick fires now
+            let start = Instant::now();
+            assert_eq!(state.next::<i32>().await, Some(1));
+            assert_eq!(start.elapsed(), Duration::ZERO);
+
+            // And the one after it waits a full period rather than catching up
+            let start = Instant::now();
+            assert_eq!(state.next::<i32>().await, Some(1));
+            assert_eq!(start.elapsed(), PERIOD);
+        }
+
+        /// An overdue tick can win the select over values already queued, so it
+        /// must take the newest of them rather than whatever it happens to hold.
+        #[tokio::test(start_paused = true)]
+        async fn test_an_overdue_interval_tick_sends_the_newest_value() {
+            let (tx, rx) = broadcast::channel(8);
+            let mut state = ThrottleState::new(Frequency::Interval(PERIOD), Some(rx), Some(0));
+
+            for value in 1..=3 {
+                tx.send(value).unwrap();
+            }
+
+            // The tick is overdue and three values are waiting
+            sleep(PERIOD * 2).await;
+
+            assert_eq!(state.next::<i32>().await, Some(3));
+        }
+
+        /// The same for OnEventWhen, which must also not lose the event: the
+        /// drained values are what makes it fire.
+        #[tokio::test(start_paused = true)]
+        async fn test_an_overdue_on_event_when_tick_sends_the_newest_value() {
+            let (tx, rx) = broadcast::channel(8);
+            let mut state = ThrottleState::new(Frequency::OnEventWhen(PERIOD), Some(rx), None);
+
+            for value in 1..=3 {
+                tx.send(value).unwrap();
+            }
+
+            sleep(PERIOD * 2).await;
+
+            assert_eq!(state.next::<i32>().await, Some(3));
+        }
+
         #[tokio::test(start_paused = true)]
         async fn test_interval_repeats_the_value_without_events() {
             let (_tx, rx) = broadcast::channel::<i32>(8);


### PR DESCRIPTION
Two timing defects in the interval frequencies, found while investigating what a slow callback does to a throttle. Split out of the async-throttle work (#95) deliberately: this changes cadence for existing sync throttles, so it should be reviewable on its own.

## The burst

`tokio::time::interval` defaults to `MissedTickBehavior::Burst`: every tick that came due while nobody polled it is released at once. A throttle exists to send at most once per period, so that is precisely inverted.

Measured with one send lasting three intervals, recording when each call starts:

```
before: [0ms, 300ms, 300ms, 300ms, 400ms, 500ms, 600ms]
after:  [0ms, 300ms,               400ms, 500ms, 600ms]
```

Three sends in the same instant, then back to normal cadence. The interval now uses `Skip`, which drops the missed ticks and stays on the original schedule, so at most one catch-up send happens at the current boundary.

## The stale value

An overdue tick can win the `select!` against values already sitting in the channel, and it then sent whatever the state happened to hold. With five updates queued behind a slow send, `Frequency::Interval` sent `0` while `5` was unread.

A tick now drains everything already queued before deciding, so it sends the newest value available.

That drain also has to count as receiving, or `OnEventWhen` would lose its reason to fire: if a value arrives in the same instant as the tick, draining it without recording it would leave `event_pending` false and the value would never be sent. `Timing::record_value` is split out of `on_value` for exactly that, and `on_value` is now `record_value` plus "is this OnEvent".

## Tests

Three, all failing on main, all at the `ThrottleState` level so they need no slow callback and no spawned task:

- `test_interval_does_not_burst_after_a_delay`: three periods pass unpolled, then asserts the overdue tick fires at once and the *next* one waits a full period. Under `Burst` the second also returns immediately.
- `test_an_overdue_interval_tick_sends_the_newest_value`
- `test_an_overdue_on_event_when_tick_sends_the_newest_value`

The last two are the ones that could have been flaky, since they depend on which `select!` branch wins. They fail on main on every run, and pass on every run after the fix, because draining makes the outcome the same whichever branch won. Verified by running the suite three times each way.

## Scope

`Frequency::OnEvent` is unaffected: it has no interval, so neither defect can reach it. It still sends every value in order, and a backlog drains back to back once the callback frees up.

## Verification

`cargo test --workspace`, `cargo test -p actify`, clippy `-D warnings`, `cargo fmt --check`, and `cargo doc` with default and all features under `RUSTDOCFLAGS="-D warnings"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
