### PR TITLE
A handle exposes a view: get returns V, BroadcastAs becomes ToView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,28 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 
 ### Changed
 
+- **Breaking:** `BroadcastAs<V>` is renamed to `ToView<V>` and `to_broadcast` to
+  `to_view`, because the trait no longer decides only what is broadcast.
+
+- **Breaking:** `Handle::get` and `ReadHandle::get` return the actor's view `V`
+  rather than the actor type `T`, and no longer require `T: Clone`.
+
+  `V` is now what a handle exposes: `get`, `subscribe`, `Cache`, `Throttle` and
+  `wait_until` all speak it, while `with` and `with_mut` reach the actor type
+  itself. Reading a value no longer clones the whole actor to derive a summary
+  from the clone.
+
+  **Nothing changes when `V = T`**, which is the default for every `Clone` actor
+  type: `get` still returns a clone of the value, at the same cost. Actor types
+  that are not `Clone` gain a `get`, which they did not have. Only actors with an
+  explicit view type see a difference, and it is the view they asked for; the
+  whole value is still available through `with(|state| state.clone())`.
+
+  Most call sites that need updating fail to compile. The exception is a value
+  passed to something generic, such as `log::info!("{:?}", handle.get().await)`
+  or a serializer, which keeps compiling and starts reporting the view.
+
+
 - `Handle::create_cache`, `Handle::spawn_throttle` and `Handle::spawn_async_throttle`,
   and their `ReadHandle` counterparts, no longer require the actor type to be
   `Clone`. Each of them seeded itself by cloning the whole actor value out with

--- a/actify-macros/src/parse.rs
+++ b/actify-macros/src/parse.rs
@@ -135,7 +135,7 @@ impl MethodInfo {
         let mut errors = None;
 
         // A `&self` method cannot change the state, so it only broadcasts when
-        // asked to. Interior mutability and a custom `to_broadcast` are the
+        // asked to. Interior mutability and a custom `to_view` are the
         // cases where that is meaningful.
         let broadcasts = if skip_all_broadcasts {
             if let Some(attr) = skip_attr {

--- a/actify-test/src/main.rs
+++ b/actify-test/src/main.rs
@@ -1,6 +1,6 @@
 //! This workspace is used to test the functionalities of actify as would any user that imports the library
 
-use actify::{BroadcastAs, Handle, actify};
+use actify::{Handle, ToView, actify};
 use std::{collections::HashMap, fmt::Debug, sync::Mutex};
 
 fn main() {}
@@ -326,8 +326,8 @@ struct InteriorMutabilityActor {
     value: Mutex<i32>,
 }
 
-impl BroadcastAs<i32> for InteriorMutabilityActor {
-    fn to_broadcast(&self) -> i32 {
+impl ToView<i32> for InteriorMutabilityActor {
+    fn to_view(&self) -> i32 {
         *self.value.lock().unwrap()
     }
 }

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -13,7 +13,7 @@ use crate::{Frequency, Throttle, Throttled};
 /// Create one via [`Handle::create_cache`](crate::Handle::create_cache) (initialized with the
 /// current actor value), [`Handle::create_cache_from`](crate::Handle::create_cache_from) (custom
 /// initial value), or [`Handle::create_cache_from_default`](crate::Handle::create_cache_from_default)
-/// (starts from `T::default()`).
+/// (starts from `V::default()`).
 ///
 /// # Cloning
 ///
@@ -45,15 +45,15 @@ use crate::{Frequency, Throttle, Throttled};
 /// # }
 /// ```
 #[derive(Debug)]
-pub struct Cache<T> {
-    inner: T,
-    rx: broadcast::Receiver<T>,
+pub struct Cache<V> {
+    inner: V,
+    rx: broadcast::Receiver<V>,
     first_request: bool,
 }
 
-impl<T> Clone for Cache<T>
+impl<V> Clone for Cache<V>
 where
-    T: Clone + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
 {
     fn clone(&self) -> Self {
         // resubscribe starts after the values this cache has not read yet, so
@@ -67,11 +67,11 @@ where
     }
 }
 
-impl<T> Cache<T>
+impl<V> Cache<V>
 where
-    T: Clone + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
 {
-    pub(crate) fn new(rx: Receiver<T>, initial_value: T) -> Self {
+    pub(crate) fn new(rx: Receiver<V>, initial_value: V) -> Self {
         Self {
             inner: initial_value,
             rx,
@@ -85,7 +85,7 @@ where
         first
     }
 
-    fn store(&mut self, val: T) -> &T {
+    fn store(&mut self, val: V) -> &V {
         self.inner = val;
         &self.inner
     }
@@ -107,7 +107,7 @@ where
                 Err(TryRecvError::Empty) => return Ok(received),
                 Err(TryRecvError::Closed) if received => return Ok(true),
                 Err(TryRecvError::Closed) => return Err(CacheRecvNewestError::Closed),
-                Err(TryRecvError::Lagged(nr)) => log_lag::<T>(nr),
+                Err(TryRecvError::Lagged(nr)) => log_lag::<V>(nr),
             }
         }
     }
@@ -216,7 +216,7 @@ where
     /// assert_eq!(cache.try_recv().unwrap(), None);
     /// # }
     /// ```
-    pub fn get_newest(&mut self) -> &T {
+    pub fn get_newest(&mut self) -> &V {
         _ = self.try_recv_newest(); // Update if possible
         self.get_current()
     }
@@ -242,7 +242,7 @@ where
     /// assert_eq!(cache.get_current(), &1);
     /// # }
     /// ```
-    pub fn get_current(&self) -> &T {
+    pub fn get_current(&self) -> &V {
         &self.inner
     }
 
@@ -279,7 +279,7 @@ where
     /// assert_eq!(cache.recv_newest().await.unwrap(), &3);
     /// # }
     /// ```
-    pub async fn recv_newest(&mut self) -> Result<&T, CacheRecvNewestError> {
+    pub async fn recv_newest(&mut self) -> Result<&V, CacheRecvNewestError> {
         if self.is_first_request() {
             return Ok(self.get_newest());
         }
@@ -291,7 +291,7 @@ where
                     break;
                 }
                 Err(RecvError::Closed) => return Err(CacheRecvNewestError::Closed),
-                Err(RecvError::Lagged(nr)) => log_lag::<T>(nr),
+                Err(RecvError::Lagged(nr)) => log_lag::<V>(nr),
             }
         }
         _ = self.drain_to_newest();
@@ -331,7 +331,7 @@ where
     /// assert_eq!(cache.recv().await.unwrap(), &2);
     /// # }
     /// ```
-    pub async fn recv(&mut self) -> Result<&T, CacheRecvError> {
+    pub async fn recv(&mut self) -> Result<&V, CacheRecvError> {
         if self.is_first_request() {
             return Ok(self.get_current());
         }
@@ -394,7 +394,7 @@ where
     /// assert_eq!(cache.try_recv_newest().unwrap(), None);
     /// # }
     /// ```
-    pub fn try_recv_newest(&mut self) -> Result<Option<&T>, CacheRecvNewestError> {
+    pub fn try_recv_newest(&mut self) -> Result<Option<&V>, CacheRecvNewestError> {
         let first = self.is_first_request();
         let received = self.drain_to_newest()?;
         if received || first {
@@ -457,7 +457,7 @@ where
     /// assert_eq!(cache.try_recv().unwrap(), None);
     /// # }
     /// ```
-    pub fn try_recv(&mut self) -> Result<Option<&T>, CacheRecvError> {
+    pub fn try_recv(&mut self) -> Result<Option<&V>, CacheRecvError> {
         if self.is_first_request() {
             return Ok(Some(self.get_current()));
         }
@@ -503,7 +503,7 @@ where
     /// }).join().unwrap();
     /// # }
     /// ```
-    pub fn blocking_recv(&mut self) -> Result<&T, CacheRecvError> {
+    pub fn blocking_recv(&mut self) -> Result<&V, CacheRecvError> {
         if self.is_first_request() {
             return Ok(self.get_current());
         }
@@ -545,7 +545,7 @@ where
     /// }).join().unwrap();
     /// # }
     /// ```
-    pub fn blocking_recv_newest(&mut self) -> Result<&T, CacheRecvNewestError> {
+    pub fn blocking_recv_newest(&mut self) -> Result<&V, CacheRecvNewestError> {
         if self.is_first_request() {
             return Ok(self.get_newest());
         }
@@ -559,7 +559,7 @@ where
                     }
                 }
                 Err(RecvError::Closed) => return Err(CacheRecvNewestError::Closed),
-                Err(RecvError::Lagged(nr)) => log_lag::<T>(nr),
+                Err(RecvError::Lagged(nr)) => log_lag::<V>(nr),
             }
         }
     }
@@ -596,9 +596,9 @@ where
     /// assert_eq!(cache.get_current(), &3);
     /// # }
     /// ```
-    pub async fn wait_until<P>(&mut self, mut predicate: P) -> Result<&T, CacheRecvNewestError>
+    pub async fn wait_until<P>(&mut self, mut predicate: P) -> Result<&V, CacheRecvNewestError>
     where
-        P: FnMut(&T) -> bool,
+        P: FnMut(&V) -> bool,
     {
         if self.is_first_request() && predicate(self.get_current()) {
             return Ok(&self.inner);
@@ -613,7 +613,7 @@ where
                 }
                 // Values were dropped, so one of them may have satisfied the
                 // predicate. Nothing can recover them, so the wait goes on.
-                Err(RecvError::Lagged(nr)) => log_lag::<T>(nr),
+                Err(RecvError::Lagged(nr)) => log_lag::<V>(nr),
                 Err(RecvError::Closed) => return Err(CacheRecvNewestError::Closed),
             }
         }
@@ -633,7 +633,7 @@ where
     pub fn spawn_throttle<C, F, Fun>(&mut self, client: C, call: Fun, freq: Frequency) -> Throttle
     where
         C: Send + Sync + 'static,
-        T: Throttled<F>,
+        V: Throttled<F>,
         F: Send + Sync + 'static,
         Fun: Fn(&C, F) + Send + 'static,
     {
@@ -663,7 +663,7 @@ where
     ) -> Throttle
     where
         C: Send + Sync + 'static,
-        T: Throttled<F>,
+        V: Throttled<F>,
         F: Send + Sync + 'static,
         Fun: for<'a> Fn(&'a C, F) -> BoxFuture<'a> + Send + 'static,
     {
@@ -676,10 +676,10 @@ where
     }
 }
 
-fn log_lag<T>(nr: u64) {
+fn log_lag<V>(nr: u64) {
     log::debug!(
         "A receiver on actor type {} lagged {nr:?} messages",
-        std::any::type_name::<T>()
+        std::any::type_name::<V>()
     );
 }
 

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -12,19 +12,22 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 const DOWNCAST_FAIL: &str =
     "Actify Macro error: failed to downcast arguments to their concrete type";
 
-/// Defines how to convert an actor's value to its broadcast type.
+/// Defines the view an actor exposes: the type `V` that [`Handle::get`] returns
+/// and that the actor broadcasts.
 ///
-/// A blanket implementation is provided for [`Clone`] types, broadcasting
-/// themselves. Implement this trait to broadcast a different type `V` from
-/// your actor type `T`, enabling:
+/// A blanket implementation is provided for [`Clone`] types, whose view is
+/// themselves. Implement this trait to expose a different type `V` from your
+/// actor type `T`, which allows:
 ///
-/// - Non-Clone types to participate in broadcasting
-/// - Clone types to broadcast a lightweight summary instead of the full value
+/// - Non-Clone types to be read and broadcast
+/// - Clone types to expose a lightweight summary instead of the full value
+///
+/// [`Handle::with`] reads the actor type itself either way.
 ///
 /// # Examples
 ///
 /// ```
-/// use actify::BroadcastAs;
+/// use actify::ToView;
 ///
 /// struct HeavyState {
 ///     data: Vec<u8>,
@@ -34,35 +37,36 @@ const DOWNCAST_FAIL: &str =
 /// #[derive(Clone, Debug)]
 /// struct Summary(String);
 ///
-/// impl BroadcastAs<Summary> for HeavyState {
-///     fn to_broadcast(&self) -> Summary {
+/// impl ToView<Summary> for HeavyState {
+///     fn to_view(&self) -> Summary {
 ///         Summary(self.summary.clone())
 ///     }
 /// }
 /// ```
-pub trait BroadcastAs<V> {
-    /// Produces the value to broadcast to subscribers.
+pub trait ToView<V> {
+    /// Produces the view of the actor.
     ///
-    /// Runs on the actor task after every broadcasting method.
-    fn to_broadcast(&self) -> V;
+    /// Runs on the actor task, after every broadcasting method and on every
+    /// [`Handle::get`].
+    fn to_view(&self) -> V;
 }
 
-impl<T: Clone> BroadcastAs<T> for T {
-    fn to_broadcast(&self) -> T {
+impl<T: Clone> ToView<T> for T {
+    fn to_view(&self) -> T {
         self.clone()
     }
 }
 
 /// Creates the broadcast function that the [`Actor`] calls after each `&mut self` method.
-/// Converts the actor value to `V` via [`BroadcastAs`] and sends it to all subscribers.
+/// Converts the actor value to `V` via [`ToView`] and sends it to all subscribers.
 fn make_broadcast_fn<T, V>(sender: broadcast::Sender<V>) -> BroadcastFn<T>
 where
-    T: BroadcastAs<V>,
+    T: ToView<V>,
     V: Clone + Send + Sync + 'static,
 {
     Box::new(move |inner: &T, method: &str| {
         if sender.receiver_count() > 0 {
-            if sender.send(inner.to_broadcast()).is_err() {
+            if sender.send(inner.to_view()).is_err() {
                 log::trace!("Broadcast failed because there are no active receivers on {method:?}");
             } else {
                 log::trace!("Broadcasted new value on {method:?}");
@@ -79,10 +83,12 @@ where
 /// access across tasks. For read-only access, see [`ReadHandle`]. For local
 /// synchronization, see [`Cache`]. For rate-limited updates, see [`Throttle`].
 ///
-/// The second type parameter `V` is the broadcast type. By default `V = T`,
-/// meaning the actor broadcasts clones of itself. To broadcast a different
-/// type, implement [`BroadcastAs<V>`] and specify `V` explicitly
-/// (e.g. `Handle::<MyType, Summary>::new(val)`).
+/// The second type parameter `V` is the view the handle exposes: what
+/// [`Handle::get`] returns and what the actor broadcasts. By default `V = T`,
+/// so reads and broadcasts are clones of the actor itself. To expose a
+/// different type, implement [`ToView<V>`] and specify `V` explicitly
+/// (e.g. `Handle::<MyType, Summary>::new(val)`). [`Handle::with`] always reads
+/// the actor type.
 pub struct Handle<T, V = T> {
     pub(super) tx: mpsc::Sender<Job<T>>,
     pub(super) broadcast_sender: broadcast::Sender<V>,
@@ -113,7 +119,7 @@ impl<T: Default + Clone + Send + Sync + 'static> Default for Handle<T> {
 
 impl<T, V> Handle<T, V>
 where
-    T: BroadcastAs<V> + Send + Sync + 'static,
+    T: ToView<V> + Send + Sync + 'static,
     V: Clone + Send + Sync + 'static,
 {
     /// Creates a new [`Handle`] and spawns the corresponding [`Actor`].
@@ -122,17 +128,17 @@ where
     /// itself and you can simply write `Handle::new(val)`.
     ///
     /// For non-Clone types (or to broadcast a lightweight summary), implement
-    /// [`BroadcastAs<V>`] and specify `V` explicitly:
+    /// [`ToView<V>`] and specify `V` explicitly:
     ///
     /// ```
-    /// # use actify::{Handle, BroadcastAs};
+    /// # use actify::{Handle, ToView};
     /// # #[tokio::main]
     /// # async fn main() {
     /// #[derive(Clone, Debug, PartialEq)]
     /// struct Size(usize);
     ///
-    /// impl BroadcastAs<Size> for Vec<u8> {
-    ///     fn to_broadcast(&self) -> Size { Size(self.len()) }
+    /// impl ToView<Size> for Vec<u8> {
+    ///     fn to_view(&self) -> Size { Size(self.len()) }
     /// }
     ///
     /// let handle: Handle<Vec<u8>, Size> = Handle::new(vec![1, 2, 3]);
@@ -165,7 +171,7 @@ where
         F: Send + Sync + 'static,
         Fun: Fn(&C, F) + Send + 'static,
     {
-        let init = val.to_broadcast();
+        let init = val.to_view();
         let handle = Self::new(val);
         let receiver = handle.subscribe();
         Throttle::spawn_from_receiver(client, call, freq, receiver, Some(init));
@@ -220,6 +226,35 @@ where
         }
     }
 
+    /// Returns the actor's current view, the type `V` it broadcasts.
+    ///
+    /// For a `Clone` actor type without a [`ToView`] implementation of its own,
+    /// `V` is the actor type and this is a clone of the whole value. Otherwise it
+    /// is whatever [`ToView::to_view`] produces, and [`Handle::with`] reads the
+    /// actor value itself.
+    /// Does not broadcast.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::Handle;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(1);
+    /// let result = handle.get().await;
+    /// assert_eq!(result, 1);
+    /// # }
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the actor has stopped, either because one of its methods
+    /// panicked or because its runtime shut down. See [Actor lifetime and
+    /// panics](crate#actor-lifetime-and-panics).
+    pub async fn get(&self) -> V {
+        self.run((), |s, _| s.inner.to_view()).await
+    }
+
     /// Creates an initialized [`Cache`] that locally synchronizes with the remote actor.
     /// As it is initialized with the current value, any updates before or during construction are included.
     ///
@@ -234,7 +269,7 @@ where
         // Subscribe before reading, so an update arriving in between is queued
         // rather than lost.
         let rx = self.subscribe();
-        let init = self.with(|inner| inner.to_broadcast()).await;
+        let init = self.get().await;
         Cache::new(rx, init)
     }
 
@@ -284,7 +319,7 @@ where
         // Subscribe before reading, so an update arriving in between is queued
         // rather than lost.
         let receiver = self.subscribe();
-        let current = self.with(|inner| inner.to_broadcast()).await;
+        let current = self.get().await;
         Throttle::spawn_from_receiver(client, call, freq, receiver, Some(current))
     }
 
@@ -412,7 +447,7 @@ where
         // Subscribe before reading, so an update arriving in between is queued
         // rather than lost.
         let receiver = self.subscribe();
-        let current = self.with(|inner| inner.to_broadcast()).await;
+        let current = self.get().await;
         Throttle::spawn_async_from_receiver(client, call, freq, receiver, Some(current))
     }
 }
@@ -664,32 +699,6 @@ impl<T: Send + Sync + 'static, V> Handle<T, V> {
             result
         })
         .await
-    }
-}
-
-impl<T: Clone + Send + Sync + 'static, V> Handle<T, V> {
-    /// Receives a clone of the current value of the actor.
-    /// Does not broadcast.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use actify::Handle;
-    /// # #[tokio::main]
-    /// # async fn main() {
-    /// let handle = Handle::new(1);
-    /// let result = handle.get().await;
-    /// assert_eq!(result, 1);
-    /// # }
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// Panics if the actor has stopped, either because one of its methods
-    /// panicked or because its runtime shut down. See [Actor lifetime and
-    /// panics](crate#actor-lifetime-and-panics).
-    pub async fn get(&self) -> T {
-        self.run((), |s, _| s.inner.clone()).await
     }
 }
 
@@ -1008,8 +1017,8 @@ mod tests {
             }
         }
 
-        impl BroadcastAs<i32> for Counted {
-            fn to_broadcast(&self) -> i32 {
+        impl ToView<i32> for Counted {
+            fn to_view(&self) -> i32 {
                 self.value
             }
         }
@@ -1027,8 +1036,9 @@ mod tests {
             assert_eq!(cache.get_current(), &1);
             assert_eq!(clones.load(Ordering::SeqCst), 0);
 
-            // Reading the value does clone it, so the count above is a count.
-            let _ = handle.get().await;
+            // Reading the actor value itself does clone it, which is what makes
+            // the zero above a count rather than a broken counter.
+            let _ = handle.with(|state| state.clone()).await;
             assert_eq!(clones.load(Ordering::SeqCst), 1);
         }
     }
@@ -1208,8 +1218,8 @@ mod tests {
         }
     }
 
-    impl BroadcastAs<i32> for NonCloneActor {
-        fn to_broadcast(&self) -> i32 {
+    impl ToView<i32> for NonCloneActor {
+        fn to_view(&self) -> i32 {
             self.value
         }
     }
@@ -1244,8 +1254,8 @@ mod tests {
         count: usize,
     }
 
-    impl BroadcastAs<usize> for BigState {
-        fn to_broadcast(&self) -> usize {
+    impl ToView<usize> for BigState {
+        fn to_view(&self) -> usize {
             self.count
         }
     }
@@ -1285,7 +1295,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_clone_actor_with_custom_broadcast() {
+    async fn test_clone_actor_with_custom_view() {
         let handle: Handle<BigState, usize> = Handle::new(BigState {
             data: vec![1, 2, 3],
             count: 3,
@@ -1293,19 +1303,16 @@ mod tests {
 
         let mut rx = handle.subscribe();
 
-        let val = handle.get().await;
-        assert_eq!(val.count, 3);
+        assert_eq!(handle.get().await, 3);
 
-        let new_big_state = BigState {
+        let updated = BigState {
             data: vec![1, 2, 3, 4],
             count: 4,
         };
-        handle.set(new_big_state.clone()).await;
+        handle.set(updated.clone()).await;
 
-        let broadcast_val: usize = rx.recv().await.unwrap();
-        assert_eq!(broadcast_val, 4);
-
-        let big_state = handle.get().await;
-        assert_eq!(big_state, new_big_state);
+        assert_eq!(rx.recv().await.unwrap(), 4);
+        assert_eq!(handle.get().await, 4);
+        assert_eq!(handle.with(|state| state.clone()).await, updated);
     }
 }

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -1033,6 +1033,39 @@ mod tests {
         }
     }
 
+    /// `V` is what a handle exposes: reads return it, and the actor type stays
+    /// private behind `with`.
+    mod views {
+        use super::*;
+
+        fn big() -> Handle<BigState, usize> {
+            Handle::new(BigState {
+                data: vec![1, 2, 3],
+                count: 7,
+            })
+        }
+
+        #[tokio::test]
+        async fn test_get_returns_the_view_not_the_state() {
+            assert_eq!(big().get().await, 7);
+        }
+
+        #[tokio::test]
+        async fn test_a_non_clone_actor_can_be_read() {
+            let handle: Handle<NonCloneActor, i32> = Handle::new(NonCloneActor { value: 1 });
+
+            assert_eq!(handle.get().await, 1);
+            assert_eq!(handle.get_read_handle().get().await, 1);
+        }
+
+        #[tokio::test]
+        async fn test_the_state_stays_reachable_through_with() {
+            let handle = big();
+
+            assert_eq!(handle.with(|state| state.data.clone()).await, vec![1, 2, 3]);
+        }
+    }
+
     fn panic_message(error: tokio::task::JoinError) -> String {
         let panic = error.into_panic();
         panic

--- a/actify/src/handles/mod.rs
+++ b/actify/src/handles/mod.rs
@@ -3,5 +3,5 @@ mod read_handle;
 
 #[cfg(test)]
 pub(crate) use handle::CHANNEL_SIZE;
-pub use handle::{BroadcastAs, Handle};
+pub use handle::{Handle, ToView};
 pub use read_handle::ReadHandle;

--- a/actify/src/handles/read_handle.rs
+++ b/actify/src/handles/read_handle.rs
@@ -2,7 +2,7 @@ use std::any::type_name;
 use std::fmt::{self, Debug};
 use tokio::sync::broadcast;
 
-use super::handle::{BroadcastAs, Handle};
+use super::handle::{Handle, ToView};
 use crate::Cache;
 use crate::throttle::{BoxFuture, Frequency, Throttle, Throttled};
 
@@ -54,23 +54,23 @@ impl<T, V> ReadHandle<T, V> {
 impl<T: Send + Sync + 'static, V> ReadHandle<T, V> {
     /// Runs a read-only closure on the actor's value and returns the result.
     ///
-    /// This is especially useful for non-Clone types where [`ReadHandle::get`]
-    /// is not available, but it works with any actor type.
+    /// Unlike [`ReadHandle::get`], which returns the view, this reads the actor
+    /// type itself.
     ///
     /// # Examples
     ///
     /// ```
-    /// # use actify::{Handle, BroadcastAs};
+    /// # use actify::{Handle, ToView};
     /// # #[tokio::main]
     /// # async fn main() {
-    /// // A non-Clone type, so get() is not available on ReadHandle
+    /// // A non-Clone type, so its view is a separate type
     /// struct Inventory { items: Vec<String> }
     ///
     /// #[derive(Clone, Debug)]
     /// struct Count(usize);
     ///
-    /// impl BroadcastAs<Count> for Inventory {
-    ///     fn to_broadcast(&self) -> Count { Count(self.items.len()) }
+    /// impl ToView<Count> for Inventory {
+    ///     fn to_view(&self) -> Count { Count(self.items.len()) }
     /// }
     ///
     /// let handle: Handle<Inventory, Count> = Handle::new(Inventory {
@@ -101,32 +101,6 @@ impl<T: Send + Sync + 'static, V> ReadHandle<T, V> {
     }
 }
 
-impl<T: Clone + Send + Sync + 'static, V> ReadHandle<T, V> {
-    /// Receives a clone of the current value of the actor.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use actify::Handle;
-    /// # #[tokio::main]
-    /// # async fn main() {
-    /// let handle = Handle::new(1);
-    /// let read_handle = handle.get_read_handle();
-    /// let result = read_handle.get().await;
-    /// assert_eq!(result, 1);
-    /// # }
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// Panics if the actor has stopped, either because one of its methods
-    /// panicked or because its runtime shut down. See [Actor lifetime and
-    /// panics](crate#actor-lifetime-and-panics).
-    pub async fn get(&self) -> T {
-        self.0.get().await
-    }
-}
-
 impl<T, V: Clone + Send + Sync + 'static> ReadHandle<T, V> {
     /// Creates a [`Cache`] initialized with the given value that locally synchronizes
     /// with broadcasted updates from the actor.
@@ -145,7 +119,7 @@ impl<T, V: Default + Clone + Send + Sync + 'static> ReadHandle<T, V> {
 
 impl<T, V> ReadHandle<T, V>
 where
-    T: BroadcastAs<V> + Send + Sync + 'static,
+    T: ToView<V> + Send + Sync + 'static,
     V: Clone + Send + Sync + 'static,
 {
     /// Creates an initialized [`Cache`] that locally synchronizes with the remote actor.
@@ -203,6 +177,30 @@ where
         Fun: for<'a> Fn(&'a C, F) -> BoxFuture<'a> + Send + 'static,
     {
         self.0.spawn_async_throttle(client, call, freq).await
+    }
+
+    /// Returns the actor's current view. See [`Handle::get`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::Handle;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(1);
+    /// let read_handle = handle.get_read_handle();
+    /// let result = read_handle.get().await;
+    /// assert_eq!(result, 1);
+    /// # }
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the actor has stopped, either because one of its methods
+    /// panicked or because its runtime shut down. See [Actor lifetime and
+    /// panics](crate#actor-lifetime-and-panics).
+    pub async fn get(&self) -> V {
+        self.0.get().await
     }
 
     /// Waits until the broadcast value satisfies `predicate` and returns it.

--- a/actify/src/lib.rs
+++ b/actify/src/lib.rs
@@ -192,11 +192,13 @@
 //!
 //! Every [`Handle`] provides a set of built-in methods that work without the macro:
 //!
-//! - [`Handle::get`]: returns a clone of the current actor value (does not broadcast)
+//! - [`Handle::get`]: returns the actor's view, which for a plain `Clone` actor is a
+//!   clone of the value itself (does not broadcast)
 //! - [`Handle::set`]: overwrites the actor value (broadcasts the change)
 //! - [`Handle::set_if_changed`]: only broadcasts when the new value differs (requires `PartialEq`)
 //! - [`Handle::subscribe`]: returns a [`tokio::sync::broadcast::Receiver`] for change notifications
-//! - [`Handle::with`]: runs a read-only closure on `&T` (does not broadcast)
+//! - [`Handle::with`]: runs a read-only closure on `&T`, the actor type rather than
+//!   its view (does not broadcast)
 //! - [`Handle::with_mut`]: runs a mutable closure on `&mut T` (broadcasts the change)
 //! - [`Handle::wait_until`]: waits until the broadcast value satisfies a predicate
 //!
@@ -246,12 +248,12 @@
 //! observe, which requires interior mutability:
 //!
 //! ```
-//! # use actify::{Handle, actify, BroadcastAs};
+//! # use actify::{Handle, actify, ToView};
 //! # use std::sync::Mutex;
 //! # #[derive(Debug)]
 //! # struct Counter { value: Mutex<i32> }
-//! # impl BroadcastAs<i32> for Counter {
-//! #     fn to_broadcast(&self) -> i32 { *self.value.lock().unwrap() }
+//! # impl ToView<i32> for Counter {
+//! #     fn to_view(&self) -> i32 { *self.value.lock().unwrap() }
 //! # }
 //! #[actify]
 //! impl Counter {
@@ -369,12 +371,17 @@
 //! - [`HashMapHandle`] for `Handle<HashMap<K, V>>`
 //! - [`HashSetHandle`] for `Handle<HashSet<K>>`
 //!
-//! # Non-Clone types
+//! # Views and non-Clone types
 //!
-//! By default, [`Handle::new`] requires `T: Clone` so it can broadcast `T`.
-//! For non-Clone types, implement [`BroadcastAs<V>`] for a Clone-able summary
-//! type `V` and specify it explicitly: `Handle::<MyType, Summary>::new(val)`.
-//! Your `#[actify]` methods work normally either way.
+//! A handle exposes a view of its actor: the type `V` that [`Handle::get`]
+//! returns and that the actor broadcasts. By default `V = T`, so
+//! [`Handle::new`] requires `T: Clone` and the view is a clone of the value.
+//!
+//! For a non-Clone type, or to expose a summary instead of the whole value,
+//! implement [`ToView<V>`] for a Clone-able `V` and name it explicitly:
+//! `Handle::<MyType, Summary>::new(val)`. Reads then return the summary, and
+//! [`Handle::with`] reads the actor type itself. Your `#[actify]` methods work
+//! normally either way.
 //!
 //! # Execution model
 //!
@@ -460,7 +467,7 @@ pub use cache::{Cache, CacheRecvError, CacheRecvNewestError};
 pub use extensions::{
     map::HashMapHandle, option::OptionHandle, set::HashSetHandle, vec::VecHandle,
 };
-pub use handles::{BroadcastAs, Handle, ReadHandle};
+pub use handles::{Handle, ReadHandle, ToView};
 pub use throttle::{BoxFuture, Frequency, Throttle, Throttled};
 
 #[doc(hidden)]


### PR DESCRIPTION
Item 21, from reviewing #108. `T: Clone` survived in exactly one place, `get`, and it was there because `get` returned the actor type while every other read path returned `V`.

```rust
pub async fn get(&self) -> V {
    self.run((), |s, _| s.inner.to_view()).await
}
```

`V` is now the view a handle exposes: `get`, `subscribe`, `Cache`, `Throttle` and `wait_until` all speak it. `with` and `with_mut` reach the actor type. That is a model that fits in one sentence, which the old one did not.

`BroadcastAs<V>` becomes `ToView<V>` and `to_broadcast` becomes `to_view`, since the trait now decides more than what gets broadcast. `To*` is Rust's convention for an owned conversion that may cost something, as in `ToString` and `ToOwned`.

## What this does and does not change

- **`V = T`, the default for every `Clone` actor: nothing changes.** `V = T` implies `T: Clone`, so the blanket impl applies and `to_view` is `clone`. Same type, same cost, same behaviour. This is every actor in the consumer repo.
- **Non-Clone actors gain `get`.** They had none, and `ReadHandle::with`'s docs used to say so out loud. That sentence is gone.
- **Explicit view types see the difference they asked for.** The whole value is still available with `with(|state| state.clone())`, which makes the cost visible at the call site.
- The three internal `with(|inner| inner.to_view())` sites collapse to `self.get().await`, which is what they said before #108 and were wrong to say.
- One more impl block goes away, since `get` moves into the `ToView` block. `Handle` and `ReadHandle` are down to five each.

Also renames `Cache<T>`'s parameter to `Cache<V>`, in its own commit. A cache always holds the handle's view type, and calling it `T` invited exactly the misreading it caused in review. Type parameter names are not API, so this changes nothing but reading.

## Migration

Most affected call sites fail to compile, since the type changes. The exception is a value flowing into something generic:

```rust
log::info!("{:?}", handle.get().await);        // still compiles, now logs the view
serde_json::to_string(&handle.get().await)?;  // still compiles, now serializes the view
```

That only affects actors with an explicit view type, of which the consumer has none, but it is worth a grep and it is in the changelog for the migration guide to pick up.

## Verification

Three new tests: `get` returns the view rather than the state, a non-Clone actor can be read through both handle types, and the state stays reachable through `with`. The first two do not compile before the change.

One pre-existing test migrated rather than adapted away: `test_clone_actor_with_custom_broadcast` read full state through `get`, which is exactly the case this changes. It now asserts all three facts, that the view is what `get` and the broadcast give, and that `with` still yields the state.

The clone counter from #108 also caught something real. Its control assertion was `get` clones the value, which is no longer true, so the control moved to `with(|state| state.clone())`. The test now reads as: creating a cache clones nothing, and cloning the state is explicit.

Full local gate green: workspace tests, `-p actify`, clippy `--all-targets --all-features -D warnings`, fmt, docs with `-D warnings` both with and without `--all-features`, 1.85 MSRV, and the trybuild snapshots with `TRYBUILD_TESTS=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)