### PR TITLE
Configure channel capacities with Handle::builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
   cloned nor required to be `Clone`. A future that borrows carries the lifetime
   of that borrow in its type, which a plain generic return type cannot express,
   hence the box. `BoxFuture` is exported for naming the bound.
+- `Handle::builder`, which sets the job channel and broadcast channel capacities
+  independently before spawning the actor:
+  `Handle::builder(val).job_capacity(8).broadcast_capacity(1024).spawn()`. Both
+  still default to 100, which is what `Handle::new` uses. Before this a single
+  internal constant sized both channels, so a burst of queued calls and a
+  subscriber that reads rarely could not be accommodated separately.
 - `ReadHandle::spawn_throttle` and `ReadHandle::spawn_async_throttle`, so a
   throttle can be spawned from a read-only view of an actor. Both behave as
   their `Handle` counterparts.

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -936,7 +936,7 @@ mod tests {
     /// capacity up internally, so twice the configured size is sent.
     /// Returns the last value sent, which the channel always retains.
     async fn overflow(handle: &Handle<i32>) -> i32 {
-        let last = (2 * crate::handles::CHANNEL_SIZE) as i32;
+        let last = (2 * crate::handles::DEFAULT_BROADCAST_CAPACITY) as i32;
         for i in 1..=last {
             handle.set(i).await;
         }

--- a/actify/src/handles/builder.rs
+++ b/actify/src/handles/builder.rs
@@ -1,3 +1,102 @@
+use std::any::type_name;
+use std::fmt::{self, Debug};
+use std::marker::PhantomData;
+
+use super::handle::{BroadcastAs, Handle};
+
+/// The number of queued jobs a [`Handle`] accepts before callers wait.
+pub(crate) const DEFAULT_JOB_CAPACITY: usize = 100;
+
+/// The number of broadcast values a subscriber may fall behind by before it lags.
+pub(crate) const DEFAULT_BROADCAST_CAPACITY: usize = 100;
+
+/// Configures the channel capacities of a [`Handle`] before spawning its actor.
+///
+/// Obtained via [`Handle::builder`]. Both capacities default to 100.
+///
+/// # Examples
+///
+/// ```
+/// # use actify::Handle;
+/// # #[tokio::main]
+/// # async fn main() {
+/// let handle: Handle<i32> = Handle::builder(1)
+///     .job_capacity(8)
+///     .broadcast_capacity(1024)
+///     .spawn();
+///
+/// assert_eq!(handle.get().await, 1);
+/// # }
+/// ```
+pub struct HandleBuilder<T, V = T> {
+    value: T,
+    job_capacity: usize,
+    broadcast_capacity: usize,
+    broadcast_type: PhantomData<fn() -> V>,
+}
+
+impl<T, V> Debug for HandleBuilder<T, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct(&format!("HandleBuilder<{}>", type_name::<T>()))
+            .field("job_capacity", &self.job_capacity)
+            .field("broadcast_capacity", &self.broadcast_capacity)
+            .finish()
+    }
+}
+
+impl<T, V> HandleBuilder<T, V> {
+    pub(super) fn new(value: T) -> Self {
+        HandleBuilder {
+            value,
+            job_capacity: DEFAULT_JOB_CAPACITY,
+            broadcast_capacity: DEFAULT_BROADCAST_CAPACITY,
+            broadcast_type: PhantomData,
+        }
+    }
+
+    /// Sets how many jobs may queue before callers wait for a slot.
+    ///
+    /// A job is one method call on the handle. The actor runs one at a time, so
+    /// this bounds how far callers may run ahead of it before
+    /// [`Handle::capacity`] reaches zero and the next caller waits.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `capacity` is zero.
+    pub fn job_capacity(mut self, capacity: usize) -> Self {
+        assert!(capacity > 0, "job_capacity must be greater than zero");
+        self.job_capacity = capacity;
+        self
+    }
+
+    /// Sets how many broadcast values a subscriber may fall behind by.
+    ///
+    /// A subscriber that falls further behind loses the oldest values and is
+    /// told how many by [`RecvError::Lagged`](tokio::sync::broadcast::error::RecvError::Lagged),
+    /// or by [`CacheRecvError::Lagged`](crate::CacheRecvError::Lagged) when it reads through a
+    /// [`Cache`](crate::Cache). Tokio rounds this up to a power of two.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `capacity` is zero.
+    pub fn broadcast_capacity(mut self, capacity: usize) -> Self {
+        assert!(capacity > 0, "broadcast_capacity must be greater than zero");
+        self.broadcast_capacity = capacity;
+        self
+    }
+}
+
+impl<T, V> HandleBuilder<T, V>
+where
+    T: BroadcastAs<V> + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    /// Spawns the actor and returns its [`Handle`].
+    pub fn spawn(self) -> Handle<T, V> {
+        Handle::spawn_with(self.value, self.job_capacity, self.broadcast_capacity)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::Handle;
@@ -36,6 +135,22 @@ mod tests {
             handle.set(value).await;
         }
 
-        assert_eq!(rx.recv().await, Ok(1), "the default broadcast capacity lags");
+        assert_eq!(
+            rx.recv().await,
+            Ok(1),
+            "the default broadcast capacity lags"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[should_panic(expected = "job_capacity must be greater than zero")]
+    async fn test_a_zero_job_capacity_panics() {
+        let _ = Handle::<i32>::builder(0).job_capacity(0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[should_panic(expected = "broadcast_capacity must be greater than zero")]
+    async fn test_a_zero_broadcast_capacity_panics() {
+        let _ = Handle::<i32>::builder(0).broadcast_capacity(0);
     }
 }

--- a/actify/src/handles/builder.rs
+++ b/actify/src/handles/builder.rs
@@ -1,0 +1,41 @@
+#[cfg(test)]
+mod tests {
+    use crate::Handle;
+    use tokio::sync::broadcast::error::RecvError;
+
+    const SENT: i32 = 3;
+
+    #[tokio::test(start_paused = true)]
+    async fn test_the_job_capacity_is_configurable() {
+        let handle: Handle<i32> = Handle::builder(0).job_capacity(5).spawn();
+
+        assert_eq!(handle.capacity(), 5);
+        assert_ne!(Handle::new(0).capacity(), 5, "5 is the default capacity");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_the_broadcast_capacity_is_configurable() {
+        let handle: Handle<i32> = Handle::builder(0).broadcast_capacity(2).spawn();
+        let mut rx = handle.subscribe();
+
+        for value in 1..=SENT {
+            handle.set(value).await;
+        }
+
+        assert_eq!(rx.recv().await, Err(RecvError::Lagged(1)));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_the_defaults_match_new() {
+        let handle: Handle<i32> = Handle::builder(0).spawn();
+        let mut rx = handle.subscribe();
+
+        assert_eq!(handle.capacity(), Handle::new(0).capacity());
+
+        for value in 1..=SENT {
+            handle.set(value).await;
+        }
+
+        assert_eq!(rx.recv().await, Ok(1), "the default broadcast capacity lags");
+    }
+}

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -3,12 +3,11 @@ use std::any::type_name;
 use std::fmt::{self, Debug};
 use tokio::sync::{broadcast, mpsc, oneshot, watch};
 
+use super::builder::{DEFAULT_BROADCAST_CAPACITY, DEFAULT_JOB_CAPACITY, HandleBuilder};
 use super::read_handle::ReadHandle;
 use crate::actor::{Actor, ActorExit, ActorMethod, BroadcastFn, ExitState, Job, serve};
 use crate::throttle::{BoxFuture, Throttle};
 use crate::{Cache, Frequency, Throttled};
-
-pub(crate) const CHANNEL_SIZE: usize = 100;
 const DOWNCAST_FAIL: &str =
     "Actify Macro error: failed to downcast arguments to their concrete type";
 
@@ -140,8 +139,40 @@ where
     /// # }
     /// ```
     pub fn new(val: T) -> Handle<T, V> {
-        let (tx, rx) = mpsc::channel(CHANNEL_SIZE);
-        let (broadcast_tx, _) = broadcast::channel::<V>(CHANNEL_SIZE);
+        Handle::spawn_with(val, DEFAULT_JOB_CAPACITY, DEFAULT_BROADCAST_CAPACITY)
+    }
+
+    /// Configures the channel capacities before spawning the actor.
+    ///
+    /// [`Handle::new`] uses the defaults, which are documented on
+    /// [`HandleBuilder`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::Handle;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// // Room for a burst of queued calls, and subscribers that read rarely
+    /// let handle: Handle<i32> = Handle::builder(1)
+    ///     .job_capacity(1024)
+    ///     .broadcast_capacity(1024)
+    ///     .spawn();
+    ///
+    /// assert_eq!(handle.capacity(), 1024);
+    /// # }
+    /// ```
+    pub fn builder(val: T) -> HandleBuilder<T, V> {
+        HandleBuilder::new(val)
+    }
+
+    pub(super) fn spawn_with(
+        val: T,
+        job_capacity: usize,
+        broadcast_capacity: usize,
+    ) -> Handle<T, V> {
+        let (tx, rx) = mpsc::channel(job_capacity);
+        let (broadcast_tx, _) = broadcast::channel::<V>(broadcast_capacity);
         let (exit_tx, exit_rx) = watch::channel(None);
         tokio::spawn(serve(
             rx,
@@ -888,7 +919,7 @@ mod tests {
         let handle = Handle::new(Ledger { seen: Vec::new() });
 
         let mut calls = tokio::task::JoinSet::new();
-        for i in 0..2 * CHANNEL_SIZE {
+        for i in 0..2 * DEFAULT_JOB_CAPACITY {
             let handle = handle.clone();
             calls.spawn(async move { handle.record(i).await });
         }
@@ -896,7 +927,7 @@ mod tests {
 
         let mut seen = handle.with(|ledger| ledger.seen.clone()).await;
         seen.sort();
-        assert_eq!(seen, (0..2 * CHANNEL_SIZE).collect::<Vec<_>>());
+        assert_eq!(seen, (0..2 * DEFAULT_JOB_CAPACITY).collect::<Vec<_>>());
     }
 
     #[derive(Debug, Clone)]

--- a/actify/src/handles/mod.rs
+++ b/actify/src/handles/mod.rs
@@ -1,3 +1,4 @@
+mod builder;
 mod handle;
 mod read_handle;
 

--- a/actify/src/handles/mod.rs
+++ b/actify/src/handles/mod.rs
@@ -3,6 +3,8 @@ mod handle;
 mod read_handle;
 
 #[cfg(test)]
-pub(crate) use handle::CHANNEL_SIZE;
+pub(crate) use builder::DEFAULT_BROADCAST_CAPACITY;
+
+pub use builder::HandleBuilder;
 pub use handle::{BroadcastAs, Handle};
 pub use read_handle::ReadHandle;

--- a/actify/src/lib.rs
+++ b/actify/src/lib.rs
@@ -379,6 +379,8 @@
 //! that actor.
 //!
 //! Jobs queue in a bounded channel, so callers wait when it is full.
+//! [`Handle::builder`] sets that bound and the broadcast bound separately; both
+//! default to 100.
 //!
 //! Two actors that call each other never return: each waits for a reply the
 //! other can only produce once it is free. The same holds for a method calling
@@ -455,7 +457,7 @@ pub use cache::{Cache, CacheRecvError, CacheRecvNewestError};
 pub use extensions::{
     map::HashMapHandle, option::OptionHandle, set::HashSetHandle, vec::VecHandle,
 };
-pub use handles::{BroadcastAs, Handle, ReadHandle};
+pub use handles::{BroadcastAs, Handle, HandleBuilder, ReadHandle};
 pub use throttle::{BoxFuture, Frequency, Throttle, Throttled};
 
 #[doc(hidden)]


### PR DESCRIPTION
Item 7 of the 0.9.0 plan. One constant, `CHANNEL_SIZE = 100`, sized both the job mpsc and the broadcast channel. Those two bounds mean unrelated things: one is how far callers may run ahead of the actor, the other is how far a subscriber may fall behind. They now have separate defaults and a builder to set them.

```rust
let handle: Handle<i32> = Handle::builder(1)
    .job_capacity(8)
    .broadcast_capacity(1024)
    .spawn();
```

`Handle::new` stays and is unchanged in behaviour: it calls the same spawn path with both defaults still 100.

## Notes for review

**`job_capacity`, not `request_capacity`.** The plan wrote `request_capacity`, but the crate already calls these things jobs: `Job<T>`, `send_job`, the lib.rs line "Jobs queue in a bounded channel", and the existing test `test_callers_wait_when_the_job_channel_is_full`. Introducing a second word for the same thing seemed worse than following the plan literally.

**Zero is rejected at the setter, not at spawn.** Both tokio channels panic on a zero capacity, and `broadcast`'s message is just "capacity is empty", which does not say which of the two capacities was wrong. The setters assert with their own name in the message, so the panic points at the call site of the mistake.

**`HandleBuilder` has a manual `Debug`.** `#[derive(Debug)]` would add `T: Debug` and `V: Debug` bounds, which the builder does not otherwise need. It prints the type name and both capacities, matching how `Handle` prints.

`PhantomData<fn() -> V>` rather than `PhantomData<V>`, so the builder is `Send`/`Sync` regardless of `V`.

## Verification

Three behavioural tests plus two on the zero assertion. Job capacity is observed through `Handle::capacity`; broadcast capacity through the lag a subscriber reports, using a power-of-two capacity since tokio rounds up.

Mutation-verified, four mutations, each killing exactly the test that should catch it:

| Mutation | Result |
| --- | --- |
| Swap the two capacities in the spawn path | both capacity tests fail |
| `job_capacity` ignores its argument | job capacity test fails |
| `broadcast_capacity` ignores its argument | broadcast capacity test fails |
| Drop the `job_capacity` zero assertion | zero-capacity test fails |

The defaults test asserts the builder and `Handle::new` agree, and deliberately does not encode 100.

Full local gate green: workspace tests, `-p actify`, clippy `--all-targets --all-features -D warnings`, fmt, docs with `-D warnings` both with and without `--all-features`, and a 1.85 MSRV check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)