### PR TITLE
One conversion trait: Throttled folds into ToView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,17 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 
 ### Changed
 
+- **Breaking:** the `Throttled` trait is gone. A throttle callback's argument type
+  now comes from `ToView`, which the trait duplicated: both were a parameterized
+  owned conversion from `&self` with a blanket implementation for `Clone` types.
+
+  Replace `impl Throttled<Payload> for View` with `impl ToView<Payload> for View`
+  and rename the method from `parse` to `to_view`. Bounds change from
+  `V: Throttled<F>` to `V: ToView<F>`. A view type can carry several `ToView`
+  implementations, and the callback signature selects which one is used, exactly
+  as it did before.
+
+
 - **Breaking:** renames, with no behaviour change and no deprecated aliases.
 
   | Before | After |

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -5,7 +5,7 @@ use tokio::sync::broadcast::{
 };
 
 use crate::throttle::BoxFuture;
-use crate::{Frequency, Throttle, Throttled};
+use crate::{Frequency, Throttle, ToView};
 
 /// A simple caching struct that can be used to locally maintain a synchronized state with an actor.
 ///
@@ -644,7 +644,7 @@ where
     pub fn spawn_throttle<C, F, Fun>(&mut self, client: C, call: Fun, freq: Frequency) -> Throttle
     where
         C: Send + Sync + 'static,
-        V: Throttled<F>,
+        V: ToView<F>,
         F: Send + Sync + 'static,
         Fun: Fn(&C, F) + Send + 'static,
     {
@@ -674,7 +674,7 @@ where
     ) -> Throttle
     where
         C: Send + Sync + 'static,
-        V: Throttled<F>,
+        V: ToView<F>,
         F: Send + Sync + 'static,
         Fun: for<'a> Fn(&'a C, F) -> BoxFuture<'a> + Send + 'static,
     {

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -6,7 +6,7 @@ use tokio::sync::{broadcast, mpsc, oneshot, watch};
 use super::read_handle::ReadHandle;
 use crate::actor::{Actor, ActorExit, ActorMethod, BroadcastFn, ExitState, Job, serve};
 use crate::throttle::{BoxFuture, Throttle};
-use crate::{Cache, Frequency, Throttled};
+use crate::{Cache, Frequency};
 
 pub(crate) const CHANNEL_SIZE: usize = 100;
 const DOWNCAST_FAIL: &str =
@@ -167,7 +167,7 @@ where
     pub fn new_throttled<C, F, Fun>(val: T, client: C, call: Fun, freq: Frequency) -> Handle<T, V>
     where
         C: Send + Sync + 'static,
-        V: Throttled<F>,
+        V: ToView<F>,
         F: Send + Sync + 'static,
         Fun: Fn(&C, F) + Send + 'static,
     {
@@ -275,8 +275,8 @@ where
 
     /// Spawns a [`Throttle`] that fires given a specified [`Frequency`].
     ///
-    /// The broadcast type must implement [`Throttled<F>`](crate::Throttled) to
-    /// convert the value into the callback argument.
+    /// The view must implement [`ToView<F>`] for the callback argument `F`,
+    /// which the blanket implementation already covers when they are the same type.
     ///
     /// `call` is any `Fn(&C, F)`, so it can be a method such as `Logger::log`
     /// below, or a closure holding captured state.
@@ -312,7 +312,7 @@ where
     pub async fn spawn_throttle<C, F, Fun>(&self, client: C, call: Fun, freq: Frequency) -> Throttle
     where
         C: Send + Sync + 'static,
-        V: Throttled<F>,
+        V: ToView<F>,
         F: Send + Sync + 'static,
         Fun: Fn(&C, F) + Send + 'static,
     {
@@ -440,7 +440,7 @@ where
     ) -> Throttle
     where
         C: Send + Sync + 'static,
-        V: Throttled<F>,
+        V: ToView<F>,
         F: Send + Sync + 'static,
         Fun: for<'a> Fn(&'a C, F) -> BoxFuture<'a> + Send + 'static,
     {

--- a/actify/src/handles/read_handle.rs
+++ b/actify/src/handles/read_handle.rs
@@ -4,7 +4,7 @@ use tokio::sync::broadcast;
 
 use super::handle::{Handle, ToView};
 use crate::Cache;
-use crate::throttle::{BoxFuture, Frequency, Throttle, Throttled};
+use crate::throttle::{BoxFuture, Frequency, Throttle};
 
 /// A clonable read-only handle that can only be used to read the internal value.
 ///
@@ -146,7 +146,7 @@ where
     pub async fn spawn_throttle<C, F, Fun>(&self, client: C, call: Fun, freq: Frequency) -> Throttle
     where
         C: Send + Sync + 'static,
-        V: Throttled<F>,
+        V: ToView<F>,
         F: Send + Sync + 'static,
         Fun: Fn(&C, F) + Send + 'static,
     {
@@ -172,7 +172,7 @@ where
     ) -> Throttle
     where
         C: Send + Sync + 'static,
-        V: Throttled<F>,
+        V: ToView<F>,
         F: Send + Sync + 'static,
         Fun: for<'a> Fn(&'a C, F) -> BoxFuture<'a> + Send + 'static,
     {

--- a/actify/src/lib.rs
+++ b/actify/src/lib.rs
@@ -336,8 +336,9 @@
 //! - [`Frequency::OnEventWhen`]: sends at most once per interval, and only when a
 //!   value arrived since the last send
 //!
-//! Use the [`Throttled`] trait to parse the actor's type into a different output type
-//! for the throttle callback.
+//! The callback can take a type other than the view: implement [`ToView<F>`] on
+//! the view type for the payload `F` you want, and the callback signature selects
+//! it. One actor can feed several throttles that way, each with its own payload.
 //!
 //! A throttle is spawned from a [`Handle`], a [`ReadHandle`] or a [`Cache`].
 //!
@@ -468,7 +469,7 @@ pub use extensions::{
     map::HashMapHandle, option::OptionHandle, set::HashSetHandle, vec::VecHandle,
 };
 pub use handles::{Handle, ReadHandle, ToView};
-pub use throttle::{BoxFuture, Frequency, Throttle, Throttled};
+pub use throttle::{BoxFuture, Frequency, Throttle};
 
 #[doc(hidden)]
 pub use actor::Actor;

--- a/actify/src/throttle.rs
+++ b/actify/src/throttle.rs
@@ -5,6 +5,8 @@ use tokio::sync::broadcast::{self, Receiver};
 use tokio::task::AbortHandle;
 use tokio::time::{self, Duration, Interval};
 
+use crate::ToView;
+
 /// The Frequency is used to tune the speed of a [`Throttle`].
 ///
 /// Each variant's example below sends through a callback that takes 50ms, on an
@@ -126,21 +128,6 @@ pub enum Frequency {
     OnEventWhen(Duration),
 }
 
-/// The Throttled trait can be implemented to parse the type held by the actor to a custom output type.
-/// This allows a single [`Handle`](crate::Handle) to attach itself to multiple throttles, each with a separate parsing implementation.
-pub trait Throttled<F> {
-    /// Implement this parse function on the type to be sent by the throttle
-    fn parse(&self) -> F;
-}
-
-// TODO add a derive macro for Throttled derivation for self
-/// A blanket implementation is used to ensure any standard type implements it
-impl<T: Clone> Throttled<T> for T {
-    fn parse(&self) -> T {
-        self.clone()
-    }
-}
-
 /// The interval a [`Frequency`] runs on, and for [`Frequency::OnEventWhen`]
 /// whether a value arrived since the last send.
 enum Timing {
@@ -257,7 +244,7 @@ impl<T: Clone> ThrottleState<T> {
     /// once every sender is gone, which ends the throttle.
     async fn next<F>(&mut self) -> Option<F>
     where
-        T: Throttled<F>,
+        T: ToView<F>,
     {
         loop {
             let ready = match self.wake().await {
@@ -298,9 +285,9 @@ impl<T: Clone> ThrottleState<T> {
     /// no value has arrived yet.
     fn current<F>(&self) -> Option<F>
     where
-        T: Throttled<F>,
+        T: ToView<F>,
     {
-        self.current_val.as_ref().map(|val| val.parse())
+        self.current_val.as_ref().map(|val| val.to_view())
     }
 }
 
@@ -383,7 +370,7 @@ impl<C, T, Fun> ThrottleTask<C, T, Fun> {
     fn spawn<F>(self) -> Throttle
     where
         C: Send + Sync + 'static,
-        T: Clone + Throttled<F> + Send + Sync + 'static,
+        T: Clone + ToView<F> + Send + Sync + 'static,
         F: Send + Sync + 'static,
         Fun: Fn(&C, F) + Send + 'static,
     {
@@ -419,7 +406,7 @@ impl<C, T, Fun> ThrottleTask<C, T, Fun> {
     fn spawn_async<F>(self) -> Throttle
     where
         C: Send + Sync + 'static,
-        T: Clone + Throttled<F> + Send + Sync + 'static,
+        T: Clone + ToView<F> + Send + Sync + 'static,
         F: Send + Sync + 'static,
         Fun: for<'a> Fn(&'a C, F) -> BoxFuture<'a> + Send + 'static,
     {
@@ -467,7 +454,7 @@ pub type BoxFuture<'a> = Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
 /// to a callback.
 ///
 /// Configure the rate with [`Frequency`]. The actor type must implement
-/// [`Throttled<F>`](Throttled) to convert the actor value into the callback
+/// [`ToView<F>`](crate::ToView) to convert the view into the callback
 /// argument type `F`.
 ///
 /// Dropping this leaves the throttle running. Call [`abort`](Self::abort) to
@@ -511,7 +498,7 @@ impl Throttle {
     ) -> Throttle
     where
         C: Send + Sync + 'static,
-        T: Clone + Throttled<F> + Send + Sync + 'static,
+        T: Clone + ToView<F> + Send + Sync + 'static,
         F: Send + Sync + 'static,
         Fun: Fn(&C, F) + Send + 'static,
     {
@@ -538,7 +525,7 @@ impl Throttle {
     ) -> Throttle
     where
         C: Send + Sync + 'static,
-        T: Clone + Throttled<F> + Send + Sync + 'static,
+        T: Clone + ToView<F> + Send + Sync + 'static,
         F: Send + Sync + 'static,
         Fun: Fn(&C, F) + Send + 'static,
     {
@@ -570,7 +557,7 @@ impl Throttle {
     ) -> Throttle
     where
         C: Send + Sync + 'static,
-        T: Clone + Throttled<F> + Send + Sync + 'static,
+        T: Clone + ToView<F> + Send + Sync + 'static,
         F: Send + Sync + 'static,
         Fun: for<'a> Fn(&'a C, F) -> BoxFuture<'a> + Send + 'static,
     {
@@ -594,7 +581,7 @@ impl Throttle {
     ) -> Throttle
     where
         C: Send + Sync + 'static,
-        T: Clone + Throttled<F> + Send + Sync + 'static,
+        T: Clone + ToView<F> + Send + Sync + 'static,
         F: Send + Sync + 'static,
         Fun: for<'a> Fn(&'a C, F) -> BoxFuture<'a> + Send + 'static,
     {
@@ -1578,8 +1565,8 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn test_throttle_parsing() {
-        // Parsing to self should succeed
+    async fn test_the_callback_payload_is_inferred() {
+        // The blanket implementation covers a callback taking the value itself
         let _ = Throttle::spawn_interval(
             DummyClient {},
             DummyClient::call_a,
@@ -1587,7 +1574,7 @@ mod tests {
             A {},
         );
 
-        // Parsing to either B or C should be infered by the compiler
+        // A has a ToView impl for both B and C, and the callback picks which
         let _ = Throttle::spawn_interval(
             DummyClient {},
             DummyClient::call_b,
@@ -1612,14 +1599,14 @@ mod tests {
     #[derive(Debug, Clone)]
     struct C {}
 
-    impl Throttled<B> for A {
-        fn parse(&self) -> B {
+    impl ToView<B> for A {
+        fn to_view(&self) -> B {
             B {}
         }
     }
 
-    impl Throttled<C> for A {
-        fn parse(&self) -> C {
+    impl ToView<C> for A {
+        fn to_view(&self) -> C {
             C {}
         }
     }

--- a/actify/src/throttle.rs
+++ b/actify/src/throttle.rs
@@ -221,17 +221,17 @@ enum Wake {
 
 /// Owns the broadcast receiver and the timing, so the loop in
 /// `ThrottleTask::spawn` is only a call to [`Self::next`] and a callback.
-struct ThrottleState<T> {
+struct ThrottleState<V> {
     timing: Timing,
-    val_rx: Option<broadcast::Receiver<T>>,
-    current_val: Option<T>,
+    val_rx: Option<broadcast::Receiver<V>>,
+    current_val: Option<V>,
 }
 
-impl<T: Clone> ThrottleState<T> {
+impl<V: Clone> ThrottleState<V> {
     fn new(
         frequency: Frequency,
-        val_rx: Option<broadcast::Receiver<T>>,
-        current_val: Option<T>,
+        val_rx: Option<broadcast::Receiver<V>>,
+        current_val: Option<V>,
     ) -> Self {
         Self {
             timing: Timing::new(frequency),
@@ -244,7 +244,7 @@ impl<T: Clone> ThrottleState<T> {
     /// once every sender is gone, which ends the throttle.
     async fn next<F>(&mut self) -> Option<F>
     where
-        T: ToView<F>,
+        V: ToView<F>,
     {
         loop {
             let ready = match self.wake().await {
@@ -285,7 +285,7 @@ impl<T: Clone> ThrottleState<T> {
     /// no value has arrived yet.
     fn current<F>(&self) -> Option<F>
     where
-        T: ToView<F>,
+        V: ToView<F>,
     {
         self.current_val.as_ref().map(|val| val.to_view())
     }
@@ -293,19 +293,19 @@ impl<T: Clone> ThrottleState<T> {
 
 /// Waits for the next broadcast value, or forever when the throttle has no
 /// receiver, as [`Throttle::spawn_interval`] does.
-async fn recv_value<T: Clone>(val_rx: &mut Option<broadcast::Receiver<T>>) -> Result<T, RecvError> {
+async fn recv_value<V: Clone>(val_rx: &mut Option<broadcast::Receiver<V>>) -> Result<V, RecvError> {
     if let Some(rx) = val_rx {
         rx.recv().await
     } else {
-        std::future::pending::<Result<T, RecvError>>().await
+        std::future::pending::<Result<V, RecvError>>().await
     }
 }
 
 /// Takes every value already queued, keeping the newest. Returns whether any
 /// were there.
-fn drain_available<T: Clone>(
-    val_rx: &mut Option<broadcast::Receiver<T>>,
-    current: &mut Option<T>,
+fn drain_available<V: Clone>(
+    val_rx: &mut Option<broadcast::Receiver<V>>,
+    current: &mut Option<V>,
 ) -> bool {
     let Some(rx) = val_rx else {
         return false;
@@ -321,7 +321,7 @@ fn drain_available<T: Clone>(
             Err(TryRecvError::Lagged(nr)) => {
                 log::debug!(
                     "Throttle of type {} lagged {nr} messages",
-                    std::any::type_name::<T>()
+                    std::any::type_name::<V>()
                 );
             }
             // A closed channel is reported by the next receive in the loop.
@@ -331,7 +331,7 @@ fn drain_available<T: Clone>(
 }
 
 /// Records a received value, or reports why none arrived.
-fn store<T>(current: &mut Option<T>, received: Result<T, RecvError>) -> Wake {
+fn store<V>(current: &mut Option<V>, received: Result<V, RecvError>) -> Wake {
     match received {
         Ok(value) => {
             *current = Some(value);
@@ -340,14 +340,14 @@ fn store<T>(current: &mut Option<T>, received: Result<T, RecvError>) -> Wake {
         Err(RecvError::Closed) => {
             log::debug!(
                 "Attached actor of type {} closed - exiting throttle",
-                std::any::type_name::<T>()
+                std::any::type_name::<V>()
             );
             Wake::Closed
         }
         Err(RecvError::Lagged(nr)) => {
             log::debug!(
                 "Throttle of type {} lagged {nr} messages",
-                std::any::type_name::<T>()
+                std::any::type_name::<V>()
             );
             Wake::Lagged
         }
@@ -358,19 +358,19 @@ fn store<T>(current: &mut Option<T>, received: Result<T, RecvError>) -> Wake {
 ///
 /// `F` is fixed by `Fun` rather than stored, so it is a parameter of
 /// [`Self::spawn`] instead of the struct.
-struct ThrottleTask<C, T, Fun> {
+struct ThrottleTask<C, V, Fun> {
     frequency: Frequency,
     client: C,
     call: Fun,
-    val_rx: Option<broadcast::Receiver<T>>,
-    current_val: Option<T>,
+    val_rx: Option<broadcast::Receiver<V>>,
+    current_val: Option<V>,
 }
 
-impl<C, T, Fun> ThrottleTask<C, T, Fun> {
+impl<C, V, Fun> ThrottleTask<C, V, Fun> {
     fn spawn<F>(self) -> Throttle
     where
         C: Send + Sync + 'static,
-        T: Clone + ToView<F> + Send + Sync + 'static,
+        V: Clone + ToView<F> + Send + Sync + 'static,
         F: Send + Sync + 'static,
         Fun: Fn(&C, F) + Send + 'static,
     {
@@ -406,7 +406,7 @@ impl<C, T, Fun> ThrottleTask<C, T, Fun> {
     fn spawn_async<F>(self) -> Throttle
     where
         C: Send + Sync + 'static,
-        T: Clone + ToView<F> + Send + Sync + 'static,
+        V: Clone + ToView<F> + Send + Sync + 'static,
         F: Send + Sync + 'static,
         Fun: for<'a> Fn(&'a C, F) -> BoxFuture<'a> + Send + 'static,
     {
@@ -489,16 +489,16 @@ impl Throttle {
     /// [`Handle::spawn_throttle`](crate::Handle::spawn_throttle) and
     /// [`Cache::spawn_throttle`](crate::Cache::spawn_throttle) take the
     /// receiver without losing updates during setup.
-    pub fn spawn<C, T, F, Fun>(
+    pub fn spawn<C, V, F, Fun>(
         client: C,
         call: Fun,
         frequency: Frequency,
-        receiver: Receiver<T>,
-        init: Option<T>,
+        receiver: Receiver<V>,
+        init: Option<V>,
     ) -> Throttle
     where
         C: Send + Sync + 'static,
-        T: Clone + ToView<F> + Send + Sync + 'static,
+        V: Clone + ToView<F> + Send + Sync + 'static,
         F: Send + Sync + 'static,
         Fun: Fn(&C, F) + Send + 'static,
     {
@@ -517,15 +517,15 @@ impl Throttle {
     /// No actor is attached, so nothing ends the task on its own. It runs until
     /// [`abort`](Self::abort) or the runtime shuts down.
     #[must_use = "without this handle the interval task cannot be stopped"]
-    pub fn spawn_interval<C, T, F, Fun>(
+    pub fn spawn_interval<C, V, F, Fun>(
         client: C,
         call: Fun,
         interval: Duration,
-        val: T,
+        val: V,
     ) -> Throttle
     where
         C: Send + Sync + 'static,
-        T: Clone + ToView<F> + Send + Sync + 'static,
+        V: Clone + ToView<F> + Send + Sync + 'static,
         F: Send + Sync + 'static,
         Fun: Fn(&C, F) + Send + 'static,
     {
@@ -548,16 +548,16 @@ impl Throttle {
     ///
     /// `call` borrows the client and returns a [`BoxFuture`], built with
     /// [`Box::pin`].
-    pub fn spawn_async<C, T, F, Fun>(
+    pub fn spawn_async<C, V, F, Fun>(
         client: C,
         call: Fun,
         frequency: Frequency,
-        receiver: Receiver<T>,
-        init: Option<T>,
+        receiver: Receiver<V>,
+        init: Option<V>,
     ) -> Throttle
     where
         C: Send + Sync + 'static,
-        T: Clone + ToView<F> + Send + Sync + 'static,
+        V: Clone + ToView<F> + Send + Sync + 'static,
         F: Send + Sync + 'static,
         Fun: for<'a> Fn(&'a C, F) -> BoxFuture<'a> + Send + 'static,
     {
@@ -573,15 +573,15 @@ impl Throttle {
 
     /// The async counterpart of [`spawn_interval`](Self::spawn_interval).
     #[must_use = "without this handle the interval task cannot be stopped"]
-    pub fn spawn_async_interval<C, T, F, Fun>(
+    pub fn spawn_async_interval<C, V, F, Fun>(
         client: C,
         call: Fun,
         interval: Duration,
-        val: T,
+        val: V,
     ) -> Throttle
     where
         C: Send + Sync + 'static,
-        T: Clone + ToView<F> + Send + Sync + 'static,
+        V: Clone + ToView<F> + Send + Sync + 'static,
         F: Send + Sync + 'static,
         Fun: for<'a> Fn(&'a C, F) -> BoxFuture<'a> + Send + 'static,
     {


### PR DESCRIPTION
Item 22, found while doing item 10 and confirmed in review.

`Throttled<F>` was `ToView<V>` under another name. Side by side, before:

```rust
pub trait Throttled<F> { fn parse(&self) -> F; }
impl<T: Clone> Throttled<T> for T { fn parse(&self) -> T { self.clone() } }

pub trait ToView<V> { fn to_view(&self) -> V; }
impl<T: Clone> ToView<T> for T { fn to_view(&self) -> T { self.clone() } }
```

Same shape, same blanket, same purpose. `Throttled` is deleted and the throttle bounds read `V: ToView<F>`.

A view type can still carry several conversions, and the callback signature still selects which one applies. That is not a hope: `test_the_callback_payload_is_inferred` already covered it, with one type having `ToView` impls for two payloads plus the blanket for itself, and three spawns picking each in turn. It needed only the trait name changed.

This is the one rename I left out of #112, because renaming `Throttled::parse` there and deleting the trait here would have cost users two breaking changes for one outcome.

## Also in this PR

`throttle.rs` names its view parameter `V` instead of `T`, matching what `Cache` got in #109. Inside that file the parameter has always been the handle's view type, and `T: ToView<F>` reads as though an actor type were converting itself. Two test helpers that are generic over an arbitrary type kept `T`, since they have nothing to do with views.

## Migration

```rust
// before
impl Throttled<Payload> for View {
    fn parse(&self) -> Payload { .. }
}

// after
impl ToView<Payload> for View {
    fn to_view(&self) -> Payload { .. }
}
```

Bounds go from `V: Throttled<F>` to `V: ToView<F>`. Nothing else changes, and callers that never implemented the trait are unaffected, since the blanket implementation covers them.

## Verification

**No red test.** Deleting a trait in favour of an existing one is compile-verified: every bound, every impl and every call site had to move, and the suite covers the behaviour already. The inference case that could plausibly have broken is the one `test_the_callback_payload_is_inferred` pins, and it passes unchanged in substance.

Full local gate green: workspace tests, `-p actify`, clippy `--all-targets --all-features -D warnings`, fmt, docs with `-D warnings` both with and without `--all-features`, and a 1.85 MSRV check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)