### PR TITLE
Spawn throttles from a ReadHandle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
   cloned nor required to be `Clone`. A future that borrows carries the lifetime
   of that borrow in its type, which a plain generic return type cannot express,
   hence the box. `BoxFuture` is exported for naming the bound.
+- `ReadHandle::spawn_throttle` and `ReadHandle::spawn_async_throttle`, so a
+  throttle can be spawned from a read-only view of an actor. Both behave as
+  their `Handle` counterparts.
 - `Throttle::abort` and `Throttle::is_finished`. A throttle spawned by
   `Throttle::spawn_interval` has no actor attached, so before this nothing could
   stop it short of shutting down the runtime.

--- a/actify/src/handles/read_handle.rs
+++ b/actify/src/handles/read_handle.rs
@@ -4,11 +4,13 @@ use tokio::sync::broadcast;
 
 use super::handle::{BroadcastAs, Handle};
 use crate::Cache;
+use crate::throttle::{BoxFuture, Frequency, Throttle, Throttled};
 
 /// A clonable read-only handle that can only be used to read the internal value.
 ///
 /// Obtained via [`Handle::get_read_handle`]. Supports [`ReadHandle::get`],
-/// [`ReadHandle::with`], [`ReadHandle::subscribe`], and [`ReadHandle::create_cache`].
+/// [`ReadHandle::with`], [`ReadHandle::subscribe`], [`ReadHandle::create_cache`],
+/// [`ReadHandle::spawn_throttle`], and [`ReadHandle::spawn_async_throttle`].
 pub struct ReadHandle<T, V = T>(Handle<T, V>);
 
 impl<T, V> ReadHandle<T, V> {
@@ -157,6 +159,51 @@ where
     /// panics](crate#actor-lifetime-and-panics).
     pub async fn create_cache(&self) -> Cache<V> {
         self.0.create_cache().await
+    }
+
+    /// Spawns a [`Throttle`] that fires given a specified [`Frequency`].
+    ///
+    /// See [`Handle::spawn_throttle`] for the callback forms and an example.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the actor has stopped, either because one of its methods
+    /// panicked or because its runtime shut down. See [Actor lifetime and
+    /// panics](crate#actor-lifetime-and-panics).
+    pub async fn spawn_throttle<C, F, Fun>(&self, client: C, call: Fun, freq: Frequency) -> Throttle
+    where
+        C: Send + Sync + 'static,
+        V: Throttled<F>,
+        F: Send + Sync + 'static,
+        Fun: Fn(&C, F) + Send + 'static,
+    {
+        self.0.spawn_throttle(client, call, freq).await
+    }
+
+    /// Spawns a [`Throttle`] whose callback is awaited before the next value is
+    /// looked for.
+    ///
+    /// `call` borrows the client and returns a [`BoxFuture`], built with
+    /// [`Box::pin`]. See [`Handle::spawn_async_throttle`] for how to write one.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the actor has stopped, either because one of its methods
+    /// panicked or because its runtime shut down. See [Actor lifetime and
+    /// panics](crate#actor-lifetime-and-panics).
+    pub async fn spawn_async_throttle<C, F, Fun>(
+        &self,
+        client: C,
+        call: Fun,
+        freq: Frequency,
+    ) -> Throttle
+    where
+        C: Send + Sync + 'static,
+        V: Throttled<F>,
+        F: Send + Sync + 'static,
+        Fun: for<'a> Fn(&'a C, F) -> BoxFuture<'a> + Send + 'static,
+    {
+        self.0.spawn_async_throttle(client, call, freq).await
     }
 }
 

--- a/actify/src/lib.rs
+++ b/actify/src/lib.rs
@@ -316,8 +316,8 @@
 //! # ReadHandle
 //!
 //! A [`ReadHandle`] is a read-only view of an actor. It supports [`get`](ReadHandle::get),
-//! [`subscribe`](ReadHandle::subscribe), and cache creation, but cannot mutate the actor.
-//! Obtain one via [`Handle::get_read_handle`].
+//! [`subscribe`](ReadHandle::subscribe), cache creation and throttle spawning, but
+//! cannot mutate the actor. Obtain one via [`Handle::get_read_handle`].
 //!
 //! # Throttle
 //!
@@ -332,8 +332,10 @@
 //! Use the [`Throttled`] trait to parse the actor's type into a different output type
 //! for the throttle callback.
 //!
-//! [`Handle::spawn_async_throttle`] and [`Cache::spawn_async_throttle`] take an
-//! async callback. Each call is awaited before the throttle looks for the next
+//! A throttle is spawned from a [`Handle`], a [`ReadHandle`] or a [`Cache`].
+//!
+//! [`Handle::spawn_async_throttle`], [`ReadHandle::spawn_async_throttle`] and
+//! [`Cache::spawn_async_throttle`] take an async callback. Each call is awaited before the throttle looks for the next
 //! value, so a callback slower than the [`Frequency`] delays the following send
 //! rather than running alongside it.
 //!

--- a/actify/src/throttle.rs
+++ b/actify/src/throttle.rs
@@ -1009,6 +1009,22 @@ mod tests {
         }
 
         #[tokio::test(start_paused = true)]
+        async fn test_a_read_handle_can_spawn_one() {
+            let handle = Handle::new(1);
+            let read_handle = handle.get_read_handle();
+            let (writer, mut received) = writer();
+
+            let _throttle = read_handle
+                .spawn_async_throttle(writer, write, Frequency::OnEvent)
+                .await;
+
+            handle.set(2).await;
+
+            assert_eq!(next_sent(&mut received).await, Some(1));
+            assert_eq!(next_sent(&mut received).await, Some(2));
+        }
+
+        #[tokio::test(start_paused = true)]
         async fn test_a_cache_can_spawn_one() {
             let handle = Handle::new(1);
             let mut cache = handle.create_cache().await;
@@ -1244,6 +1260,27 @@ mod tests {
 
         // Synchronizing counts as receiving: the cache holds the value too
         assert_eq!(cache.get_current(), &2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_throttle_from_read_handle() {
+        let handle = Handle::new(1);
+        let read_handle = handle.get_read_handle();
+        let counter = CounterClient::new();
+
+        read_handle
+            .spawn_throttle(counter.clone(), CounterClient::call, Frequency::OnEvent)
+            .await;
+        sleep(PERIOD).await;
+
+        assert_eq!(*counter.last.lock().unwrap(), Some(1));
+        assert_eq!(*counter.count.lock().unwrap(), 1);
+
+        handle.set(2).await;
+        sleep(PERIOD).await;
+
+        assert_eq!(*counter.last.lock().unwrap(), Some(2));
+        assert_eq!(*counter.count.lock().unwrap(), 2);
     }
 
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
`ReadHandle` had neither `spawn_throttle` nor `spawn_async_throttle`. #95 left the async one out on purpose: adding it alone would have made the read handle async-only while `Handle` and `Cache` have both. This adds the pair.

Both delegate to the inner `Handle`, so a read handle inherits the subscribe-before-get ordering from `fba35d4` and the initial fire carrying the current value. Bounds match `Handle`'s exactly, and they live in the impl block that already carries `T: Clone + BroadcastAs<V>` and `V: Clone + Send + Sync + 'static`.

Closes the "ReadHandle lacks spawn_throttle" known issue.

## Commits

1. `test:` two tests that fail to compile on main, one per spawn.
2. The two methods, plus the doc lines in `lib.rs` and `ReadHandle` that listed what a read handle supports.

## Verification

`test_throttle_from_read_handle` checks both the initial fire and an update afterwards, by value and by call count. `test_a_read_handle_can_spawn_one` does the same through the async callback used by the rest of that module.

Mutation-verified: replacing either delegation with a fresh subscription and no initial value (`Throttle::spawn_from_receiver(.., self.subscribe(), None)`) fails both tests.

Full local gate green: workspace tests, `-p actify`, clippy `--all-targets --all-features -D warnings`, fmt, and docs with `-D warnings` both with and without `--all-features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)