### PR TITLE
Let the actor derive the broadcast value, dropping T: Clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,15 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 
 ### Changed
 
+- `Handle::create_cache`, `Handle::spawn_throttle` and `Handle::spawn_async_throttle`,
+  and their `ReadHandle` counterparts, no longer require the actor type to be
+  `Clone`. Each of them seeded itself by cloning the whole actor value out with
+  `get` and deriving the broadcast value from that clone. They now ask the actor
+  to derive it in place, which drops the bound and the clone: a
+  `Handle<BigState, Summary>` no longer copies all of `BigState` to create a
+  cache, and actor types that are not `Clone` can now use both.
+
+
 - **Breaking:** `Cache::spawn_throttle` takes `&mut self` and first
   synchronizes the cache to the newest broadcast value, which becomes the
   throttle's initial fire. Previously the throttle got a fresh subscription

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -1012,6 +1012,80 @@ mod tests {
         }
     }
 
+    /// Deriving the broadcast value inside the actor means the actor value
+    /// itself is never cloned, so these work on actor types that are not Clone.
+    mod broadcast_derivation {
+        use super::*;
+        use crate::Frequency;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::{Arc, Mutex};
+
+        #[tokio::test]
+        async fn test_a_non_clone_actor_can_create_a_cache() {
+            let handle: Handle<NonCloneActor, i32> = Handle::new(NonCloneActor { value: 1 });
+
+            let cache = handle.create_cache().await;
+
+            assert_eq!(cache.get_current(), &1);
+        }
+
+        #[tokio::test]
+        async fn test_a_non_clone_actor_can_spawn_a_throttle() {
+            let handle: Handle<NonCloneActor, i32> = Handle::new(NonCloneActor { value: 1 });
+            let seen = Arc::new(Mutex::new(Vec::new()));
+            let sink = seen.clone();
+
+            let throttle = handle
+                .spawn_throttle(
+                    sink,
+                    |sink: &Arc<Mutex<Vec<i32>>>, value: i32| sink.lock().unwrap().push(value),
+                    Frequency::OnEvent,
+                )
+                .await;
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+            assert_eq!(*seen.lock().unwrap(), vec![1]);
+            throttle.abort();
+        }
+
+        /// Counts every clone of the actor value.
+        #[derive(Debug)]
+        struct Counted {
+            clones: Arc<AtomicUsize>,
+            value: i32,
+        }
+
+        impl Clone for Counted {
+            fn clone(&self) -> Self {
+                self.clones.fetch_add(1, Ordering::SeqCst);
+                Counted {
+                    clones: self.clones.clone(),
+                    value: self.value,
+                }
+            }
+        }
+
+        impl BroadcastAs<i32> for Counted {
+            fn to_broadcast(&self) -> i32 {
+                self.value
+            }
+        }
+
+        #[tokio::test]
+        async fn test_creating_a_cache_does_not_clone_the_actor_value() {
+            let clones = Arc::new(AtomicUsize::new(0));
+            let handle: Handle<Counted, i32> = Handle::new(Counted {
+                clones: clones.clone(),
+                value: 1,
+            });
+
+            let cache = handle.create_cache().await;
+
+            assert_eq!(cache.get_current(), &1);
+            assert_eq!(clones.load(Ordering::SeqCst), 0);
+        }
+    }
+
     fn panic_message(error: tokio::task::JoinError) -> String {
         let panic = error.into_panic();
         panic

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -544,13 +544,7 @@ where
             _ = self.wait_for_exit() => self.report_actor_gone().await,
         }
     }
-}
 
-impl<T, V> Handle<T, V>
-where
-    T: Clone + BroadcastAs<V> + Send + Sync + 'static,
-    V: Clone + Send + Sync + 'static,
-{
     /// Creates an initialized [`Cache`] that locally synchronizes with the remote actor.
     /// As it is initialized with the current value, any updates before or during construction are included.
     ///
@@ -562,10 +556,11 @@ where
     /// panicked or because its runtime shut down. See [Actor lifetime and
     /// panics](crate#actor-lifetime-and-panics).
     pub async fn create_cache(&self) -> Cache<V> {
-        // Subscribe before get, so an update arriving in between is queued rather than lost.
+        // Subscribe before reading, so an update arriving in between is queued
+        // rather than lost.
         let rx = self.subscribe();
-        let init = self.get().await;
-        Cache::new(rx, init.to_broadcast())
+        let init = self.with(|inner| inner.to_broadcast()).await;
+        Cache::new(rx, init)
     }
 
     /// Spawns a [`Throttle`] that fires given a specified [`Frequency`].
@@ -611,10 +606,11 @@ where
         F: Send + Sync + 'static,
         Fun: Fn(&C, F) + Send + 'static,
     {
-        // Subscribe before get, so an update arriving in between is queued rather than lost.
+        // Subscribe before reading, so an update arriving in between is queued
+        // rather than lost.
         let receiver = self.subscribe();
-        let current = self.get().await;
-        Throttle::spawn_from_receiver(client, call, freq, receiver, Some(current.to_broadcast()))
+        let current = self.with(|inner| inner.to_broadcast()).await;
+        Throttle::spawn_from_receiver(client, call, freq, receiver, Some(current))
     }
 
     /// Spawns a [`Throttle`] whose callback is awaited before the next value is
@@ -738,16 +734,11 @@ where
         F: Send + Sync + 'static,
         Fun: for<'a> Fn(&'a C, F) -> BoxFuture<'a> + Send + 'static,
     {
-        // Subscribe before get, so an update arriving in between is queued rather than lost.
+        // Subscribe before reading, so an update arriving in between is queued
+        // rather than lost.
         let receiver = self.subscribe();
-        let current = self.get().await;
-        Throttle::spawn_async_from_receiver(
-            client,
-            call,
-            freq,
-            receiver,
-            Some(current.to_broadcast()),
-        )
+        let current = self.with(|inner| inner.to_broadcast()).await;
+        Throttle::spawn_async_from_receiver(client, call, freq, receiver, Some(current))
     }
 }
 
@@ -1083,6 +1074,10 @@ mod tests {
 
             assert_eq!(cache.get_current(), &1);
             assert_eq!(clones.load(Ordering::SeqCst), 0);
+
+            // Reading the value does clone it, so the count above is a count.
+            let _ = handle.get().await;
+            assert_eq!(clones.load(Ordering::SeqCst), 1);
         }
     }
 

--- a/actify/src/handles/read_handle.rs
+++ b/actify/src/handles/read_handle.rs
@@ -169,7 +169,7 @@ impl<T, V: Default + Clone + Send + Sync + 'static> ReadHandle<T, V> {
 
 impl<T, V> ReadHandle<T, V>
 where
-    T: Clone + BroadcastAs<V> + Send + Sync + 'static,
+    T: BroadcastAs<V> + Send + Sync + 'static,
     V: Clone + Send + Sync + 'static,
 {
     /// Creates an initialized [`Cache`] that locally synchronizes with the remote actor.


### PR DESCRIPTION
**Stacked on #107, base is `feat/wait-until`.** Merge that first. Rebasing this onto main is a one-line conflict if #107 changes shape.

Came out of reviewing #107: `Handle::create_cache`, `Handle::spawn_throttle` and `Handle::spawn_async_throttle` all seeded themselves like this

```rust
let rx = self.subscribe();
let init = self.get().await;          // clones the whole actor value out
Cache::new(rx, init.to_broadcast())   // then derives V from that clone
```

`BroadcastAs::to_broadcast` takes `&self`, so the clone is pure overhead. Asking the actor to derive the value in place is what `wait_until` already does:

```rust
let init = self.with(|inner| inner.to_broadcast()).await;
```

Two consequences, both wanted:

- **`T: Clone` is gone** from that impl block on `Handle` and on `ReadHandle`. Actor types that are not `Clone` can now create caches and spawn throttles, which they could not before. Relaxing a bound is not breaking.
- **No clone of the actor value.** A `Handle<BigState, Summary>` no longer copies all of `BigState` every time you create a cache or spawn a throttle, just to compute a small summary.

The subscribe-before-read ordering is unchanged and still commented at each site.

Also merges two `impl` blocks that this change leaves with identical bounds, since #107 added the second one.

## Verification

Three tests. Two are compile-level, in the sense that they do not build before the change: a non-Clone actor creating a cache, and one spawning a throttle. `NonCloneActor` was already in the test module for exactly this kind of check.

The third counts clones, using an actor whose `Clone` impl increments a counter:

```rust
let cache = handle.create_cache().await;
assert_eq!(cache.get_current(), &1);
assert_eq!(clones.load(Ordering::SeqCst), 0);

// Reading the value does clone it, so the count above is a count.
let _ = handle.get().await;
assert_eq!(clones.load(Ordering::SeqCst), 1);
```

The second half is there so the zero means something. Without it the assertion would pass just as well against a broken counter.

Full local gate green: workspace tests, `-p actify`, clippy `--all-targets --all-features -D warnings`, fmt, docs with `-D warnings` both with and without `--all-features`, and a 1.85 MSRV check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)