### PR TITLE
One error type for a cache receive, and no thiserror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,10 +51,9 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 ### Changed
 
 - **Breaking:** `CacheRecvNewestError` is gone. Every receive on a `Cache`
-  returns `CacheRecvError`, which is now `#[non_exhaustive]`. The methods that
-  skip to the newest value never return `Lagged`, which each of them documents;
-  a caller of those matched a single-variant enum before and now matches one
-  variant plus the wildcard that `#[non_exhaustive]` requires anyway.
+  returns `CacheRecvError`. The methods that skip to the newest value never
+  return `Lagged`, which each of them documents, so a caller of those gains a
+  match arm that cannot be reached. Matching stays exhaustive.
 
 - The `thiserror` dependency is dropped. `CacheRecvError` implements `Display`
   and `Error` by hand, with the same messages: `Cache channel closed` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,17 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 
 ### Changed
 
+- **Breaking:** `CacheRecvNewestError` is gone. Every receive on a `Cache`
+  returns `CacheRecvError`, which is now `#[non_exhaustive]`. The methods that
+  skip to the newest value never return `Lagged`, which each of them documents;
+  a caller of those matched a single-variant enum before and now matches one
+  variant plus the wildcard that `#[non_exhaustive]` requires anyway.
+
+- The `thiserror` dependency is dropped. `CacheRecvError` implements `Display`
+  and `Error` by hand, with the same messages: `Cache channel closed` and
+  `Cache channel lagged by {n}`.
+
+
 - **Breaking:** `BroadcastAs<V>` is renamed to `ToView<V>` and `to_broadcast` to
   `to_view`, because the trait no longer decides only what is broadcast.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,6 @@ version = "0.8.3"
 dependencies = [
  "actify-macros",
  "log",
- "thiserror",
  "tokio",
 ]
 
@@ -456,26 +455,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/actify/Cargo.toml
+++ b/actify/Cargo.toml
@@ -10,7 +10,6 @@ documentation = "https://docs.rs/actify/latest/actify/"
 readme = "../README.md"
 
 [dependencies]
-thiserror = "2.0.12"
 tokio = { version = "1.44.1", features = ["full"] }
 log = "0.4"
 actify-macros = { path = "../actify-macros", version = "0.5.0" }

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -700,7 +700,6 @@ fn log_lag<V>(nr: u64) {
 /// [`Lagged`](Self::Lagged), because falling behind is what they are for. Their
 /// documentation says so individually.
 #[derive(Debug, PartialEq, Clone)]
-#[non_exhaustive]
 pub enum CacheRecvError {
     /// The actor has stopped and every update it broadcast has been delivered.
     Closed,

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -735,44 +735,24 @@ mod tests {
     use crate::Handle;
     use tokio::time::{Duration, sleep};
 
-    mod errors {
-        use super::*;
+    /// One error type covers the whole receive family. The `_newest` methods
+    /// never lag, which their docs state, but they no longer need a type of
+    /// their own to say so.
+    #[tokio::test(start_paused = true)]
+    async fn test_every_receive_reports_the_same_error_type() {
+        let handle = Handle::new(0);
+        let mut cache = handle.create_cache().await;
+        _ = cache.get_newest();
+        drop(handle);
 
-        /// One error type covers the whole receive family. The `_newest` methods
-        /// never lag, which their docs state, but they no longer need a type of
-        /// their own to say so.
-        #[tokio::test(start_paused = true)]
-        async fn test_every_receive_reports_the_same_error_type() {
-            let handle = Handle::new(0);
-            let mut cache = handle.create_cache().await;
-            _ = cache.get_newest();
-            drop(handle);
-
-            let expected: Result<&i32, CacheRecvError> = Err(CacheRecvError::Closed);
-            assert_eq!(cache.recv().await, expected);
-            assert_eq!(cache.recv_newest().await, expected);
-            assert_eq!(cache.try_recv(), Err(CacheRecvError::Closed));
-            assert_eq!(cache.try_recv_newest(), Err(CacheRecvError::Closed));
-            assert_eq!(cache.wait_until(|v| *v == 9).await, expected);
-        }
-
-        #[test]
-        fn test_the_error_reads_the_same_without_thiserror() {
-            assert_eq!(CacheRecvError::Closed.to_string(), "Cache channel closed");
-            assert_eq!(
-                CacheRecvError::Lagged(3).to_string(),
-                "Cache channel lagged by 3"
-            );
-        }
-
-        #[test]
-        fn test_the_error_is_an_error() {
-            fn assert_error<E: std::error::Error + Send + Sync + 'static>() {}
-            assert_error::<CacheRecvError>();
-
-            let boxed: Box<dyn std::error::Error> = Box::new(CacheRecvError::Closed);
-            assert!(boxed.source().is_none());
-        }
+        assert_eq!(cache.recv().await, Err(CacheRecvError::Closed));
+        assert_eq!(cache.recv_newest().await, Err(CacheRecvError::Closed));
+        assert_eq!(cache.try_recv(), Err(CacheRecvError::Closed));
+        assert_eq!(cache.try_recv_newest(), Err(CacheRecvError::Closed));
+        assert_eq!(
+            cache.wait_until(|v| *v == 9).await,
+            Err(CacheRecvError::Closed)
+        );
     }
 
     mod waiting {

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -718,6 +718,46 @@ mod tests {
     use crate::Handle;
     use tokio::time::{Duration, sleep};
 
+    mod errors {
+        use super::*;
+
+        /// One error type covers the whole receive family. The `_newest` methods
+        /// never lag, which their docs state, but they no longer need a type of
+        /// their own to say so.
+        #[tokio::test(start_paused = true)]
+        async fn test_every_receive_reports_the_same_error_type() {
+            let handle = Handle::new(0);
+            let mut cache = handle.create_cache().await;
+            _ = cache.get_newest();
+            drop(handle);
+
+            let expected: Result<&i32, CacheRecvError> = Err(CacheRecvError::Closed);
+            assert_eq!(cache.recv().await, expected);
+            assert_eq!(cache.recv_newest().await, expected);
+            assert_eq!(cache.try_recv(), Err(CacheRecvError::Closed));
+            assert_eq!(cache.try_recv_newest(), Err(CacheRecvError::Closed));
+            assert_eq!(cache.wait_until(|v| *v == 9).await, expected);
+        }
+
+        #[test]
+        fn test_the_error_reads_the_same_without_thiserror() {
+            assert_eq!(CacheRecvError::Closed.to_string(), "Cache channel closed");
+            assert_eq!(
+                CacheRecvError::Lagged(3).to_string(),
+                "Cache channel lagged by 3"
+            );
+        }
+
+        #[test]
+        fn test_the_error_is_an_error() {
+            fn assert_error<E: std::error::Error + Send + Sync + 'static>() {}
+            assert_error::<CacheRecvError>();
+
+            let boxed: Box<dyn std::error::Error> = Box::new(CacheRecvError::Closed);
+            assert!(boxed.source().is_none());
+        }
+    }
+
     mod waiting {
         use super::*;
         use tokio::time::{Instant, timeout};

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -1,5 +1,4 @@
-use std::fmt::Debug;
-use thiserror::Error;
+use std::fmt::{self, Debug};
 use tokio::sync::broadcast::{
     self, Receiver,
     error::{RecvError, TryRecvError},
@@ -96,7 +95,7 @@ where
     /// A closed channel is only reported once its queue is exhausted, so a final
     /// update broadcast before the actor stopped is still returned. Closing is
     /// permanent, so the next call reports it.
-    fn drain_to_newest(&mut self) -> Result<bool, CacheRecvNewestError> {
+    fn drain_to_newest(&mut self) -> Result<bool, CacheRecvError> {
         let mut received = false;
         loop {
             match self.rx.try_recv() {
@@ -106,7 +105,7 @@ where
                 }
                 Err(TryRecvError::Empty) => return Ok(received),
                 Err(TryRecvError::Closed) if received => return Ok(true),
-                Err(TryRecvError::Closed) => return Err(CacheRecvNewestError::Closed),
+                Err(TryRecvError::Closed) => return Err(CacheRecvError::Closed),
                 Err(TryRecvError::Lagged(nr)) => log_lag::<V>(nr),
             }
         }
@@ -258,8 +257,11 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`CacheRecvNewestError::Closed`] once the actor has been dropped
+    /// Returns [`CacheRecvError::Closed`] once the actor has been dropped
     /// and every update it broadcast has been delivered (after the first call).
+    ///
+    /// Never returns [`CacheRecvError::Lagged`]: falling behind is what skipping
+    /// to the newest value does.
     ///
     /// # Examples
     ///
@@ -279,7 +281,7 @@ where
     /// assert_eq!(cache.recv_newest().await.unwrap(), &3);
     /// # }
     /// ```
-    pub async fn recv_newest(&mut self) -> Result<&V, CacheRecvNewestError> {
+    pub async fn recv_newest(&mut self) -> Result<&V, CacheRecvError> {
         if self.is_first_request() {
             return Ok(self.get_newest());
         }
@@ -290,7 +292,7 @@ where
                     self.inner = val;
                     break;
                 }
-                Err(RecvError::Closed) => return Err(CacheRecvNewestError::Closed),
+                Err(RecvError::Closed) => return Err(CacheRecvError::Closed),
                 Err(RecvError::Lagged(nr)) => log_lag::<V>(nr),
             }
         }
@@ -353,9 +355,12 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`CacheRecvNewestError::Closed`] once the actor has been dropped
+    /// Returns [`CacheRecvError::Closed`] once the actor has been dropped
     /// and every update it broadcast has been delivered. A final update sent
     /// just before the actor stopped is therefore still returned.
+    ///
+    /// Never returns [`CacheRecvError::Lagged`]: falling behind is what skipping
+    /// to the newest value does.
     ///
     /// # Examples
     ///
@@ -394,7 +399,7 @@ where
     /// assert_eq!(cache.try_recv_newest().unwrap(), None);
     /// # }
     /// ```
-    pub fn try_recv_newest(&mut self) -> Result<Option<&V>, CacheRecvNewestError> {
+    pub fn try_recv_newest(&mut self) -> Result<Option<&V>, CacheRecvError> {
         let first = self.is_first_request();
         let received = self.drain_to_newest()?;
         if received || first {
@@ -525,8 +530,11 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`CacheRecvNewestError::Closed`] once the actor has been dropped
+    /// Returns [`CacheRecvError::Closed`] once the actor has been dropped
     /// and every update it broadcast has been delivered (after the first call).
+    ///
+    /// Never returns [`CacheRecvError::Lagged`]: falling behind is what skipping
+    /// to the newest value does.
     ///
     /// # Examples
     ///
@@ -545,7 +553,7 @@ where
     /// }).join().unwrap();
     /// # }
     /// ```
-    pub fn blocking_recv_newest(&mut self) -> Result<&V, CacheRecvNewestError> {
+    pub fn blocking_recv_newest(&mut self) -> Result<&V, CacheRecvError> {
         if self.is_first_request() {
             return Ok(self.get_newest());
         }
@@ -558,7 +566,7 @@ where
                         return Ok(&self.inner);
                     }
                 }
-                Err(RecvError::Closed) => return Err(CacheRecvNewestError::Closed),
+                Err(RecvError::Closed) => return Err(CacheRecvError::Closed),
                 Err(RecvError::Lagged(nr)) => log_lag::<V>(nr),
             }
         }
@@ -577,8 +585,11 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`CacheRecvNewestError::Closed`] once the actor has stopped and
+    /// Returns [`CacheRecvError::Closed`] once the actor has stopped and
     /// every update it broadcast has been tested.
+    ///
+    /// Never returns [`CacheRecvError::Lagged`]: a lagging channel is logged and
+    /// the wait continues.
     ///
     /// # Examples
     ///
@@ -596,7 +607,7 @@ where
     /// assert_eq!(cache.get_current(), &3);
     /// # }
     /// ```
-    pub async fn wait_until<P>(&mut self, mut predicate: P) -> Result<&V, CacheRecvNewestError>
+    pub async fn wait_until<P>(&mut self, mut predicate: P) -> Result<&V, CacheRecvError>
     where
         P: FnMut(&V) -> bool,
     {
@@ -614,7 +625,7 @@ where
                 // Values were dropped, so one of them may have satisfied the
                 // predicate. Nothing can recover them, so the wait goes on.
                 Err(RecvError::Lagged(nr)) => log_lag::<V>(nr),
-                Err(RecvError::Closed) => return Err(CacheRecvNewestError::Closed),
+                Err(RecvError::Closed) => return Err(CacheRecvError::Closed),
             }
         }
     }
@@ -683,17 +694,31 @@ fn log_lag<V>(nr: u64) {
     );
 }
 
-/// Error returned by [`Cache::recv`] and [`Cache::try_recv`].
-#[derive(Error, Debug, PartialEq, Clone)]
+/// Error returned when a [`Cache`] cannot deliver a value.
+///
+/// The methods that skip to the newest value never return
+/// [`Lagged`](Self::Lagged), because falling behind is what they are for. Their
+/// documentation says so individually.
+#[derive(Debug, PartialEq, Clone)]
+#[non_exhaustive]
 pub enum CacheRecvError {
     /// The actor has stopped and every update it broadcast has been delivered.
-    #[error("Cache channel closed")]
     Closed,
     /// The cache fell behind and the channel dropped the given number of
     /// updates. The cached value is unchanged.
-    #[error("Cache channel lagged by {0}")]
     Lagged(u64),
 }
+
+impl fmt::Display for CacheRecvError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CacheRecvError::Closed => write!(f, "Cache channel closed"),
+            CacheRecvError::Lagged(nr) => write!(f, "Cache channel lagged by {nr}"),
+        }
+    }
+}
+
+impl std::error::Error for CacheRecvError {}
 
 impl From<RecvError> for CacheRecvError {
     fn from(err: RecvError) -> Self {
@@ -702,14 +727,6 @@ impl From<RecvError> for CacheRecvError {
             RecvError::Lagged(nr) => CacheRecvError::Lagged(nr),
         }
     }
-}
-
-/// Error returned by [`Cache::recv_newest`] and [`Cache::try_recv_newest`].
-#[derive(Error, Debug, PartialEq, Clone)]
-pub enum CacheRecvNewestError {
-    /// The actor has stopped and every update it broadcast has been delivered.
-    #[error("Cache channel closed")]
-    Closed,
 }
 
 #[cfg(test)]
@@ -819,7 +836,7 @@ mod tests {
 
             assert_eq!(
                 finished(cache.wait_until(|v| *v == 9)).await,
-                Err(CacheRecvNewestError::Closed)
+                Err(CacheRecvError::Closed)
             );
         }
     }
@@ -1055,9 +1072,9 @@ mod tests {
 
         drop(handle);
         assert_eq!(cache.recv().await, Err(CacheRecvError::Closed));
-        assert_eq!(cache.recv_newest().await, Err(CacheRecvNewestError::Closed));
+        assert_eq!(cache.recv_newest().await, Err(CacheRecvError::Closed));
         assert_eq!(cache.try_recv(), Err(CacheRecvError::Closed));
-        assert_eq!(cache.try_recv_newest(), Err(CacheRecvNewestError::Closed));
+        assert_eq!(cache.try_recv_newest(), Err(CacheRecvError::Closed));
     }
 
     /// A value broadcast just before the actor stops is still buffered in the
@@ -1074,7 +1091,7 @@ mod tests {
 
         assert_eq!(cache.try_recv_newest().unwrap(), Some(&2));
         // Only once the queue is drained does the closed channel surface
-        assert_eq!(cache.try_recv_newest(), Err(CacheRecvNewestError::Closed));
+        assert_eq!(cache.try_recv_newest(), Err(CacheRecvError::Closed));
     }
 
     /// The same guarantee for the awaiting variant.
@@ -1089,7 +1106,7 @@ mod tests {
         sleep(Duration::from_millis(10)).await;
 
         assert_eq!(cache.recv_newest().await.unwrap(), &2);
-        assert_eq!(cache.recv_newest().await, Err(CacheRecvNewestError::Closed));
+        assert_eq!(cache.recv_newest().await, Err(CacheRecvError::Closed));
     }
 
     /// Fills the broadcast channel past its capacity, so the cache's receiver

--- a/actify/src/lib.rs
+++ b/actify/src/lib.rs
@@ -317,7 +317,7 @@
 //! [`Cache::wait_until`] waits until the cached value satisfies a predicate,
 //! reading through the cache so it holds the value that matched.
 //!
-//! See [`CacheRecvError`] and [`CacheRecvNewestError`] for possible error conditions.
+//! See [`CacheRecvError`] for the possible error conditions.
 //!
 //! # ReadHandle
 //!
@@ -463,7 +463,7 @@ mod throttle;
 
 // Reexport for easier reference
 pub use actify_macros::{actify, broadcast, skip_broadcast};
-pub use cache::{Cache, CacheRecvError, CacheRecvNewestError};
+pub use cache::{Cache, CacheRecvError};
 pub use extensions::{
     map::HashMapHandle, option::OptionHandle, set::HashSetHandle, vec::VecHandle,
 };


### PR DESCRIPTION
Item 9 of the 0.9.0 plan.

`CacheRecvNewestError` existed to express "this method cannot lag" in the type system, at the cost of a second error type for one channel and a single-variant enum. That fact now lives in the docs of the four methods it applies to, and everything returns `CacheRecvError`.

`CacheRecvError` stays exhaustively matchable. The plan had it gaining `#[non_exhaustive]`, and that is dropped: tokio's broadcast fails in exactly two ways, so a third variant is not foreseeable, and what the attribute buys is avoiding a breaking bump in a crate that ships breaking minors and has no 1.0 planned. The honest cost of the unification is therefore one match arm downstream that cannot be reached, and nothing else.

With only one small enum left, `thiserror` is no longer worth a dependency. `Display` and `Error` are written by hand, with the messages unchanged.

## Verification

One test: `test_every_receive_reports_the_same_error_type` drives all five methods (`recv`, `recv_newest`, `try_recv`, `try_recv_newest`, `wait_until`) against a dropped actor and asserts the same `Err(CacheRecvError::Closed)` from each. It does not compile before the change, which is the red.

The hand-written `Display` was mutation-verified while writing it, by changing the `Closed` text and by dropping the count from `Lagged`. The test that pinned those strings is not kept: it guarded this migration rather than an invariant, and keeping it would tax any future rewording. Two other tests were written and dropped for the same reason, one asserting the exact messages and one asserting `Error + Send + Sync`, which the compiler already enforces at the impl.

`cargo tree -p actify | grep thiserror` returns nothing.

Full local gate green: workspace tests, `-p actify`, clippy `--all-targets --all-features -D warnings`, fmt, docs with `-D warnings` both with and without `--all-features`, and a 1.85 MSRV check.

## Not in this PR

The plan bundled `Frequency` losing `Ord`/`PartialOrd` and gaining `#[non_exhaustive]` into this item. That is a different type with a different reason, so it is going in its own small PR rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

