### PR TITLE
Remove Handle::new_throttled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,25 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
   `Throttle::spawn_interval` has no actor attached, so before this nothing could
   stop it short of shutting down the runtime.
 
+### Removed
+
+- **Breaking:** `Handle::new_throttled`. It was `Handle::new` followed by a
+  throttle spawn, and it stopped composing once spawn functions began returning a
+  `Throttle`: it would have had to hand back a tuple. Its one property worth
+  keeping is that it needs no `await`, and the replacement does not either:
+
+  ```rust
+  let init = value.to_view();
+  let handle = Handle::new(value);
+  let throttle = Throttle::spawn(client, call, freq, handle.subscribe(), Some(init));
+  ```
+
+  Nothing can broadcast between `new` and `subscribe`, because no other handle to
+  that actor exists yet. Note that the initial value is now passed explicitly, so
+  it is on the caller to pass the value the actor was created with.
+
 ### Changed
+
 
 - **Breaking:** the `Throttled` trait is gone. A throttle callback's argument type
   now comes from `ToView`, which the trait duplicated: both were a parameterized

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -161,23 +161,6 @@ where
         }
     }
 
-    /// Creates a new [`Handle`] and initializes a corresponding [`Throttle`].
-    /// The throttle fires given a specified [`Frequency`].
-    /// See [`Handle::spawn_throttle`] for an example.
-    pub fn new_throttled<C, F, Fun>(val: T, client: C, call: Fun, freq: Frequency) -> Handle<T, V>
-    where
-        C: Send + Sync + 'static,
-        V: ToView<F>,
-        F: Send + Sync + 'static,
-        Fun: Fn(&C, F) + Send + 'static,
-    {
-        let init = val.to_view();
-        let handle = Self::new(val);
-        let receiver = handle.subscribe();
-        Throttle::spawn(client, call, freq, receiver, Some(init));
-        handle
-    }
-
     /// Waits until the broadcast value satisfies `predicate` and returns it.
     ///
     /// Tests the actor's current value first, so a predicate that already holds

--- a/actify/src/throttle.rs
+++ b/actify/src/throttle.rs
@@ -1209,31 +1209,6 @@ mod tests {
         assert_eq!(count, 1)
     }
 
-    /// Attaching a throttle to a new actor takes no await, so it works from a
-    /// synchronous function. It fires once with the initial value before any
-    /// broadcast, and then again for each update.
-    #[tokio::test(start_paused = true)]
-    async fn test_a_throttle_can_be_attached_without_awaiting() {
-        let counter = CounterClient::new();
-
-        let handle: Handle<i32> = Handle::new(1);
-        let _throttle = Throttle::spawn(
-            counter.clone(),
-            CounterClient::call,
-            Frequency::OnEvent,
-            handle.subscribe(),
-            Some(1),
-        );
-        sleep(Duration::from_millis(10)).await;
-
-        assert_eq!(*counter.count.lock().unwrap(), 1);
-
-        handle.set(2).await;
-        sleep(Duration::from_millis(10)).await;
-
-        assert_eq!(*counter.count.lock().unwrap(), 2);
-    }
-
     /// An update already queued in the cache's receiver but not yet consumed
     /// must reach a throttle spawned from that cache. The cache first
     /// synchronizes to the newest broadcast value, which becomes the

--- a/actify/src/throttle.rs
+++ b/actify/src/throttle.rs
@@ -1209,13 +1209,21 @@ mod tests {
         assert_eq!(count, 1)
     }
 
-    /// The throttle attached by new_throttled fires once with the initial
-    /// value before any broadcast, and then again for each update.
+    /// Attaching a throttle to a new actor takes no await, so it works from a
+    /// synchronous function. It fires once with the initial value before any
+    /// broadcast, and then again for each update.
     #[tokio::test(start_paused = true)]
-    async fn test_new_throttled_fires_init_and_updates() {
+    async fn test_a_throttle_can_be_attached_without_awaiting() {
         let counter = CounterClient::new();
-        let handle: Handle<i32> =
-            Handle::new_throttled(1, counter.clone(), CounterClient::call, Frequency::OnEvent);
+
+        let handle: Handle<i32> = Handle::new(1);
+        let _throttle = Throttle::spawn(
+            counter.clone(),
+            CounterClient::call,
+            Frequency::OnEvent,
+            handle.subscribe(),
+            Some(1),
+        );
         sleep(Duration::from_millis(10)).await;
 
         assert_eq!(*counter.count.lock().unwrap(), 1);


### PR DESCRIPTION
Item 10b, split from item 10 because it is a removal rather than a rename.

`Handle::new_throttled` was `Handle::new` followed by a throttle spawn, and it stopped composing in #93 when spawn functions began returning a `Throttle`: to keep the throttle reachable it would have had to return a tuple.

The only property worth preserving is that it needs no `await`, unlike `spawn_throttle`, so it works from a synchronous function. The replacement does not need one either:

```rust
let init = value.to_view();
let handle = Handle::new(value);
let throttle = Throttle::spawn(client, call, freq, handle.subscribe(), Some(init));
```

Three lines instead of one, and the throttle is now reachable so it can be aborted. Nothing can broadcast between `new` and `subscribe`, since no other handle to that actor exists yet.

One thing the caller now carries: the initial value is passed explicitly, so it is on them to pass the value the actor was created with. That is the cost of the removal and it is in the changelog.

## Verification

`test_new_throttled_fires_init_and_updates` is deleted along with the method. I first converted it to exercise the replacement, but that was wrong twice over: its comment claimed the throttle works from a synchronous function, which an `async fn` test that awaits cannot show, and once that claim was stripped the test had no coverage of its own. Both facts it asserted are already pinned elsewhere:

- the initial value firing exactly once: `initial_value::test_on_event_sends_it_once_and_stays_quiet`
- an initial fire followed by an update, counting 2: `test_spawn_throttle_update_during_construction`
- `Throttle::spawn` with an explicit initial value: `test_exit_on_shutdown`

Both of the first two go through `spawn_throttle`, which calls `Throttle::spawn` with `Some(init)`, so it is the same code path.

**No red test,** as with the other removals: the compiler is the check for anything that called it, and nothing in the workspace did apart from that one test.

Full local gate green: workspace tests, `-p actify`, clippy `--all-targets --all-features -D warnings`, fmt, docs with `-D warnings` both with and without `--all-features`, and a 1.85 MSRV check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
