### PR TITLE
Add StringHandle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 
 ### Added
 
+- `StringHandle` for `Handle<String>`, with `len`, `is_empty`, `clear`,
+  `truncate`, `push`, `push_str`, `contains`, `starts_with`, `ends_with`,
+  `replace`, `split`, `trim`, `to_lowercase` and `to_uppercase`.
+
+  The methods that borrow in `std` return owned values here, since nothing
+  borrowed can leave an actor: `trim` and `replace` return `String`, and `split`
+  returns `Vec<String>` rather than an iterator. Arguments are owned for the same
+  reason, so the pattern methods take `String`.
+
+
 - `OptionHandle::take` and `OptionHandle::replace`, mirroring
   `std::option::Option::take` and `std::option::Option::replace` in both
   signature and behaviour.

--- a/actify/src/extensions/mod.rs
+++ b/actify/src/extensions/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod map;
 pub(crate) mod option;
 pub(crate) mod set;
+pub(crate) mod string;
 pub(crate) mod vec;

--- a/actify/src/extensions/string.rs
+++ b/actify/src/extensions/string.rs
@@ -1,0 +1,341 @@
+use actify_macros::actify;
+
+/// An extension trait for `String` actors, made available on the [`Handle`](crate::Handle)
+/// as [`StringHandle`](crate::StringHandle).
+trait ActorString {
+    fn len(&self) -> usize;
+
+    fn is_empty(&self) -> bool;
+
+    fn clear(&mut self);
+
+    fn truncate(&mut self, new_len: usize);
+
+    fn to_uppercase(&self) -> String;
+
+    fn to_lowercase(&self) -> String;
+
+    fn push_str(&mut self, string: String);
+
+    fn push(&mut self, ch: char);
+
+    fn contains(&self, pat: String) -> bool;
+
+    fn replace(&self, from: String, to: String) -> String;
+
+    fn trim(&self) -> String;
+
+    fn starts_with(&self, pat: String) -> bool;
+
+    fn ends_with(&self, pat: String) -> bool;
+
+    fn split(&self, pat: String) -> Vec<String>;
+}
+
+/// Extension methods for `Handle<String>`, exposed as [`StringHandle`](crate::StringHandle).
+#[actify]
+impl ActorString for String {
+    /// Returns the length of the string in bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, StringHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new("hello".to_string());
+    /// assert_eq!(handle.len().await, 5);
+    /// # }
+    /// ```
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    /// Returns `true` if the string has a length of zero.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, StringHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(String::new());
+    /// assert!(handle.is_empty().await);
+    /// # }
+    /// ```
+    fn is_empty(&self) -> bool {
+        self.is_empty()
+    }
+
+    /// Truncates the string to zero length.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, StringHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new("hello".to_string());
+    /// handle.clear().await;
+    /// assert!(handle.is_empty().await);
+    /// # }
+    /// ```
+    fn clear(&mut self) {
+        self.clear()
+    }
+
+    /// Shortens the string to the specified length.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `new_len` does not lie on a char boundary.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, StringHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new("hello world".to_string());
+    /// handle.truncate(5).await;
+    /// assert_eq!(handle.get().await, "hello");
+    /// # }
+    /// ```
+    fn truncate(&mut self, new_len: usize) {
+        self.truncate(new_len)
+    }
+
+    /// Returns the uppercase equivalent of this string, as a new `String`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, StringHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new("hello".to_string());
+    /// assert_eq!(handle.to_uppercase().await, "HELLO");
+    /// # }
+    /// ```
+    fn to_uppercase(&self) -> String {
+        self.as_str().to_uppercase()
+    }
+
+    /// Returns the lowercase equivalent of this string, as a new `String`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, StringHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new("HELLO".to_string());
+    /// assert_eq!(handle.to_lowercase().await, "hello");
+    /// # }
+    /// ```
+    fn to_lowercase(&self) -> String {
+        self.as_str().to_lowercase()
+    }
+
+    /// Appends a given string to the end of this string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, StringHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new("hello".to_string());
+    /// handle.push_str(" world".to_string()).await;
+    /// assert_eq!(handle.get().await, "hello world");
+    /// # }
+    /// ```
+    fn push_str(&mut self, string: String) {
+        self.push_str(&string)
+    }
+
+    /// Appends the given char to the end of this string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, StringHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new("hello".to_string());
+    /// handle.push('!').await;
+    /// assert_eq!(handle.get().await, "hello!");
+    /// # }
+    /// ```
+    fn push(&mut self, ch: char) {
+        self.push(ch)
+    }
+
+    /// Returns `true` if the string contains the given pattern.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, StringHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new("hello world".to_string());
+    /// assert!(handle.contains("world".to_string()).await);
+    /// assert!(!handle.contains("xyz".to_string()).await);
+    /// # }
+    /// ```
+    fn contains(&self, pat: String) -> bool {
+        self.as_str().contains(&*pat)
+    }
+
+    /// Replaces all matches of a pattern with another string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, StringHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new("hello world".to_string());
+    /// let result = handle.replace("world".to_string(), "rust".to_string()).await;
+    /// assert_eq!(result, "hello rust");
+    /// # }
+    /// ```
+    fn replace(&self, from: String, to: String) -> String {
+        self.as_str().replace(from.as_str(), to.as_str())
+    }
+
+    /// Returns a string with leading and trailing whitespace removed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, StringHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new("  hello  ".to_string());
+    /// assert_eq!(handle.trim().await, "hello");
+    /// # }
+    /// ```
+    fn trim(&self) -> String {
+        self.as_str().trim().to_owned()
+    }
+
+    /// Returns `true` if the string starts with the given pattern.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, StringHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new("hello world".to_string());
+    /// assert!(handle.starts_with("hello".to_string()).await);
+    /// # }
+    /// ```
+    fn starts_with(&self, pat: String) -> bool {
+        self.as_str().starts_with(&*pat)
+    }
+
+    /// Returns `true` if the string ends with the given pattern.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, StringHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new("hello world".to_string());
+    /// assert!(handle.ends_with("world".to_string()).await);
+    /// # }
+    /// ```
+    fn ends_with(&self, pat: String) -> bool {
+        self.as_str().ends_with(&*pat)
+    }
+
+    /// Splits the string by the given pattern and returns the parts as a `Vec<String>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, StringHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new("a,b,c".to_string());
+    /// let parts = handle.split(",".to_string()).await;
+    /// assert_eq!(parts, vec!["a", "b", "c"]);
+    /// # }
+    /// ```
+    fn split(&self, pat: String) -> Vec<String> {
+        self.as_str().split(&*pat).map(String::from).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Handle;
+
+    /// Reading the string leaves it untouched. The `push` afterwards proves the
+    /// subscription is live and the first assertion did not pass by accident.
+    #[tokio::test]
+    async fn test_getter_does_not_broadcast() {
+        let handle = Handle::new("ab".to_string());
+        let mut rx = handle.subscribe();
+
+        assert_eq!(handle.len().await, 2);
+        assert!(rx.try_recv().is_err());
+
+        // The actor broadcasts before it replies, so the value is already
+        // queued and a missing broadcast fails here instead of hanging.
+        handle.push('c').await;
+        assert_eq!(rx.try_recv().unwrap(), "abc");
+    }
+
+    #[tokio::test]
+    async fn test_mutations_reach_the_actor() {
+        let handle = Handle::new(String::new());
+
+        handle.push_str("hello".to_string()).await;
+        handle.push(' ').await;
+        handle.push_str("world".to_string()).await;
+        assert_eq!(handle.get().await, "hello world");
+
+        handle.truncate(5).await;
+        assert_eq!(handle.get().await, "hello");
+
+        handle.clear().await;
+        assert!(handle.is_empty().await);
+    }
+
+    /// The borrowing methods of `str` return owned values here, since nothing
+    /// borrowed can leave the actor.
+    #[tokio::test]
+    async fn test_readers_return_owned_values() {
+        let handle = Handle::new("  Hello World  ".to_string());
+
+        assert_eq!(handle.trim().await, "Hello World");
+        assert_eq!(handle.to_uppercase().await, "  HELLO WORLD  ");
+        assert_eq!(handle.to_lowercase().await, "  hello world  ");
+        assert_eq!(
+            handle
+                .replace("World".to_string(), "there".to_string())
+                .await,
+            "  Hello there  "
+        );
+        assert_eq!(
+            handle.split(String::from(" ")).await,
+            vec!["", "", "Hello", "World", "", ""]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_pattern_queries() {
+        let handle = Handle::new("hello world".to_string());
+
+        assert!(handle.contains("lo wo".to_string()).await);
+        assert!(handle.starts_with("hello".to_string()).await);
+        assert!(handle.ends_with("world".to_string()).await);
+        assert!(!handle.contains("goodbye".to_string()).await);
+    }
+}

--- a/actify/src/extensions/vec.rs
+++ b/actify/src/extensions/vec.rs
@@ -91,6 +91,6 @@ mod tests {
         assert!(rx.try_recv().is_err());
 
         handle.push(4).await;
-        assert_eq!(rx.recv().await.unwrap(), vec![1, 2, 3, 4]);
+        assert_eq!(rx.try_recv().unwrap(), vec![1, 2, 3, 4]);
     }
 }

--- a/actify/src/lib.rs
+++ b/actify/src/lib.rs
@@ -372,6 +372,7 @@
 //! - [`VecHandle`] for `Handle<Vec<T>>`
 //! - [`HashMapHandle`] for `Handle<HashMap<K, V>>`
 //! - [`HashSetHandle`] for `Handle<HashSet<K>>`
+//! - [`StringHandle`] for `Handle<String>`
 //!
 //! # Views and non-Clone types
 //!
@@ -470,7 +471,8 @@ mod throttle;
 pub use actify_macros::{actify, broadcast, skip_broadcast};
 pub use cache::{Cache, CacheRecvError};
 pub use extensions::{
-    map::HashMapHandle, option::OptionHandle, set::HashSetHandle, vec::VecHandle,
+    map::HashMapHandle, option::OptionHandle, set::HashSetHandle, string::StringHandle,
+    vec::VecHandle,
 };
 pub use handles::{Handle, ReadHandle, ToView};
 pub use throttle::{BoxFuture, Frequency, Throttle};


### PR DESCRIPTION
Item 12a, the first slice of PR #58. That branch is +1618 lines across six files, which is not reviewable or revertible in one go, so it goes in one PR per type.

`StringHandle` for `Handle<String>`: `len`, `is_empty`, `clear`, `truncate`, `push`, `push_str`, `contains`, `starts_with`, `ends_with`, `replace`, `split`, `trim`, `to_lowercase`, `to_uppercase`.

Every method keeps its `std` name. Where `std` borrows, these return owned values, because nothing borrowed can leave an actor: `trim` and `replace` return `String`, and `split` returns `Vec<String>` rather than an iterator, the same way `VecHandle::drain` collects. Arguments are owned for the same reason, so the pattern methods take `String`.

## What changed from #58

- The `use crate as actify;` line is gone, since #115 made `::actify` resolve inside the crate.
- Unit tests added. #58 had doctests only, while the extensions on main also carry tests.
- `replace` used `&*from, &*to`; clippy rejects the second as an explicit auto-deref, so both are now `as_str()`.

Nothing in #58's string surface needed renaming, and the receivers were already right, so broadcasting behaves correctly under #83's rule without a single attribute.

## Verification

Four tests: getters do not broadcast, mutators reach the actor, the borrowing methods return owned values, and the pattern queries answer correctly. Plus a doctest on every method, carried over from #58.

Mutation-verified from both directions:

| Mutation | Result |
| --- | --- |
| `#[actify::skip_broadcast]` on `push` | `test_getter_does_not_broadcast` fails |
| `#[actify::broadcast]` on `len` | same test fails |

My first attempt at those wrote `#[actify_macros::skip_broadcast]`, which the macro does not recognise, so both mutations were silently no-ops and appeared to survive. Only `#[skip_broadcast]` and `#[actify::skip_broadcast]` are matched, deliberately, so that another crate's attribute is never claimed.

**One drive-by, flagged:** the broadcast assertion used `rx.recv().await`, and under the skip mutation the test hung for 60 seconds instead of failing. The actor broadcasts before it replies, so the value is already queued when `push().await` returns and `rx.try_recv()` is both deterministic and immediate. `vec.rs` had the identical line, so it got the same one-line change; it is the only edit in this PR outside the new file and the wiring.

Full local gate green: workspace tests, `-p actify`, clippy `--all-targets --all-features -D warnings`, fmt, docs with `-D warnings` both with and without `--all-features`, and a 1.85 MSRV check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)