### PR TITLE
Keep the macro's reach inside a private module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,19 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
   that actor exists yet. Note that the initial value is now passed explicitly, so
   it is on the caller to pass the value the actor was created with.
 
+### Fixed
+
+- Generated code no longer breaks when a type in scope shares a name with
+  something that code refers to. A user type called `Box` or `Any` next to an
+  `#[actify]` impl made the generated body resolve `Box::new` to that type. All
+  such references are now absolute paths into a private module.
+
 ### Changed
+
+- **Breaking:** `Handle::send_job` is renamed to `Handle::__send_job`, and `Actor`
+  moves from the crate root to `actify::__private`. Both were `#[doc(hidden)]`
+  already and exist only for generated code to call. The names now say so.
+
 
 
 - **Breaking:** the `Throttled` trait is gone. A throttle callback's argument type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,16 +67,20 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 
 ### Fixed
 
-- Generated code no longer breaks when a type in scope shares a name with
-  something that code refers to. A user type called `Box` or `Any` next to an
-  `#[actify]` impl made the generated body resolve `Box::new` to that type. All
-  such references are now absolute paths into a private module.
+- Generated code no longer breaks when something in scope shares a name with what
+  that code refers to. A user type called `Box` next to an `#[actify]` impl made
+  the generated body resolve `Box::new` to that type, and a module named `actify`
+  would have broken the paths to the crate itself. Generated code now names
+  standard library types by absolute path (`::std::boxed::Box`) and reaches the
+  crate as `::actify`, neither of which a local item can shadow.
 
 ### Changed
 
 - **Breaking:** `Handle::send_job` is renamed to `Handle::__send_job`, and `Actor`
   moves from the crate root to `actify::__private`. Both were `#[doc(hidden)]`
-  already and exist only for generated code to call. The names now say so.
+  already and exist only for generated code to reach. The names now say so, and
+  the module gives that contract one place to live rather than leaving it spread
+  across a hidden root export and a hidden method.
 
 
 

--- a/actify-macros/src/codegen/handle.rs
+++ b/actify-macros/src/codegen/handle.rs
@@ -47,7 +47,7 @@ pub fn generate_trait_impl(info: &ImplInfo) -> proc_macro2::TokenStream {
     quote! {
         #(#impl_attrs)*
         #[allow(unused_parens)]
-        impl #impl_generics #handle_trait_ident #trait_generics for actify::Handle<#impl_type, __V> #where_clause
+        impl #impl_generics #handle_trait_ident #trait_generics for ::actify::Handle<#impl_type, __V> #where_clause
         {
             #(#methods)*
         }
@@ -120,9 +120,9 @@ fn method_body(
     quote! {
         #(#attrs)*
         async fn #ident #method_generics(&self, #(#arg_names: #arg_types),*) #return_type #where_clause {
-            let __actify_res = self.send_job(
-                Box::new(|__actify_s: &mut actify::Actor<#impl_type>, __actify_args: Box<dyn std::any::Any + Send>|
-                Box::pin(async move {
+            let __actify_res = self.__send_job(
+                ::actify::__private::Box::new(|__actify_s: &mut ::actify::__private::Actor<#impl_type>, __actify_args: ::actify::__private::Box<dyn ::actify::__private::Any + Send>|
+                ::actify::__private::Box::pin(async move {
                     let (#(#arg_names),*): (#(#arg_types),*) = *__actify_args
                         .downcast()
                         .expect("Downcasting failed due to an error in the Actify macro");
@@ -131,9 +131,9 @@ fn method_body(
 
                     #broadcast
 
-                    Box::new(__actify_result) as Box<dyn std::any::Any + Send>
+                    ::actify::__private::Box::new(__actify_result) as ::actify::__private::Box<dyn ::actify::__private::Any + Send>
                 })),
-                Box::new((#(#arg_names),*)),
+                ::actify::__private::Box::new((#(#arg_names),*)),
             ).await;
 
             *__actify_res.downcast().expect("Downcasting failed due to an error in the Actify macro")

--- a/actify-macros/src/codegen/handle.rs
+++ b/actify-macros/src/codegen/handle.rs
@@ -121,8 +121,8 @@ fn method_body(
         #(#attrs)*
         async fn #ident #method_generics(&self, #(#arg_names: #arg_types),*) #return_type #where_clause {
             let __actify_res = self.__send_job(
-                ::actify::__private::Box::new(|__actify_s: &mut ::actify::__private::Actor<#impl_type>, __actify_args: ::actify::__private::Box<dyn ::actify::__private::Any + Send>|
-                ::actify::__private::Box::pin(async move {
+                ::std::boxed::Box::new(|__actify_s: &mut ::actify::__private::Actor<#impl_type>, __actify_args: ::std::boxed::Box<dyn ::std::any::Any + Send>|
+                ::std::boxed::Box::pin(async move {
                     let (#(#arg_names),*): (#(#arg_types),*) = *__actify_args
                         .downcast()
                         .expect("Downcasting failed due to an error in the Actify macro");
@@ -131,9 +131,9 @@ fn method_body(
 
                     #broadcast
 
-                    ::actify::__private::Box::new(__actify_result) as ::actify::__private::Box<dyn ::actify::__private::Any + Send>
+                    ::std::boxed::Box::new(__actify_result) as ::std::boxed::Box<dyn ::std::any::Any + Send>
                 })),
-                ::actify::__private::Box::new((#(#arg_names),*)),
+                ::std::boxed::Box::new((#(#arg_names),*)),
             ).await;
 
             *__actify_res.downcast().expect("Downcasting failed due to an error in the Actify macro")

--- a/actify-test/src/main.rs
+++ b/actify-test/src/main.rs
@@ -130,6 +130,35 @@ impl ShadowingActor {
     }
 }
 
+/// Types in scope whose names collide with what the generated code refers to.
+///
+/// A module of its own, since shadowing `Box` at file scope would break every
+/// other test here.
+///
+/// Only the test build reaches it, hence the allowance.
+#[allow(dead_code)]
+mod shadowed_std_names {
+    use actify::actify;
+
+    #[allow(dead_code)]
+    struct Box;
+
+    #[allow(dead_code)]
+    struct Any;
+
+    #[derive(Clone, Debug)]
+    pub struct ShadowedStdNames {
+        pub value: i32,
+    }
+
+    #[actify]
+    impl ShadowedStdNames {
+        pub fn value(&self) -> i32 {
+            self.value
+        }
+    }
+}
+
 /// Generic bounds written inline on the impl block instead of in a where clause
 #[allow(dead_code)]
 #[derive(Clone, Debug)]
@@ -407,6 +436,17 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
     use tokio::time::{Instant, sleep};
+
+    /// Generated code must not resolve `Box` or `Any` to a user type that
+    /// happens to share the name.
+    #[tokio::test]
+    async fn test_shadowed_std_names() {
+        use crate::shadowed_std_names::{ShadowedStdNames, ShadowedStdNamesHandle};
+
+        let handle = Handle::new(ShadowedStdNames { value: 7 });
+
+        assert_eq!(handle.value().await, 7);
+    }
 
     #[tokio::test]
     async fn test_custom_trait_name() {

--- a/actify/src/extensions/map.rs
+++ b/actify/src/extensions/map.rs
@@ -1,4 +1,3 @@
-use crate as actify;
 use actify_macros::actify;
 use std::collections::HashMap;
 use std::hash::Hash;

--- a/actify/src/extensions/option.rs
+++ b/actify/src/extensions/option.rs
@@ -1,4 +1,3 @@
-use crate as actify;
 use actify_macros::actify;
 
 trait ActorOption<T> {

--- a/actify/src/extensions/set.rs
+++ b/actify/src/extensions/set.rs
@@ -1,4 +1,3 @@
-use crate as actify;
 use actify_macros::actify;
 use std::collections::HashSet;
 use std::hash::Hash;

--- a/actify/src/extensions/vec.rs
+++ b/actify/src/extensions/vec.rs
@@ -1,4 +1,3 @@
-use crate as actify;
 use actify_macros::actify;
 use core::ops::RangeBounds;
 

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -490,7 +490,7 @@ impl<T: Send + Sync + 'static, V> Handle<T, V> {
     }
 
     #[doc(hidden)]
-    pub async fn send_job(
+    pub async fn __send_job(
         &self,
         call: ActorMethod<T>,
         args: Box<dyn Any + Send>,
@@ -530,7 +530,7 @@ impl<T: Send + Sync + 'static, V> Handle<T, V> {
         R: Send + 'static,
     {
         let res = self
-            .send_job(
+            .__send_job(
                 Box::new(move |s: &mut Actor<T>, boxed_args: Box<dyn Any + Send>| {
                     Box::pin(async move {
                         let args = *boxed_args.downcast::<A>().expect(DOWNCAST_FAIL);
@@ -730,7 +730,6 @@ impl<T, V: Default + Clone + Send + Sync + 'static> Handle<T, V> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate as actify;
 
     /// A panicking actor method must surface as a panic naming that cause, not
     /// as the generic message used when the actor merely stopped.

--- a/actify/src/lib.rs
+++ b/actify/src/lib.rs
@@ -475,15 +475,14 @@ pub use extensions::{
 pub use handles::{Handle, ReadHandle, ToView};
 pub use throttle::{BoxFuture, Frequency, Throttle};
 
-/// Items the [`actify`](macro@crate::actify) macro needs in generated code.
+/// The crate's own items that the [`actify`](macro@crate::actify) macro needs in
+/// generated code. Standard library types are named by absolute path instead.
 ///
 /// Not part of the public API. Anything here may change in a patch release, and
 /// nothing outside generated code should name it.
 #[doc(hidden)]
 pub mod __private {
     pub use crate::actor::Actor;
-    pub use std::any::Any;
-    pub use std::boxed::Box;
 }
 
 #[cfg(feature = "profiler")]

--- a/actify/src/lib.rs
+++ b/actify/src/lib.rs
@@ -54,7 +54,8 @@
 //!
 //! This roughly desugars to:
 //! ```
-//! # use actify::{Handle, actify, Actor};
+//! # use actify::{Handle, actify};
+//! # use actify::__private::Actor;
 //! # #[derive(Clone, Debug)]
 //! # struct Greeter {}
 //! impl Greeter {
@@ -74,7 +75,7 @@
 //! impl GreeterHandle for Handle<Greeter> {
 //!     async fn say_hi(&self, name: String) -> String {
 //!         let res = self
-//!             .send_job(
+//!             .__send_job(
 //!                 Box::new(
 //!                     |s: &mut Actor<Greeter>, args: Box<dyn std::any::Any + Send>|
 //!                     Box::pin(async move {
@@ -456,6 +457,9 @@ mod readme {
     #![doc = include_str!("../../README.md")]
 }
 
+// Generated code refers to ::actify, which has to resolve inside this crate too.
+extern crate self as actify;
+
 mod actor;
 mod cache;
 mod extensions;
@@ -471,8 +475,16 @@ pub use extensions::{
 pub use handles::{Handle, ReadHandle, ToView};
 pub use throttle::{BoxFuture, Frequency, Throttle};
 
+/// Items the [`actify`](macro@crate::actify) macro needs in generated code.
+///
+/// Not part of the public API. Anything here may change in a patch release, and
+/// nothing outside generated code should name it.
 #[doc(hidden)]
-pub use actor::Actor;
+pub mod __private {
+    pub use crate::actor::Actor;
+    pub use std::any::Any;
+    pub use std::boxed::Box;
+}
 
 #[cfg(feature = "profiler")]
 pub use actor::{get_broadcast_counts, get_sorted_broadcast_counts};


### PR DESCRIPTION
Item 11.

Two separate problems, which the first revision of this PR ran together.

**Generated code lands in the user's module, so its paths resolve in their scope.** A `struct Box;` next to an `#[actify]` impl made the generated body resolve `Box::new` to that type, and a `mod actify { .. }` would have broken the paths to the crate itself. The fix is absolute paths, and nothing else: standard library types are named `::std::boxed::Box` and `::std::any::Any`, and the crate is reached as `::actify`. A leading `::` names a crate from the extern prelude, which no local item can shadow.

**Separately, the macro's contract had no home.** Generated code reaches for `Handle`, `Actor` and a job-sending method. `Actor` was a hidden root re-export and `send_job` a hidden method, with nothing marking either as the thing generated code depends on. They now live behind one door:

```rust
#[doc(hidden)]
pub mod __private {
    pub use crate::actor::Actor;
}
```

with `send_job` renamed to `__send_job`. That is what the module is for: labelling the contract, keeping `Actor` off the crate root so it is not a public export that `cargo-semver-checks` will police after 0.9.0, and giving later items such as #13's RPITIT change somewhere to add to. It is not what fixes the shadowing.

Standard library types deliberately do not go through it. Routing them through a private module is something serde does, to choose between `core`, `alloc` and `std` in one place for `no_std` builds. actify depends on tokio and is std-only, so that buys nothing here and only adds a hop.

`extern crate self as actify;` in `lib.rs` makes `::actify` resolve inside the crate, which removed the `use crate as actify;` line from four extension modules and one test module.

## This fixes a real bug

A user type named `Box` next to an `#[actify]` impl made the generated body resolve `Box::new` to that type. `test_shadowed_std_names` covers it, in a module of its own since shadowing `Box` at file scope would break every other test in that file.

I checked it is a genuine red by stashing the library and macro changes together, keeping only the new fixture:

```
error[E0599]: no associated function or constant named `new` found for struct
              `shadowed_std_names::Box` in the current scope
   --> actify-test/src/main.rs:152:5
141 |     struct Box;
```

My first attempt at that check stashed only the macro, which left the library half-migrated and produced unrelated errors about `Actor` and `send_job`. That proved nothing, so I redid it.

The test calls the generated method rather than only compiling it, so the fixture is exercised rather than merely present.

## Verification

The compile-fail snapshots are unchanged: they contain our own `compile_error!` output, not paths into generated code. Checked with `TRYBUILD_TESTS=1`.

`actify-test` is a separate crate that consumes the macro exactly as a user would, so its 26 tests are the real check that `::actify::__private::` resolves downstream.

Full local gate green: workspace tests, `-p actify`, clippy `--all-targets --all-features -D warnings`, fmt, docs with `-D warnings` both with and without `--all-features`, 1.85 MSRV, and trybuild.

## Note on the docs

The "roughly desugars to" example in `lib.rs` shows generated code, so it now shows `actify::__private::Actor` and `__send_job`. That is honest about what generated code reaches for, and it is the one place the private module appears in the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
