### PR TITLE
Wait until a predicate holds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,15 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 
 ### Changed
 
+- `Handle::create_cache`, `Handle::spawn_throttle` and `Handle::spawn_async_throttle`,
+  and their `ReadHandle` counterparts, no longer require the actor type to be
+  `Clone`. Each of them seeded itself by cloning the whole actor value out with
+  `get` and deriving the broadcast value from that clone. They now ask the actor
+  to derive it in place, which drops the bound and the clone: a
+  `Handle<BigState, Summary>` no longer copies all of `BigState` to create a
+  cache, and actor types that are not `Clone` can now use both.
+
+
 - **Breaking:** `Cache::spawn_throttle` takes `&mut self` and first
   synchronizes the cache to the newest broadcast value, which becomes the
   throttle's initial fire. Previously the throttle got a fresh subscription

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
   cloned nor required to be `Clone`. A future that borrows carries the lifetime
   of that borrow in its type, which a plain generic return type cannot express,
   hence the box. `BoxFuture` is exported for naming the bound.
-- `Handle::wait_until`, `ReadHandle::wait_until` and `Cache::wait_for`, which
+- `Handle::wait_until`, `ReadHandle::wait_until` and `Cache::wait_until`, which
   wait until the broadcast value satisfies a predicate and return the value that
   satisfied it. The current value is tested first, so a predicate that already
   holds returns without waiting for an update.
@@ -42,7 +42,7 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
   The predicate takes the broadcast type, which the actor produces without
   cloning itself, so waiting works on non-Clone actor types. `Handle::wait_until`
   panics if the actor stops while it waits, as the other handle methods do;
-  `Cache::wait_for` returns `CacheRecvNewestError::Closed`.
+  `Cache::wait_until` returns `CacheRecvNewestError::Closed`.
 - `ReadHandle::spawn_throttle` and `ReadHandle::spawn_async_throttle`, so a
   throttle can be spawned from a read-only view of an actor. Both behave as
   their `Handle` counterparts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,11 +33,9 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
   satisfied it. The current value is tested first, so a predicate that already
   holds returns without waiting for an update.
 
-  Every value is tested in the order it was broadcast, including values the actor
-  has already moved past, so a state the actor passed through still ends the
-  wait. The value returned may therefore be older than the actor's current one.
-  A lagging receiver is the one case where a matching value can be missed: it is
-  logged and the wait continues.
+  Every value is tested in the order it was broadcast, so a state the actor has
+  since moved past still ends the wait. A lagging receiver is the one case where
+  a matching value can be missed: it is logged and the wait continues.
 
   The predicate takes the broadcast type, which the actor produces without
   cloning itself, so waiting works on non-Clone actor types. `Handle::wait_until`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,21 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
   cloned nor required to be `Clone`. A future that borrows carries the lifetime
   of that borrow in its type, which a plain generic return type cannot express,
   hence the box. `BoxFuture` is exported for naming the bound.
+- `Handle::wait_until`, `ReadHandle::wait_until` and `Cache::wait_for`, which
+  wait until the broadcast value satisfies a predicate and return the value that
+  satisfied it. The current value is tested first, so a predicate that already
+  holds returns without waiting for an update.
+
+  Every value is tested in the order it was broadcast, including values the actor
+  has already moved past, so a state the actor passed through still ends the
+  wait. The value returned may therefore be older than the actor's current one.
+  A lagging receiver is the one case where a matching value can be missed: it is
+  logged and the wait continues.
+
+  The predicate takes the broadcast type, which the actor produces without
+  cloning itself, so waiting works on non-Clone actor types. `Handle::wait_until`
+  panics if the actor stops while it waits, as the other handle methods do;
+  `Cache::wait_for` returns `CacheRecvNewestError::Closed`.
 - `ReadHandle::spawn_throttle` and `ReadHandle::spawn_async_throttle`, so a
   throttle can be spawned from a read-only view of an actor. Both behave as
   their `Handle` counterparts.

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -591,11 +591,11 @@ where
     /// let setter = handle.clone();
     /// tokio::spawn(async move { setter.set(3).await });
     ///
-    /// assert_eq!(cache.wait_for(|value| *value == 3).await, Ok(&3));
+    /// assert_eq!(cache.wait_until(|value| *value == 3).await, Ok(&3));
     /// assert_eq!(cache.get_current(), &3);
     /// # }
     /// ```
-    pub async fn wait_for<P>(&mut self, mut predicate: P) -> Result<&T, CacheRecvNewestError>
+    pub async fn wait_until<P>(&mut self, mut predicate: P) -> Result<&T, CacheRecvNewestError>
     where
         P: FnMut(&T) -> bool,
     {
@@ -736,7 +736,7 @@ mod tests {
             let mut cache = handle.create_cache().await;
             let start = Instant::now();
 
-            assert_eq!(finished(cache.wait_for(|v| *v == 7)).await, Ok(&7));
+            assert_eq!(finished(cache.wait_until(|v| *v == 7)).await, Ok(&7));
             assert_eq!(start.elapsed(), Duration::ZERO);
         }
 
@@ -752,7 +752,7 @@ mod tests {
                 }
             });
 
-            assert_eq!(finished(cache.wait_for(|v| *v == 3)).await, Ok(&3));
+            assert_eq!(finished(cache.wait_until(|v| *v == 3)).await, Ok(&3));
             assert_eq!(cache.get_current(), &3);
         }
 
@@ -767,7 +767,7 @@ mod tests {
             handle.set(1).await;
             handle.set(2).await;
 
-            assert_eq!(finished(cache.wait_for(|v| *v == 1)).await, Ok(&1));
+            assert_eq!(finished(cache.wait_until(|v| *v == 1)).await, Ok(&1));
         }
 
         #[tokio::test(start_paused = true)]
@@ -777,7 +777,7 @@ mod tests {
             drop(handle);
 
             assert_eq!(
-                finished(cache.wait_for(|v| *v == 9)).await,
+                finished(cache.wait_until(|v| *v == 9)).await,
                 Err(CacheRecvNewestError::Closed)
             );
         }

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -663,6 +663,70 @@ mod tests {
     use crate::Handle;
     use tokio::time::{Duration, sleep};
 
+    mod waiting {
+        use super::*;
+        use tokio::time::{Instant, timeout};
+
+        const PERIOD: Duration = Duration::from_millis(100);
+
+        /// Fails rather than hanging when the wait never ends.
+        async fn finished<T>(wait: impl std::future::Future<Output = T>) -> T {
+            timeout(PERIOD * 10, wait).await.expect("the wait never ended")
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn test_a_satisfied_predicate_returns_without_waiting() {
+            let handle = Handle::new(7);
+            let mut cache = handle.create_cache().await;
+            let start = Instant::now();
+
+            assert_eq!(finished(cache.wait_for(|v| *v == 7)).await, Ok(&7));
+            assert_eq!(start.elapsed(), Duration::ZERO);
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn test_the_wait_ends_on_the_matching_update() {
+            let handle = Handle::new(0);
+            let mut cache = handle.create_cache().await;
+            let setter = handle.clone();
+            tokio::spawn(async move {
+                for value in [1, 2, 3] {
+                    sleep(PERIOD).await;
+                    setter.set(value).await;
+                }
+            });
+
+            assert_eq!(finished(cache.wait_for(|v| *v == 3)).await, Ok(&3));
+            assert_eq!(cache.get_current(), &3);
+        }
+
+        /// Every queued value is tested, including one the actor has already
+        /// moved past. Skipping to the newest value would miss the 1 entirely
+        /// and wait forever.
+        #[tokio::test(start_paused = true)]
+        async fn test_a_value_the_actor_has_moved_past_still_matches() {
+            let handle = Handle::new(0);
+            let mut cache = handle.create_cache().await;
+
+            handle.set(1).await;
+            handle.set(2).await;
+
+            assert_eq!(finished(cache.wait_for(|v| *v == 1)).await, Ok(&1));
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn test_a_dropped_actor_ends_the_wait() {
+            let handle = Handle::new(0);
+            let mut cache = handle.create_cache().await;
+            drop(handle);
+
+            assert_eq!(
+                finished(cache.wait_for(|v| *v == 9)).await,
+                Err(CacheRecvNewestError::Closed)
+            );
+        }
+    }
+
     #[tokio::test(start_paused = true)]
     async fn test_create_cache_update_during_construction() {
         let handle = Handle::new(1);

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -564,6 +564,60 @@ where
         }
     }
 
+    /// Waits until the cached value satisfies `predicate` and returns it.
+    ///
+    /// Reads through the cache, so the value that satisfied the predicate is the
+    /// one the cache holds afterwards. Every queued value is tested in the order
+    /// it was sent, including values the actor has already moved past, so the
+    /// value returned may no longer be the actor's current value.
+    ///
+    /// Counts as the cache's first read, which means a predicate satisfied by
+    /// the value the cache already holds returns without waiting.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CacheRecvNewestError::Closed`] once the actor has stopped and
+    /// every update it broadcast has been tested.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::Handle;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(0);
+    /// let mut cache = handle.create_cache().await;
+    ///
+    /// let setter = handle.clone();
+    /// tokio::spawn(async move { setter.set(3).await });
+    ///
+    /// assert_eq!(cache.wait_for(|value| *value == 3).await, Ok(&3));
+    /// assert_eq!(cache.get_current(), &3);
+    /// # }
+    /// ```
+    pub async fn wait_for<P>(&mut self, mut predicate: P) -> Result<&T, CacheRecvNewestError>
+    where
+        P: FnMut(&T) -> bool,
+    {
+        if self.is_first_request() && predicate(self.get_current()) {
+            return Ok(&self.inner);
+        }
+
+        loop {
+            match self.rx.recv().await {
+                Ok(value) => {
+                    if predicate(self.store(value)) {
+                        return Ok(&self.inner);
+                    }
+                }
+                // Values were dropped, so one of them may have satisfied the
+                // predicate. Nothing can recover them, so the wait goes on.
+                Err(RecvError::Lagged(nr)) => log_lag::<T>(nr),
+                Err(RecvError::Closed) => return Err(CacheRecvNewestError::Closed),
+            }
+        }
+    }
+
     /// Spawns a [`Throttle`] that fires given a specified [`Frequency`], given any broadcasted updates by the actor.
     ///
     /// First synchronizes the cache to the newest broadcast value, which
@@ -671,7 +725,9 @@ mod tests {
 
         /// Fails rather than hanging when the wait never ends.
         async fn finished<T>(wait: impl std::future::Future<Output = T>) -> T {
-            timeout(PERIOD * 10, wait).await.expect("the wait never ended")
+            timeout(PERIOD * 10, wait)
+                .await
+                .expect("the wait never ended")
         }
 
         #[tokio::test(start_paused = true)]

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -567,9 +567,11 @@ where
     /// Waits until the cached value satisfies `predicate` and returns it.
     ///
     /// Reads through the cache, so the value that satisfied the predicate is the
-    /// one the cache holds afterwards. Every queued value is tested in the order
-    /// it was sent, including values the actor has already moved past, so the
-    /// value returned may no longer be the actor's current value.
+    /// one the cache holds afterwards. Tests the value the cache holds, then
+    /// each value queued in it, then values as they are broadcast, in the order
+    /// they were sent, except values lost while the cache was behind, which are
+    /// logged. The value returned may be older than the value the actor holds by
+    /// then.
     ///
     /// Counts as the cache's first read, which means a predicate satisfied by
     /// the value the cache already holds returns without waiting.
@@ -677,7 +679,7 @@ where
 
 fn log_lag<T>(nr: u64) {
     log::debug!(
-        "Cache of actor type {} lagged {nr:?} messages",
+        "A receiver on actor type {} lagged {nr:?} messages",
         std::any::type_name::<T>()
     );
 }

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -570,8 +570,7 @@ where
     /// one the cache holds afterwards. Tests the value the cache holds, then
     /// each value queued in it, then values as they are broadcast, in the order
     /// they were sent, except values lost while the cache was behind, which are
-    /// logged. The value returned may be older than the value the actor holds by
-    /// then.
+    /// logged.
     ///
     /// Counts as the cache's first read, which means a predicate satisfied by
     /// the value the cache already holds returns without waiting.

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -811,6 +811,95 @@ mod tests {
         });
     }
 
+    mod waiting {
+        use super::*;
+        use tokio::time::{Duration, Instant, sleep, timeout};
+
+        const PERIOD: Duration = Duration::from_millis(100);
+
+        /// Fails rather than hanging when the wait never ends.
+        async fn finished<T>(wait: impl Future<Output = T>) -> T {
+            timeout(PERIOD * 10, wait).await.expect("the wait never ended")
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn test_a_satisfied_predicate_returns_without_waiting() {
+            let handle = Handle::new(7);
+            let start = Instant::now();
+
+            assert_eq!(finished(handle.wait_until(|v| *v == 7)).await, 7);
+            assert_eq!(start.elapsed(), Duration::ZERO);
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn test_the_wait_ends_on_the_matching_update() {
+            let handle = Handle::new(0);
+            let setter = handle.clone();
+            tokio::spawn(async move {
+                sleep(PERIOD).await;
+                setter.set(9).await;
+            });
+
+            let start = Instant::now();
+
+            assert_eq!(finished(handle.wait_until(|v| *v == 9)).await, 9);
+            assert_eq!(start.elapsed(), PERIOD);
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn test_updates_that_do_not_match_are_skipped() {
+            let handle = Handle::new(0);
+            let setter = handle.clone();
+            tokio::spawn(async move {
+                for value in [1, 2, 3] {
+                    sleep(PERIOD).await;
+                    setter.set(value).await;
+                }
+            });
+
+            assert_eq!(finished(handle.wait_until(|v| *v == 3)).await, 3);
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn test_an_update_during_construction_is_not_lost() {
+            let handle = Handle::new(1);
+            let setter = handle.clone();
+            // On the current-thread test runtime this task first runs when
+            // wait_until awaits the actor, so the update is broadcast exactly
+            // between its subscribe and its read.
+            let update = tokio::spawn(async move { setter.set(2).await });
+
+            assert_eq!(finished(handle.wait_until(|v| *v == 2)).await, 2);
+            update.await.unwrap();
+        }
+
+        /// The predicate runs on the broadcast type, so the actor type itself
+        /// never has to be cloned or even be `Clone`.
+        #[tokio::test(start_paused = true)]
+        async fn test_a_non_clone_actor_can_be_waited_on() {
+            let handle: Handle<NonCloneActor, i32> = Handle::new(NonCloneActor { value: 1 });
+            let setter = handle.clone();
+            tokio::spawn(async move { setter.set_value(2).await });
+
+            assert_eq!(finished(handle.wait_until(|value| *value == 2)).await, 2);
+        }
+
+        #[tokio::test]
+        async fn test_a_dead_actor_ends_the_wait_with_a_panic() {
+            let handle = Handle::new(PanicStruct {});
+            let waiter = handle.clone();
+            let wait = tokio::spawn(async move { waiter.wait_until(|_| false).await });
+
+            let _ = tokio::spawn(async move { handle.panic().await }).await;
+
+            let message = panic_message(wait.await.unwrap_err());
+            assert!(
+                message.contains("A panic occurred in the Actor"),
+                "expected the actor's panic to be reported, got: {message}"
+            );
+        }
+    }
+
     fn panic_message(error: tokio::task::JoinError) -> String {
         let panic = error.into_panic();
         panic

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -1012,6 +1012,80 @@ mod tests {
         }
     }
 
+    /// Deriving the broadcast value inside the actor means the actor value
+    /// itself is never cloned, so these work on actor types that are not Clone.
+    mod broadcast_derivation {
+        use super::*;
+        use crate::Frequency;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::{Arc, Mutex};
+
+        #[tokio::test]
+        async fn test_a_non_clone_actor_can_create_a_cache() {
+            let handle: Handle<NonCloneActor, i32> = Handle::new(NonCloneActor { value: 1 });
+
+            let cache = handle.create_cache().await;
+
+            assert_eq!(cache.get_current(), &1);
+        }
+
+        #[tokio::test]
+        async fn test_a_non_clone_actor_can_spawn_a_throttle() {
+            let handle: Handle<NonCloneActor, i32> = Handle::new(NonCloneActor { value: 1 });
+            let seen = Arc::new(Mutex::new(Vec::new()));
+            let sink = seen.clone();
+
+            let throttle = handle
+                .spawn_throttle(
+                    sink,
+                    |sink: &Arc<Mutex<Vec<i32>>>, value: i32| sink.lock().unwrap().push(value),
+                    Frequency::OnEvent,
+                )
+                .await;
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+            assert_eq!(*seen.lock().unwrap(), vec![1]);
+            throttle.abort();
+        }
+
+        /// Counts every clone of the actor value.
+        #[derive(Debug)]
+        struct Counted {
+            clones: Arc<AtomicUsize>,
+            value: i32,
+        }
+
+        impl Clone for Counted {
+            fn clone(&self) -> Self {
+                self.clones.fetch_add(1, Ordering::SeqCst);
+                Counted {
+                    clones: self.clones.clone(),
+                    value: self.value,
+                }
+            }
+        }
+
+        impl BroadcastAs<i32> for Counted {
+            fn to_broadcast(&self) -> i32 {
+                self.value
+            }
+        }
+
+        #[tokio::test]
+        async fn test_creating_a_cache_does_not_clone_the_actor_value() {
+            let clones = Arc::new(AtomicUsize::new(0));
+            let handle: Handle<Counted, i32> = Handle::new(Counted {
+                clones: clones.clone(),
+                value: 1,
+            });
+
+            let cache = handle.create_cache().await;
+
+            assert_eq!(cache.get_current(), &1);
+            assert_eq!(clones.load(Ordering::SeqCst), 0);
+        }
+    }
+
     fn panic_message(error: tokio::task::JoinError) -> String {
         let panic = error.into_panic();
         panic

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -498,9 +498,7 @@ where
     /// Tests the actor's current value first, so a predicate that already holds
     /// returns without waiting for an update. Every value broadcast after that
     /// is tested in the order it was sent, except values lost while the receiver
-    /// was behind, which are logged. The value returned is the one that
-    /// satisfied the predicate, which may be older than the value the actor
-    /// holds by then.
+    /// was behind, which are logged.
     ///
     /// The predicate receives the broadcast type `V`, which the actor produces
     /// without cloning itself, so this works on non-Clone actor types.

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -925,7 +925,10 @@ mod tests {
                 }
             });
 
+            let start = Instant::now();
+
             assert_eq!(finished(handle.wait_until(|v| *v == 3)).await, 3);
+            assert_eq!(start.elapsed(), PERIOD * 3);
         }
 
         #[tokio::test(start_paused = true)]

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -895,6 +895,12 @@ mod tests {
                 .expect("the wait never ended")
         }
 
+        /// Whether the future is still waiting after several periods. The clock
+        /// is paused in these tests, so the wait costs no real time.
+        async fn still_waiting<T>(wait: impl Future<Output = T>) -> bool {
+            timeout(PERIOD * 10, wait).await.is_err()
+        }
+
         #[tokio::test(start_paused = true)]
         async fn test_a_satisfied_predicate_returns_without_waiting() {
             let handle = Handle::new(7);
@@ -966,8 +972,40 @@ mod tests {
             assert_eq!(finished(read_handle.wait_until(|v| *v == 5)).await, 5);
         }
 
-        /// A handle holds a broadcast sender, so a waiting handle keeps its own
-        /// channel open and cannot learn from it that the actor is gone.
+        /// A dead actor closes the job channel but not the broadcast channel.
+        /// A broadcast channel closes when its last sender drops, and a `Handle`
+        /// owns one, so code waiting on a subscription taken from a handle is
+        /// holding that channel open itself. This is why [`Handle::wait_until`]
+        /// watches the exit signal and not only its receiver: on this path
+        /// `recv` waits forever.
+        #[tokio::test(start_paused = true)]
+        async fn test_a_handle_keeps_its_own_broadcast_channel_open() {
+            let handle = Handle::new(PanicStruct {});
+            let mut receiver = handle.subscribe();
+
+            let killer = handle.clone();
+            let killed = tokio::spawn(async move { killer.panic().await }).await;
+            assert!(killed.is_err(), "the actor must be dead for the rest");
+
+            let caller = handle.clone();
+            let call = tokio::spawn(async move { caller.get().await }).await;
+            assert!(call.is_err(), "a call through the job channel panics");
+
+            assert!(
+                still_waiting(receiver.recv()).await,
+                "the subscription reported the actor gone while a handle held a sender"
+            );
+
+            drop(handle);
+            assert!(
+                matches!(
+                    receiver.recv().await,
+                    Err(broadcast::error::RecvError::Closed)
+                ),
+                "dropping the last sender closes the channel"
+            );
+        }
+
         #[tokio::test(start_paused = true)]
         async fn test_a_dead_actor_ends_the_wait_with_a_panic() {
             let handle = Handle::new(PanicStruct {});

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -237,7 +237,7 @@ impl<T: Send + Sync + 'static, V> Handle<T, V> {
             respond_to,
         };
         if self.tx.send(job).await.is_err() {
-            return self.report_actor_gone().await;
+            self.report_actor_gone().await;
         }
         match get_result.await {
             Ok(res) => res,
@@ -250,7 +250,7 @@ impl<T: Send + Sync + 'static, V> Handle<T, V> {
     /// The exit signal may not have been written yet when the channel first
     /// reports its failure, so this waits for it rather than guessing from
     /// scheduling order.
-    async fn report_actor_gone(&self) -> Box<dyn Any + Send> {
+    async fn report_actor_gone(&self) -> ! {
         if self.wait_for_exit().await == ActorExit::Panicked {
             panic!("A panic occurred in the Actor of type {}", type_name::<T>());
         }
@@ -485,6 +485,77 @@ impl<T, V: Default + Clone + Send + Sync + 'static> Handle<T, V> {
     /// or [`Handle::create_cache_from`] to start from a custom value.
     pub fn create_cache_from_default(&self) -> Cache<V> {
         self.create_cache_from(V::default())
+    }
+}
+
+impl<T, V> Handle<T, V>
+where
+    T: BroadcastAs<V> + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    /// Waits until the broadcast value satisfies `predicate` and returns it.
+    ///
+    /// Tests the actor's current value first, so a predicate that already holds
+    /// returns without waiting for an update. After that, every value the actor
+    /// broadcasts is tested in the order it was sent, including values the actor
+    /// has already moved past. The value returned is the one that satisfied the
+    /// predicate, which may no longer be the actor's current value.
+    ///
+    /// The predicate receives the broadcast type `V`, which the actor produces
+    /// without cloning itself, so this works on non-Clone actor types.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::Handle;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(0);
+    ///
+    /// let setter = handle.clone();
+    /// tokio::spawn(async move { setter.set(3).await });
+    ///
+    /// assert_eq!(handle.wait_until(|value| *value == 3).await, 3);
+    /// # }
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the actor has stopped, either because one of its methods
+    /// panicked or because its runtime shut down. See [Actor lifetime and
+    /// panics](crate#actor-lifetime-and-panics).
+    pub async fn wait_until<P>(&self, mut predicate: P) -> V
+    where
+        P: FnMut(&V) -> bool,
+    {
+        // Subscribe before reading, so an update arriving in between is queued
+        // rather than lost.
+        let mut receiver = self.subscribe();
+        let current = self.with(|inner| inner.to_broadcast()).await;
+        if predicate(&current) {
+            return current;
+        }
+
+        loop {
+            // This handle holds a broadcast sender, so the channel it is
+            // waiting on cannot report a stopped actor. The exit signal can.
+            let received = tokio::select! {
+                received = receiver.recv() => received,
+                _ = self.wait_for_exit() => self.report_actor_gone().await,
+            };
+
+            match received {
+                Ok(value) if predicate(&value) => return value,
+                Ok(_) => continue,
+                // Values were dropped, so one of them may have satisfied the
+                // predicate. Nothing can recover them, so the wait goes on.
+                Err(broadcast::error::RecvError::Lagged(nr)) => log::debug!(
+                    "A wait on actor type {} lagged {nr} messages",
+                    type_name::<T>()
+                ),
+                Err(broadcast::error::RecvError::Closed) => self.report_actor_gone().await,
+            }
+        }
     }
 }
 
@@ -819,7 +890,9 @@ mod tests {
 
         /// Fails rather than hanging when the wait never ends.
         async fn finished<T>(wait: impl Future<Output = T>) -> T {
-            timeout(PERIOD * 10, wait).await.expect("the wait never ended")
+            timeout(PERIOD * 10, wait)
+                .await
+                .expect("the wait never ended")
         }
 
         #[tokio::test(start_paused = true)]
@@ -884,7 +957,18 @@ mod tests {
             assert_eq!(finished(handle.wait_until(|value| *value == 2)).await, 2);
         }
 
-        #[tokio::test]
+        #[tokio::test(start_paused = true)]
+        async fn test_a_read_handle_can_wait() {
+            let handle = Handle::new(0);
+            let read_handle = handle.get_read_handle();
+            tokio::spawn(async move { handle.set(5).await });
+
+            assert_eq!(finished(read_handle.wait_until(|v| *v == 5)).await, 5);
+        }
+
+        /// A handle holds a broadcast sender, so a waiting handle keeps its own
+        /// channel open and cannot learn from it that the actor is gone.
+        #[tokio::test(start_paused = true)]
         async fn test_a_dead_actor_ends_the_wait_with_a_panic() {
             let handle = Handle::new(PanicStruct {});
             let waiter = handle.clone();
@@ -892,7 +976,7 @@ mod tests {
 
             let _ = tokio::spawn(async move { handle.panic().await }).await;
 
-            let message = panic_message(wait.await.unwrap_err());
+            let message = panic_message(finished(wait).await.unwrap_err());
             assert!(
                 message.contains("A panic occurred in the Actor"),
                 "expected the actor's panic to be reported, got: {message}"

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -496,10 +496,11 @@ where
     /// Waits until the broadcast value satisfies `predicate` and returns it.
     ///
     /// Tests the actor's current value first, so a predicate that already holds
-    /// returns without waiting for an update. After that, every value the actor
-    /// broadcasts is tested in the order it was sent, including values the actor
-    /// has already moved past. The value returned is the one that satisfied the
-    /// predicate, which may no longer be the actor's current value.
+    /// returns without waiting for an update. Every value broadcast after that
+    /// is tested in the order it was sent, except values lost while the receiver
+    /// was behind, which are logged. The value returned is the one that
+    /// satisfied the predicate, which may be older than the value the actor
+    /// holds by then.
     ///
     /// The predicate receives the broadcast type `V`, which the actor produces
     /// without cloning itself, so this works on non-Clone actor types.
@@ -524,37 +525,25 @@ where
     /// Panics if the actor has stopped, either because one of its methods
     /// panicked or because its runtime shut down. See [Actor lifetime and
     /// panics](crate#actor-lifetime-and-panics).
-    pub async fn wait_until<P>(&self, mut predicate: P) -> V
+    pub async fn wait_until<P>(&self, predicate: P) -> V
     where
         P: FnMut(&V) -> bool,
     {
         // Subscribe before reading, so an update arriving in between is queued
         // rather than lost.
-        let mut receiver = self.subscribe();
+        let receiver = self.subscribe();
         let current = self.with(|inner| inner.to_broadcast()).await;
-        if predicate(&current) {
-            return current;
-        }
+        let mut cache = Cache::new(receiver, current);
 
-        loop {
-            // This handle holds a broadcast sender, so the channel it is
-            // waiting on cannot report a stopped actor. The exit signal can.
-            let received = tokio::select! {
-                received = receiver.recv() => received,
-                _ = self.wait_for_exit() => self.report_actor_gone().await,
-            };
-
-            match received {
-                Ok(value) if predicate(&value) => return value,
-                Ok(_) => continue,
-                // Values were dropped, so one of them may have satisfied the
-                // predicate. Nothing can recover them, so the wait goes on.
-                Err(broadcast::error::RecvError::Lagged(nr)) => log::debug!(
-                    "A wait on actor type {} lagged {nr} messages",
-                    type_name::<T>()
-                ),
-                Err(broadcast::error::RecvError::Closed) => self.report_actor_gone().await,
-            }
+        tokio::select! {
+            // A handle owns a broadcast sender, so the cache's channel stays
+            // open even once the actor has panicked or its runtime has gone
+            // away. The exit signal is what reports those.
+            found = cache.wait_until(predicate) => match found {
+                Ok(value) => value.clone(),
+                Err(_) => self.report_actor_gone().await,
+            },
+            _ = self.wait_for_exit() => self.report_actor_gone().await,
         }
     }
 }

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -171,6 +171,250 @@ where
         Throttle::spawn_from_receiver(client, call, freq, receiver, Some(init));
         handle
     }
+
+    /// Waits until the broadcast value satisfies `predicate` and returns it.
+    ///
+    /// Tests the actor's current value first, so a predicate that already holds
+    /// returns without waiting for an update. Every value broadcast after that
+    /// is tested in the order it was sent, except values lost while the receiver
+    /// was behind, which are logged.
+    ///
+    /// The predicate receives the broadcast type `V`, which the actor produces
+    /// without cloning itself, so this works on non-Clone actor types.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::Handle;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(0);
+    ///
+    /// let setter = handle.clone();
+    /// tokio::spawn(async move { setter.set(3).await });
+    ///
+    /// assert_eq!(handle.wait_until(|value| *value == 3).await, 3);
+    /// # }
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the actor has stopped, either because one of its methods
+    /// panicked or because its runtime shut down. See [Actor lifetime and
+    /// panics](crate#actor-lifetime-and-panics).
+    pub async fn wait_until<P>(&self, predicate: P) -> V
+    where
+        P: FnMut(&V) -> bool,
+    {
+        let mut cache = self.create_cache().await;
+
+        tokio::select! {
+            // A handle owns a broadcast sender, so the cache's channel stays
+            // open even once the actor has panicked or its runtime has gone
+            // away. The exit signal is what reports those.
+            found = cache.wait_until(predicate) => match found {
+                Ok(value) => value.clone(),
+                Err(_) => self.report_actor_gone().await,
+            },
+            _ = self.wait_for_exit() => self.report_actor_gone().await,
+        }
+    }
+
+    /// Creates an initialized [`Cache`] that locally synchronizes with the remote actor.
+    /// As it is initialized with the current value, any updates before or during construction are included.
+    ///
+    /// See also [`Handle::create_cache_from_default`] for a cache that starts from `V::default()`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the actor has stopped, either because one of its methods
+    /// panicked or because its runtime shut down. See [Actor lifetime and
+    /// panics](crate#actor-lifetime-and-panics).
+    pub async fn create_cache(&self) -> Cache<V> {
+        // Subscribe before reading, so an update arriving in between is queued
+        // rather than lost.
+        let rx = self.subscribe();
+        let init = self.with(|inner| inner.to_broadcast()).await;
+        Cache::new(rx, init)
+    }
+
+    /// Spawns a [`Throttle`] that fires given a specified [`Frequency`].
+    ///
+    /// The broadcast type must implement [`Throttled<F>`](crate::Throttled) to
+    /// convert the value into the callback argument.
+    ///
+    /// `call` is any `Fn(&C, F)`, so it can be a method such as `Logger::log`
+    /// below, or a closure holding captured state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, Frequency};
+    /// # use std::sync::{Arc, Mutex};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// struct Logger(Arc<Mutex<Vec<i32>>>);
+    /// impl Logger {
+    ///     fn log(&self, val: i32) { self.0.lock().unwrap().push(val); }
+    /// }
+    ///
+    /// let handle = Handle::new(1);
+    /// let values = Arc::new(Mutex::new(Vec::new()));
+    /// handle.spawn_throttle(Logger(values.clone()), Logger::log, Frequency::OnEvent).await;
+    ///
+    /// handle.set(2).await;
+    /// tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    /// // Fires once with the current value on creation, then on each broadcast
+    /// assert_eq!(*values.lock().unwrap(), vec![1, 2]);
+    /// # }
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the actor has stopped, either because one of its methods
+    /// panicked or because its runtime shut down. See [Actor lifetime and
+    /// panics](crate#actor-lifetime-and-panics).
+    pub async fn spawn_throttle<C, F, Fun>(&self, client: C, call: Fun, freq: Frequency) -> Throttle
+    where
+        C: Send + Sync + 'static,
+        V: Throttled<F>,
+        F: Send + Sync + 'static,
+        Fun: Fn(&C, F) + Send + 'static,
+    {
+        // Subscribe before reading, so an update arriving in between is queued
+        // rather than lost.
+        let receiver = self.subscribe();
+        let current = self.with(|inner| inner.to_broadcast()).await;
+        Throttle::spawn_from_receiver(client, call, freq, receiver, Some(current))
+    }
+
+    /// Spawns a [`Throttle`] whose callback is awaited before the next value is
+    /// looked for.
+    ///
+    /// `call` borrows the client and returns a [`BoxFuture`], so the client is
+    /// neither cloned nor required to be `Clone`. See [Slow
+    /// calls](Throttle#slow-calls) for what happens while one runs.
+    ///
+    /// # Writing the callback
+    ///
+    /// The future may borrow the client, and a future's type carries the
+    /// lifetime of what it borrows. A plain generic return type cannot express
+    /// that, so the future is boxed and every callback ends up shaped like:
+    ///
+    /// ```text
+    /// |client, value| Box::pin(async move { ... })
+    /// ```
+    ///
+    /// An `async fn` on the client wraps directly, without an `async` block of
+    /// its own:
+    ///
+    /// ```
+    /// # use actify::{Frequency, Handle};
+    /// # use tokio::sync::mpsc;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// struct Forwarder {
+    ///     sink: mpsc::Sender<i32>,
+    /// }
+    ///
+    /// impl Forwarder {
+    ///     async fn forward(&self, value: i32) {
+    ///         let _ = self.sink.send(value).await;
+    ///     }
+    /// }
+    ///
+    /// let (sink, mut received) = mpsc::channel(8);
+    /// let handle = Handle::new(1);
+    ///
+    /// let throttle = handle
+    ///     .spawn_async_throttle(
+    ///         Forwarder { sink },
+    ///         |forwarder, value| Box::pin(forwarder.forward(value)),
+    ///         Frequency::OnEvent,
+    ///     )
+    ///     .await;
+    ///
+    /// handle.set(2).await;
+    ///
+    /// assert_eq!(received.recv().await, Some(1));
+    /// assert_eq!(received.recv().await, Some(2));
+    /// throttle.abort();
+    /// # }
+    /// ```
+    ///
+    /// Anything longer goes in an `async move` block, which can await as often
+    /// as it likes and use the client throughout:
+    ///
+    /// ```
+    /// # use actify::{Frequency, Handle};
+    /// # use tokio::sync::mpsc;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// struct Journal {
+    ///     writes: mpsc::Sender<String>,
+    /// }
+    ///
+    /// let (writes, mut received) = mpsc::channel(8);
+    /// let handle = Handle::new(1);
+    ///
+    /// let throttle = handle
+    ///     .spawn_async_throttle(
+    ///         Journal { writes },
+    ///         |journal, value: i32| {
+    ///             Box::pin(async move {
+    ///                 let _ = journal.writes.send(format!("begin {value}")).await;
+    ///                 let _ = journal.writes.send(format!("end {value}")).await;
+    ///             })
+    ///         },
+    ///         Frequency::OnEvent,
+    ///     )
+    ///     .await;
+    ///
+    /// assert_eq!(received.recv().await.as_deref(), Some("begin 1"));
+    /// assert_eq!(received.recv().await.as_deref(), Some("end 1"));
+    /// throttle.abort();
+    /// # }
+    /// ```
+    ///
+    /// A method reference on its own does not work, because an `async fn`
+    /// returns its own future type rather than a boxed one:
+    ///
+    /// ```compile_fail
+    /// # use actify::{Frequency, Handle};
+    /// # struct Forwarder;
+    /// # impl Forwarder { async fn forward(&self, _value: i32) {} }
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// # let handle = Handle::new(1);
+    /// handle
+    ///     .spawn_async_throttle(Forwarder, Forwarder::forward, Frequency::OnEvent)
+    ///     .await;
+    /// # }
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the actor has stopped, either because one of its methods
+    /// panicked or because its runtime shut down. See [Actor lifetime and
+    /// panics](crate#actor-lifetime-and-panics).
+    pub async fn spawn_async_throttle<C, F, Fun>(
+        &self,
+        client: C,
+        call: Fun,
+        freq: Frequency,
+    ) -> Throttle
+    where
+        C: Send + Sync + 'static,
+        V: Throttled<F>,
+        F: Send + Sync + 'static,
+        Fun: for<'a> Fn(&'a C, F) -> BoxFuture<'a> + Send + 'static,
+    {
+        // Subscribe before reading, so an update arriving in between is queued
+        // rather than lost.
+        let receiver = self.subscribe();
+        let current = self.with(|inner| inner.to_broadcast()).await;
+        Throttle::spawn_async_from_receiver(client, call, freq, receiver, Some(current))
+    }
 }
 
 impl<T, V> Handle<T, V> {
@@ -485,260 +729,6 @@ impl<T, V: Default + Clone + Send + Sync + 'static> Handle<T, V> {
     /// or [`Handle::create_cache_from`] to start from a custom value.
     pub fn create_cache_from_default(&self) -> Cache<V> {
         self.create_cache_from(V::default())
-    }
-}
-
-impl<T, V> Handle<T, V>
-where
-    T: BroadcastAs<V> + Send + Sync + 'static,
-    V: Clone + Send + Sync + 'static,
-{
-    /// Waits until the broadcast value satisfies `predicate` and returns it.
-    ///
-    /// Tests the actor's current value first, so a predicate that already holds
-    /// returns without waiting for an update. Every value broadcast after that
-    /// is tested in the order it was sent, except values lost while the receiver
-    /// was behind, which are logged.
-    ///
-    /// The predicate receives the broadcast type `V`, which the actor produces
-    /// without cloning itself, so this works on non-Clone actor types.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use actify::Handle;
-    /// # #[tokio::main]
-    /// # async fn main() {
-    /// let handle = Handle::new(0);
-    ///
-    /// let setter = handle.clone();
-    /// tokio::spawn(async move { setter.set(3).await });
-    ///
-    /// assert_eq!(handle.wait_until(|value| *value == 3).await, 3);
-    /// # }
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// Panics if the actor has stopped, either because one of its methods
-    /// panicked or because its runtime shut down. See [Actor lifetime and
-    /// panics](crate#actor-lifetime-and-panics).
-    pub async fn wait_until<P>(&self, predicate: P) -> V
-    where
-        P: FnMut(&V) -> bool,
-    {
-        // Subscribe before reading, so an update arriving in between is queued
-        // rather than lost.
-        let receiver = self.subscribe();
-        let current = self.with(|inner| inner.to_broadcast()).await;
-        let mut cache = Cache::new(receiver, current);
-
-        tokio::select! {
-            // A handle owns a broadcast sender, so the cache's channel stays
-            // open even once the actor has panicked or its runtime has gone
-            // away. The exit signal is what reports those.
-            found = cache.wait_until(predicate) => match found {
-                Ok(value) => value.clone(),
-                Err(_) => self.report_actor_gone().await,
-            },
-            _ = self.wait_for_exit() => self.report_actor_gone().await,
-        }
-    }
-
-    /// Creates an initialized [`Cache`] that locally synchronizes with the remote actor.
-    /// As it is initialized with the current value, any updates before or during construction are included.
-    ///
-    /// See also [`Handle::create_cache_from_default`] for a cache that starts from `V::default()`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the actor has stopped, either because one of its methods
-    /// panicked or because its runtime shut down. See [Actor lifetime and
-    /// panics](crate#actor-lifetime-and-panics).
-    pub async fn create_cache(&self) -> Cache<V> {
-        // Subscribe before reading, so an update arriving in between is queued
-        // rather than lost.
-        let rx = self.subscribe();
-        let init = self.with(|inner| inner.to_broadcast()).await;
-        Cache::new(rx, init)
-    }
-
-    /// Spawns a [`Throttle`] that fires given a specified [`Frequency`].
-    ///
-    /// The broadcast type must implement [`Throttled<F>`](crate::Throttled) to
-    /// convert the value into the callback argument.
-    ///
-    /// `call` is any `Fn(&C, F)`, so it can be a method such as `Logger::log`
-    /// below, or a closure holding captured state.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use actify::{Handle, Frequency};
-    /// # use std::sync::{Arc, Mutex};
-    /// # #[tokio::main]
-    /// # async fn main() {
-    /// struct Logger(Arc<Mutex<Vec<i32>>>);
-    /// impl Logger {
-    ///     fn log(&self, val: i32) { self.0.lock().unwrap().push(val); }
-    /// }
-    ///
-    /// let handle = Handle::new(1);
-    /// let values = Arc::new(Mutex::new(Vec::new()));
-    /// handle.spawn_throttle(Logger(values.clone()), Logger::log, Frequency::OnEvent).await;
-    ///
-    /// handle.set(2).await;
-    /// tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    /// // Fires once with the current value on creation, then on each broadcast
-    /// assert_eq!(*values.lock().unwrap(), vec![1, 2]);
-    /// # }
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// Panics if the actor has stopped, either because one of its methods
-    /// panicked or because its runtime shut down. See [Actor lifetime and
-    /// panics](crate#actor-lifetime-and-panics).
-    pub async fn spawn_throttle<C, F, Fun>(&self, client: C, call: Fun, freq: Frequency) -> Throttle
-    where
-        C: Send + Sync + 'static,
-        V: Throttled<F>,
-        F: Send + Sync + 'static,
-        Fun: Fn(&C, F) + Send + 'static,
-    {
-        // Subscribe before reading, so an update arriving in between is queued
-        // rather than lost.
-        let receiver = self.subscribe();
-        let current = self.with(|inner| inner.to_broadcast()).await;
-        Throttle::spawn_from_receiver(client, call, freq, receiver, Some(current))
-    }
-
-    /// Spawns a [`Throttle`] whose callback is awaited before the next value is
-    /// looked for.
-    ///
-    /// `call` borrows the client and returns a [`BoxFuture`], so the client is
-    /// neither cloned nor required to be `Clone`. See [Slow
-    /// calls](Throttle#slow-calls) for what happens while one runs.
-    ///
-    /// # Writing the callback
-    ///
-    /// The future may borrow the client, and a future's type carries the
-    /// lifetime of what it borrows. A plain generic return type cannot express
-    /// that, so the future is boxed and every callback ends up shaped like:
-    ///
-    /// ```text
-    /// |client, value| Box::pin(async move { ... })
-    /// ```
-    ///
-    /// An `async fn` on the client wraps directly, without an `async` block of
-    /// its own:
-    ///
-    /// ```
-    /// # use actify::{Frequency, Handle};
-    /// # use tokio::sync::mpsc;
-    /// # #[tokio::main]
-    /// # async fn main() {
-    /// struct Forwarder {
-    ///     sink: mpsc::Sender<i32>,
-    /// }
-    ///
-    /// impl Forwarder {
-    ///     async fn forward(&self, value: i32) {
-    ///         let _ = self.sink.send(value).await;
-    ///     }
-    /// }
-    ///
-    /// let (sink, mut received) = mpsc::channel(8);
-    /// let handle = Handle::new(1);
-    ///
-    /// let throttle = handle
-    ///     .spawn_async_throttle(
-    ///         Forwarder { sink },
-    ///         |forwarder, value| Box::pin(forwarder.forward(value)),
-    ///         Frequency::OnEvent,
-    ///     )
-    ///     .await;
-    ///
-    /// handle.set(2).await;
-    ///
-    /// assert_eq!(received.recv().await, Some(1));
-    /// assert_eq!(received.recv().await, Some(2));
-    /// throttle.abort();
-    /// # }
-    /// ```
-    ///
-    /// Anything longer goes in an `async move` block, which can await as often
-    /// as it likes and use the client throughout:
-    ///
-    /// ```
-    /// # use actify::{Frequency, Handle};
-    /// # use tokio::sync::mpsc;
-    /// # #[tokio::main]
-    /// # async fn main() {
-    /// struct Journal {
-    ///     writes: mpsc::Sender<String>,
-    /// }
-    ///
-    /// let (writes, mut received) = mpsc::channel(8);
-    /// let handle = Handle::new(1);
-    ///
-    /// let throttle = handle
-    ///     .spawn_async_throttle(
-    ///         Journal { writes },
-    ///         |journal, value: i32| {
-    ///             Box::pin(async move {
-    ///                 let _ = journal.writes.send(format!("begin {value}")).await;
-    ///                 let _ = journal.writes.send(format!("end {value}")).await;
-    ///             })
-    ///         },
-    ///         Frequency::OnEvent,
-    ///     )
-    ///     .await;
-    ///
-    /// assert_eq!(received.recv().await.as_deref(), Some("begin 1"));
-    /// assert_eq!(received.recv().await.as_deref(), Some("end 1"));
-    /// throttle.abort();
-    /// # }
-    /// ```
-    ///
-    /// A method reference on its own does not work, because an `async fn`
-    /// returns its own future type rather than a boxed one:
-    ///
-    /// ```compile_fail
-    /// # use actify::{Frequency, Handle};
-    /// # struct Forwarder;
-    /// # impl Forwarder { async fn forward(&self, _value: i32) {} }
-    /// # #[tokio::main]
-    /// # async fn main() {
-    /// # let handle = Handle::new(1);
-    /// handle
-    ///     .spawn_async_throttle(Forwarder, Forwarder::forward, Frequency::OnEvent)
-    ///     .await;
-    /// # }
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// Panics if the actor has stopped, either because one of its methods
-    /// panicked or because its runtime shut down. See [Actor lifetime and
-    /// panics](crate#actor-lifetime-and-panics).
-    pub async fn spawn_async_throttle<C, F, Fun>(
-        &self,
-        client: C,
-        call: Fun,
-        freq: Frequency,
-    ) -> Throttle
-    where
-        C: Send + Sync + 'static,
-        V: Throttled<F>,
-        F: Send + Sync + 'static,
-        Fun: for<'a> Fn(&'a C, F) -> BoxFuture<'a> + Send + 'static,
-    {
-        // Subscribe before reading, so an update arriving in between is queued
-        // rather than lost.
-        let receiver = self.subscribe();
-        let current = self.with(|inner| inner.to_broadcast()).await;
-        Throttle::spawn_async_from_receiver(client, call, freq, receiver, Some(current))
     }
 }
 

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -863,12 +863,6 @@ mod tests {
                 .expect("the wait never ended")
         }
 
-        /// Whether the future is still waiting after several periods. The clock
-        /// is paused in these tests, so the wait costs no real time.
-        async fn still_waiting<T>(wait: impl Future<Output = T>) -> bool {
-            timeout(PERIOD * 10, wait).await.is_err()
-        }
-
         #[tokio::test(start_paused = true)]
         async fn test_a_satisfied_predicate_returns_without_waiting() {
             let handle = Handle::new(7);
@@ -943,40 +937,8 @@ mod tests {
             assert_eq!(finished(read_handle.wait_until(|v| *v == 5)).await, 5);
         }
 
-        /// A dead actor closes the job channel but not the broadcast channel.
-        /// A broadcast channel closes when its last sender drops, and a `Handle`
-        /// owns one, so code waiting on a subscription taken from a handle is
-        /// holding that channel open itself. This is why [`Handle::wait_until`]
-        /// watches the exit signal and not only its receiver: on this path
-        /// `recv` waits forever.
-        #[tokio::test(start_paused = true)]
-        async fn test_a_handle_keeps_its_own_broadcast_channel_open() {
-            let handle = Handle::new(PanicStruct {});
-            let mut receiver = handle.subscribe();
-
-            let killer = handle.clone();
-            let killed = tokio::spawn(async move { killer.panic().await }).await;
-            assert!(killed.is_err(), "the actor must be dead for the rest");
-
-            let caller = handle.clone();
-            let call = tokio::spawn(async move { caller.get().await }).await;
-            assert!(call.is_err(), "a call through the job channel panics");
-
-            assert!(
-                still_waiting(receiver.recv()).await,
-                "the subscription reported the actor gone while a handle held a sender"
-            );
-
-            drop(handle);
-            assert!(
-                matches!(
-                    receiver.recv().await,
-                    Err(broadcast::error::RecvError::Closed)
-                ),
-                "dropping the last sender closes the channel"
-            );
-        }
-
+        /// A handle owns a broadcast sender, so the channel the wait is reading
+        /// never reports the actor gone. Only the exit signal does.
         #[tokio::test(start_paused = true)]
         async fn test_a_dead_actor_ends_the_wait_with_a_panic() {
             let handle = Handle::new(PanicStruct {});

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -544,13 +544,7 @@ where
             _ = self.wait_for_exit() => self.report_actor_gone().await,
         }
     }
-}
 
-impl<T, V> Handle<T, V>
-where
-    T: Clone + BroadcastAs<V> + Send + Sync + 'static,
-    V: Clone + Send + Sync + 'static,
-{
     /// Creates an initialized [`Cache`] that locally synchronizes with the remote actor.
     /// As it is initialized with the current value, any updates before or during construction are included.
     ///
@@ -562,10 +556,11 @@ where
     /// panicked or because its runtime shut down. See [Actor lifetime and
     /// panics](crate#actor-lifetime-and-panics).
     pub async fn create_cache(&self) -> Cache<V> {
-        // Subscribe before get, so an update arriving in between is queued rather than lost.
+        // Subscribe before reading, so an update arriving in between is queued
+        // rather than lost.
         let rx = self.subscribe();
-        let init = self.get().await;
-        Cache::new(rx, init.to_broadcast())
+        let init = self.with(|inner| inner.to_broadcast()).await;
+        Cache::new(rx, init)
     }
 
     /// Spawns a [`Throttle`] that fires given a specified [`Frequency`].
@@ -611,10 +606,11 @@ where
         F: Send + Sync + 'static,
         Fun: Fn(&C, F) + Send + 'static,
     {
-        // Subscribe before get, so an update arriving in between is queued rather than lost.
+        // Subscribe before reading, so an update arriving in between is queued
+        // rather than lost.
         let receiver = self.subscribe();
-        let current = self.get().await;
-        Throttle::spawn_from_receiver(client, call, freq, receiver, Some(current.to_broadcast()))
+        let current = self.with(|inner| inner.to_broadcast()).await;
+        Throttle::spawn_from_receiver(client, call, freq, receiver, Some(current))
     }
 
     /// Spawns a [`Throttle`] whose callback is awaited before the next value is
@@ -738,16 +734,11 @@ where
         F: Send + Sync + 'static,
         Fun: for<'a> Fn(&'a C, F) -> BoxFuture<'a> + Send + 'static,
     {
-        // Subscribe before get, so an update arriving in between is queued rather than lost.
+        // Subscribe before reading, so an update arriving in between is queued
+        // rather than lost.
         let receiver = self.subscribe();
-        let current = self.get().await;
-        Throttle::spawn_async_from_receiver(
-            client,
-            call,
-            freq,
-            receiver,
-            Some(current.to_broadcast()),
-        )
+        let current = self.with(|inner| inner.to_broadcast()).await;
+        Throttle::spawn_async_from_receiver(client, call, freq, receiver, Some(current))
     }
 }
 
@@ -1083,6 +1074,10 @@ mod tests {
 
             assert_eq!(cache.get_current(), &1);
             assert_eq!(clones.load(Ordering::SeqCst), 0);
+
+            // Reading the value does clone it, so the count above is a count.
+            let _ = handle.get().await;
+            assert_eq!(clones.load(Ordering::SeqCst), 1);
         }
     }
 

--- a/actify/src/handles/read_handle.rs
+++ b/actify/src/handles/read_handle.rs
@@ -14,12 +14,6 @@ use crate::throttle::{BoxFuture, Frequency, Throttle, Throttled};
 /// [`ReadHandle::spawn_async_throttle`].
 pub struct ReadHandle<T, V = T>(Handle<T, V>);
 
-impl<T, V> ReadHandle<T, V> {
-    pub(super) fn new(handle: Handle<T, V>) -> Self {
-        ReadHandle(handle)
-    }
-}
-
 impl<T, V> Clone for ReadHandle<T, V> {
     fn clone(&self) -> Self {
         ReadHandle(self.0.clone())
@@ -50,6 +44,10 @@ impl<T, V> ReadHandle<T, V> {
     /// ```
     pub fn subscribe(&self) -> broadcast::Receiver<V> {
         self.0.subscribe()
+    }
+
+    pub(super) fn new(handle: Handle<T, V>) -> Self {
+        ReadHandle(handle)
     }
 }
 
@@ -100,28 +98,6 @@ impl<T: Send + Sync + 'static, V> ReadHandle<T, V> {
         R: Send + 'static,
     {
         self.0.with(f).await
-    }
-}
-
-impl<T, V> ReadHandle<T, V>
-where
-    T: BroadcastAs<V> + Send + Sync + 'static,
-    V: Clone + Send + Sync + 'static,
-{
-    /// Waits until the broadcast value satisfies `predicate` and returns it.
-    ///
-    /// See [`Handle::wait_until`] for which values are tested.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the actor has stopped, either because one of its methods
-    /// panicked or because its runtime shut down. See [Actor lifetime and
-    /// panics](crate#actor-lifetime-and-panics).
-    pub async fn wait_until<P>(&self, predicate: P) -> V
-    where
-        P: FnMut(&V) -> bool,
-    {
-        self.0.wait_until(predicate).await
     }
 }
 
@@ -227,6 +203,22 @@ where
         Fun: for<'a> Fn(&'a C, F) -> BoxFuture<'a> + Send + 'static,
     {
         self.0.spawn_async_throttle(client, call, freq).await
+    }
+
+    /// Waits until the broadcast value satisfies `predicate` and returns it.
+    ///
+    /// See [`Handle::wait_until`] for which values are tested.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the actor has stopped, either because one of its methods
+    /// panicked or because its runtime shut down. See [Actor lifetime and
+    /// panics](crate#actor-lifetime-and-panics).
+    pub async fn wait_until<P>(&self, predicate: P) -> V
+    where
+        P: FnMut(&V) -> bool,
+    {
+        self.0.wait_until(predicate).await
     }
 }
 

--- a/actify/src/handles/read_handle.rs
+++ b/actify/src/handles/read_handle.rs
@@ -169,7 +169,7 @@ impl<T, V: Default + Clone + Send + Sync + 'static> ReadHandle<T, V> {
 
 impl<T, V> ReadHandle<T, V>
 where
-    T: Clone + BroadcastAs<V> + Send + Sync + 'static,
+    T: BroadcastAs<V> + Send + Sync + 'static,
     V: Clone + Send + Sync + 'static,
 {
     /// Creates an initialized [`Cache`] that locally synchronizes with the remote actor.

--- a/actify/src/handles/read_handle.rs
+++ b/actify/src/handles/read_handle.rs
@@ -9,8 +9,9 @@ use crate::throttle::{BoxFuture, Frequency, Throttle, Throttled};
 /// A clonable read-only handle that can only be used to read the internal value.
 ///
 /// Obtained via [`Handle::get_read_handle`]. Supports [`ReadHandle::get`],
-/// [`ReadHandle::with`], [`ReadHandle::subscribe`], [`ReadHandle::create_cache`],
-/// [`ReadHandle::spawn_throttle`], and [`ReadHandle::spawn_async_throttle`].
+/// [`ReadHandle::with`], [`ReadHandle::subscribe`], [`ReadHandle::wait_until`],
+/// [`ReadHandle::create_cache`], [`ReadHandle::spawn_throttle`], and
+/// [`ReadHandle::spawn_async_throttle`].
 pub struct ReadHandle<T, V = T>(Handle<T, V>);
 
 impl<T, V> ReadHandle<T, V> {
@@ -99,6 +100,28 @@ impl<T: Send + Sync + 'static, V> ReadHandle<T, V> {
         R: Send + 'static,
     {
         self.0.with(f).await
+    }
+}
+
+impl<T, V> ReadHandle<T, V>
+where
+    T: BroadcastAs<V> + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    /// Waits until the broadcast value satisfies `predicate` and returns it.
+    ///
+    /// See [`Handle::wait_until`] for which values are tested.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the actor has stopped, either because one of its methods
+    /// panicked or because its runtime shut down. See [Actor lifetime and
+    /// panics](crate#actor-lifetime-and-panics).
+    pub async fn wait_until<P>(&self, predicate: P) -> V
+    where
+        P: FnMut(&V) -> bool,
+    {
+        self.0.wait_until(predicate).await
     }
 }
 

--- a/actify/src/lib.rs
+++ b/actify/src/lib.rs
@@ -198,6 +198,7 @@
 //! - [`Handle::subscribe`]: returns a [`tokio::sync::broadcast::Receiver`] for change notifications
 //! - [`Handle::with`]: runs a read-only closure on `&T` (does not broadcast)
 //! - [`Handle::with_mut`]: runs a mutable closure on `&mut T` (broadcasts the change)
+//! - [`Handle::wait_until`]: waits until the broadcast value satisfies a predicate
 //!
 //! # Broadcasting
 //!
@@ -311,13 +312,17 @@
 //! current value), [`Handle::create_cache_from`] (custom initial value),
 //! or [`Handle::create_cache_from_default`] (starts from `T::default()`).
 //!
+//! [`Cache::wait_for`] waits until the cached value satisfies a predicate,
+//! reading through the cache so it holds the value that matched.
+//!
 //! See [`CacheRecvError`] and [`CacheRecvNewestError`] for possible error conditions.
 //!
 //! # ReadHandle
 //!
 //! A [`ReadHandle`] is a read-only view of an actor. It supports [`get`](ReadHandle::get),
-//! [`subscribe`](ReadHandle::subscribe), cache creation and throttle spawning, but
-//! cannot mutate the actor. Obtain one via [`Handle::get_read_handle`].
+//! [`subscribe`](ReadHandle::subscribe), [`wait_until`](ReadHandle::wait_until), cache
+//! creation and throttle spawning, but cannot mutate the actor. Obtain one via
+//! [`Handle::get_read_handle`].
 //!
 //! # Throttle
 //!

--- a/actify/src/lib.rs
+++ b/actify/src/lib.rs
@@ -312,7 +312,7 @@
 //! current value), [`Handle::create_cache_from`] (custom initial value),
 //! or [`Handle::create_cache_from_default`] (starts from `T::default()`).
 //!
-//! [`Cache::wait_for`] waits until the cached value satisfies a predicate,
+//! [`Cache::wait_until`] waits until the cached value satisfies a predicate,
 //! reading through the cache so it holds the value that matched.
 //!
 //! See [`CacheRecvError`] and [`CacheRecvNewestError`] for possible error conditions.


### PR DESCRIPTION
Item 20 of the 0.9.0 plan, and the one thing the usage audit turned up that stands on its own evidence: waiting for a state to satisfy a condition is currently hand-rolled per predicate, once per shape (equal, at least, one of, not equal, some, none, empty, within margin).

```rust
handle.wait_until(|value| *value == 3).await;
cache.wait_until(|value| value.is_ready()).await?;
```

Three methods, one name: `Handle::wait_until`, `ReadHandle::wait_until` (delegating) and `Cache::wait_until`. The cache one was first written as `wait_for`, matching `tokio::sync::watch::Receiver::wait_for` signature for signature, but a `Cache` is not a watch receiver (broadcast-backed, FIFO, its own first-read semantics), so the resemblance was worth less than one name for one concept. The return types still differ, which is inherent: `V` owned and panicking, versus `Result<&T, _>`. Branched from main, so it does not depend on #106.

## Design decisions worth reviewing

**Every value is tested, not just the newest.** The plan said to build this on `recv_newest` semantics. Implementing it made me change my mind: coalescing to the newest value can skip a state the actor passed through, and the failure mode is that the wait never ends. Testing every value in order costs a stale return value at worst. `test_a_value_the_actor_has_moved_past_still_matches` pins this: two values are queued, the predicate matches the older one, and a coalescing implementation would wait forever.

The remaining hole is lag, which drops values before anyone can test them. It is logged and the wait continues, and it is documented.

**The handle's wait runs on a `Cache`.** Suggested in review, and it holds up: the predicate loop, the broadcast ordering and the lag policy now exist once, in `Cache::wait_until`, and `Handle::wait_until` adds only the part a cache cannot see.

```rust
let receiver = self.subscribe();
let current = self.with(|inner| inner.to_broadcast()).await;
let mut cache = Cache::new(receiver, current);

tokio::select! {
    found = cache.wait_until(predicate) => match found {
        Ok(value) => value.clone(),
        Err(_) => self.report_actor_gone().await,
    },
    _ = self.wait_for_exit() => self.report_actor_gone().await,
}
```

It calls `create_cache`, which is now possible: that method required `T: Clone` until #108 removed the bound, which is why an earlier revision of this PR built the cache by hand. So the subscribe-before-read ordering lives in exactly one place. Costs are one clone of `V` on return and an `Err` arm that cannot fire while `self` is alive.

Reversing the order inside `create_cache` now fails four tests, three of them waiting tests, so the shared ordering is covered from both sides.

## Also in this PR: one impl block per set of bounds

`Handle` and `ReadHandle` each ended up with two pairs of inherent impl blocks whose bounds were character for character identical, so nothing decided which methods went in which. This PR created one of those pairs and #108 created the other. They are merged, leaving six blocks on each type, each gating a different set of methods, which is what impl-block bounds are for. `Cache` has a single block and needed nothing.

The merge is a pure move: no body changed, and the sorted list of all 27 public and `pub(super)` signatures across both files is byte-identical before and after.

The dedup is visible in the mutation results below: a single mutation inside the shared loop now fails a handle test and a cache test together.

**`wait_until` watches the exit signal, not just the channel.** This was a genuine find while testing.

A broadcast channel closes when its last **sender** drops, not when the actor dies. There are two senders per actor: one owned by every `Handle` and one moved into the actor's broadcast function. A dying actor drops only the second, so code waiting on a subscription it took from a handle is holding that channel open itself. `RecvError::Closed` can never arrive, and the wait would hang forever instead of panicking like every other handle method. It now selects over `wait_for_exit` as well, and `report_actor_gone` returns `!` so it can be used in that position.

`test_a_dead_actor_ends_the_wait_with_a_panic` covers it, and removing the exit branch makes it fail in milliseconds rather than hanging. A second test that walked through the channel mechanism was written and then deleted in review: every assertion in it was about tokio's broadcast semantics rather than actify's code, so it would have passed with `wait_until` completely broken. The mechanism is a doc comment on the test that does the work.

A `Cache` holds a receiver and no sender, so its channel does close, which is why `Cache::wait_until` needs no equivalent and returns `Closed` normally.

**The predicate takes the broadcast type `V`,** produced inside the actor via `with`, so the actor value is never cloned and `wait_until` works on non-Clone actor types. `test_a_non_clone_actor_can_be_waited_on` covers that.

**No timeout parameter.** Callers wrap in `tokio::time::timeout`.

## Verification

11 tests across the three methods, including the subscribe-before-read race that #83 and #91 also guard.

Mutation-verified, four mutations, each killing exactly one intended test:

| Mutation | Tests that failed |
| --- | --- |
| Read before subscribing | `test_an_update_during_construction_is_not_lost`, plus two more |
| Do not test the held value first | `test_a_satisfied_predicate_returns_without_waiting`, on both the handle and the cache |
| Ignore the predicate in the loop | `test_updates_that_do_not_match_are_skipped` and the cache's `test_the_wait_ends_on_the_matching_update` |
| Coalesce to the newest value | `test_a_value_the_actor_has_moved_past_still_matches` |
| Stop watching the exit signal | `test_a_dead_actor_ends_the_wait_with_a_panic` |

The last one initially hung for 60 seconds instead of failing, which is a bad way to learn about a regression, so that test now runs on a paused clock behind the same timeout helper as the others and fails in milliseconds with "the wait never ended".

Full local gate green: workspace tests, `-p actify`, clippy `--all-targets --all-features -D warnings`, fmt, docs with `-D warnings` both with and without `--all-features`, and a 1.85 MSRV check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




