### PR TITLE
Frequency stops deriving PartialOrd and Ord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 
 ### Changed
 
+- **Breaking:** `Frequency` no longer derives `PartialOrd` and `Ord`. The derived
+  order came from the declaration order of the variants, so `OnEvent` compared
+  less than `Interval`, which means nothing, and among intervals a longer
+  duration compared greater while being the lower frequency. `PartialEq` and `Eq`
+  stay.
+
+
 - **Breaking:** `CacheRecvNewestError` is gone. Every receive on a `Cache`
   returns `CacheRecvError`. The methods that skip to the newest value never
   return `Lagged`, which each of them documents, so a caller of those gains a

--- a/actify/src/throttle.rs
+++ b/actify/src/throttle.rs
@@ -15,7 +15,7 @@ use tokio::time::{self, Duration, Interval};
 /// build up the ticks it missed. The interval keeps its original schedule and
 /// the next send happens at the next boundary, carrying the newest value
 /// received in the meantime rather than the one current when the tick came due.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Frequency {
     /// Sends every value as it arrives.
     ///


### PR DESCRIPTION
Item 9b, split out of item 9 because it is a different type for different reasons.

`Frequency` derived `PartialOrd` and `Ord`, which produced an order nobody asked for and nobody could use correctly:

- Across variants it followed declaration order, so `OnEvent < Interval(_) < OnEventWhen(_)`. There is no sense in which `OnEvent` is less than an interval.
- Within `Interval`, it ordered by duration, so `Interval(1s) < Interval(2s)` while 1s is the *higher* frequency. Backwards for a type with this name.

`PartialEq` and `Eq` stay, since comparing two frequencies for equality is meaningful.

Nothing in the workspace ordered a `Frequency`, which I checked before removing.

**No red test.** This removes a trait implementation, so the compiler is the test: anything that ordered a `Frequency` stops building. A trybuild case pinning the absence of an impl would be noise and a snapshot to maintain. Flagging it because the working agreement is red-then-green, and this is the documented exception.

The plan also had this item adding `#[non_exhaustive]` to `Frequency`. That is dropped, by the same reasoning that removed it from `CacheRecvError` in #110: three variants fixed by design, and exhaustive matching is worth more to a caller than avoiding a breaking bump in a crate that ships breaking minors and has no 1.0 planned.

Full local gate green: workspace tests, `-p actify`, clippy `--all-targets --all-features -D warnings`, fmt, docs with `-D warnings` both with and without `--all-features`, and a 1.85 MSRV check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)