### PR TITLE
Add VecDequeHandle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 
 ### Added
 
+- `VecDequeHandle` for `Handle<VecDeque<T>>`, with `push_back`, `push_front`,
+  `pop_back`, `pop_front`, `front`, `back`, `get_index`, `len`, `is_empty`,
+  `clear`, `contains`, `drain` and `retain`.
+
+  `front`, `back` and `get_index` clone what `std` would borrow. `get_index`
+  carries its suffix because an inherent `Handle::get` would shadow a generated
+  method called `get`.
+
+
 - `StringHandle` for `Handle<String>`, with `len`, `is_empty`, `clear`,
   `truncate`, `push`, `push_str`, `contains`, `starts_with`, `ends_with`,
   `replace`, `split`, `trim`, `to_lowercase` and `to_uppercase`.

--- a/actify/src/extensions/mod.rs
+++ b/actify/src/extensions/mod.rs
@@ -3,3 +3,4 @@ pub(crate) mod option;
 pub(crate) mod set;
 pub(crate) mod string;
 pub(crate) mod vec;
+pub(crate) mod vecdeque;

--- a/actify/src/extensions/vecdeque.rs
+++ b/actify/src/extensions/vecdeque.rs
@@ -1,0 +1,355 @@
+use actify_macros::actify;
+use core::ops::RangeBounds;
+use std::collections::VecDeque;
+
+/// An extension trait for `VecDeque<T>` actors, made available on the [`Handle`](crate::Handle)
+/// as [`VecDequeHandle`](crate::VecDequeHandle).
+trait ActorVecDeque<T> {
+    fn push_back(&mut self, value: T);
+
+    fn push_front(&mut self, value: T);
+
+    fn pop_back(&mut self) -> Option<T>;
+
+    fn pop_front(&mut self) -> Option<T>;
+
+    fn len(&self) -> usize;
+
+    fn is_empty(&self) -> bool;
+
+    fn clear(&mut self);
+
+    fn get_index(&self, index: usize) -> Option<T>;
+
+    fn front(&self) -> Option<T>;
+
+    fn back(&self) -> Option<T>;
+
+    fn contains(&self, value: T) -> bool
+    where
+        T: PartialEq;
+
+    fn drain<R>(&mut self, range: R) -> Vec<T>
+    where
+        R: RangeBounds<usize> + Send + Sync + 'static;
+
+    fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&T) -> bool + Send + Sync + 'static;
+}
+
+/// Extension methods for `Handle<VecDeque<T>>`, exposed as [`VecDequeHandle`](crate::VecDequeHandle).
+#[actify]
+impl<T> ActorVecDeque<T> for VecDeque<T>
+where
+    T: Clone + Send + Sync + 'static,
+{
+    /// Appends an element to the back of the deque.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecDequeHandle};
+    /// # use std::collections::VecDeque;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(VecDeque::new());
+    /// handle.push_back(1).await;
+    /// handle.push_back(2).await;
+    /// assert_eq!(handle.get().await, VecDeque::from([1, 2]));
+    /// # }
+    /// ```
+    fn push_back(&mut self, value: T) {
+        self.push_back(value)
+    }
+
+    /// Prepends an element to the front of the deque.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecDequeHandle};
+    /// # use std::collections::VecDeque;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(VecDeque::new());
+    /// handle.push_front(1).await;
+    /// handle.push_front(2).await;
+    /// assert_eq!(handle.get().await, VecDeque::from([2, 1]));
+    /// # }
+    /// ```
+    fn push_front(&mut self, value: T) {
+        self.push_front(value)
+    }
+
+    /// Removes the last element from the deque and returns it, or `None` if it is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecDequeHandle};
+    /// # use std::collections::VecDeque;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(VecDeque::from([1, 2, 3]));
+    /// assert_eq!(handle.pop_back().await, Some(3));
+    /// # }
+    /// ```
+    fn pop_back(&mut self) -> Option<T> {
+        self.pop_back()
+    }
+
+    /// Removes the first element from the deque and returns it, or `None` if it is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecDequeHandle};
+    /// # use std::collections::VecDeque;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(VecDeque::from([1, 2, 3]));
+    /// assert_eq!(handle.pop_front().await, Some(1));
+    /// # }
+    /// ```
+    fn pop_front(&mut self) -> Option<T> {
+        self.pop_front()
+    }
+
+    /// Returns the number of elements in the deque.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecDequeHandle};
+    /// # use std::collections::VecDeque;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(VecDeque::from([1, 2, 3]));
+    /// assert_eq!(handle.len().await, 3);
+    /// # }
+    /// ```
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    /// Returns `true` if the deque contains no elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecDequeHandle};
+    /// # use std::collections::VecDeque;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(VecDeque::<i32>::new());
+    /// assert!(handle.is_empty().await);
+    /// # }
+    /// ```
+    fn is_empty(&self) -> bool {
+        self.is_empty()
+    }
+
+    /// Clears the deque, removing all values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecDequeHandle};
+    /// # use std::collections::VecDeque;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(VecDeque::from([1, 2, 3]));
+    /// handle.clear().await;
+    /// assert!(handle.is_empty().await);
+    /// # }
+    /// ```
+    fn clear(&mut self) {
+        self.clear()
+    }
+
+    /// Returns a clone of the element at the given index, or `None` if out of bounds.
+    /// Named `get_index` to avoid conflict with [`Handle::get`](crate::Handle::get).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecDequeHandle};
+    /// # use std::collections::VecDeque;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(VecDeque::from([10, 20, 30]));
+    /// assert_eq!(handle.get_index(1).await, Some(20));
+    /// assert_eq!(handle.get_index(5).await, None);
+    /// # }
+    /// ```
+    fn get_index(&self, index: usize) -> Option<T> {
+        self.get(index).cloned()
+    }
+
+    /// Returns a clone of the front element, or `None` if the deque is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecDequeHandle};
+    /// # use std::collections::VecDeque;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(VecDeque::from([10, 20, 30]));
+    /// assert_eq!(handle.front().await, Some(10));
+    /// # }
+    /// ```
+    fn front(&self) -> Option<T> {
+        self.front().cloned()
+    }
+
+    /// Returns a clone of the back element, or `None` if the deque is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecDequeHandle};
+    /// # use std::collections::VecDeque;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(VecDeque::from([10, 20, 30]));
+    /// assert_eq!(handle.back().await, Some(30));
+    /// # }
+    /// ```
+    fn back(&self) -> Option<T> {
+        self.back().cloned()
+    }
+
+    /// Returns `true` if the deque contains an element equal to the given value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecDequeHandle};
+    /// # use std::collections::VecDeque;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(VecDeque::from([1, 2, 3]));
+    /// assert!(handle.contains(2).await);
+    /// assert!(!handle.contains(5).await);
+    /// # }
+    /// ```
+    fn contains(&self, value: T) -> bool
+    where
+        T: PartialEq,
+    {
+        self.contains(&value)
+    }
+
+    /// Removes the specified range from the deque and returns the removed items as a `Vec`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecDequeHandle};
+    /// # use std::collections::VecDeque;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(VecDeque::from([1, 2, 3, 4]));
+    /// let drained = handle.drain(1..3).await;
+    /// assert_eq!(drained, vec![2, 3]);
+    /// assert_eq!(handle.get().await, VecDeque::from([1, 4]));
+    /// # }
+    /// ```
+    fn drain<R>(&mut self, range: R) -> Vec<T>
+    where
+        R: RangeBounds<usize> + Send + Sync + 'static,
+    {
+        self.drain(range).collect()
+    }
+
+    /// Retains only the elements specified by the predicate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecDequeHandle};
+    /// # use std::collections::VecDeque;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(VecDeque::from([1, 2, 3, 4, 5]));
+    /// handle.retain(|x| *x > 2).await;
+    /// assert_eq!(handle.get().await, VecDeque::from([3, 4, 5]));
+    /// # }
+    /// ```
+    fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&T) -> bool + Send + Sync + 'static,
+    {
+        self.retain(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Handle;
+
+    fn deque() -> Handle<VecDeque<i32>> {
+        Handle::new(VecDeque::from([1, 2, 3]))
+    }
+
+    /// Reading the deque leaves it untouched. The `push_back` afterwards proves
+    /// the subscription is live and the first assertion did not pass by accident.
+    #[tokio::test]
+    async fn test_getter_does_not_broadcast() {
+        let handle = deque();
+        let mut rx = handle.subscribe();
+
+        assert_eq!(handle.len().await, 3);
+        assert!(rx.try_recv().is_err());
+
+        // The actor broadcasts before it replies, so the value is already
+        // queued and a missing broadcast fails here instead of hanging.
+        handle.push_back(4).await;
+        assert_eq!(rx.try_recv().unwrap(), VecDeque::from([1, 2, 3, 4]));
+    }
+
+    #[tokio::test]
+    async fn test_both_ends_can_be_pushed_and_popped() {
+        let handle = deque();
+
+        handle.push_front(0).await;
+        handle.push_back(4).await;
+        assert_eq!(handle.get().await, VecDeque::from([0, 1, 2, 3, 4]));
+
+        assert_eq!(handle.pop_front().await, Some(0));
+        assert_eq!(handle.pop_back().await, Some(4));
+        assert_eq!(handle.get().await, VecDeque::from([1, 2, 3]));
+
+        handle.clear().await;
+        assert!(handle.is_empty().await);
+        assert_eq!(handle.pop_front().await, None);
+    }
+
+    /// The methods that borrow in `std` clone here, since nothing borrowed can
+    /// leave the actor.
+    #[tokio::test]
+    async fn test_reads_return_owned_values() {
+        let handle = deque();
+
+        assert_eq!(handle.front().await, Some(1));
+        assert_eq!(handle.back().await, Some(3));
+        assert_eq!(handle.get_index(1).await, Some(2));
+        assert_eq!(handle.get_index(9).await, None);
+        assert!(handle.contains(2).await);
+        assert!(!handle.contains(9).await);
+    }
+
+    #[tokio::test]
+    async fn test_drain_and_retain_remove_in_place() {
+        let handle = Handle::new(VecDeque::from([1, 2, 3, 4, 5]));
+
+        assert_eq!(handle.drain(1..3).await, vec![2, 3]);
+        assert_eq!(handle.get().await, VecDeque::from([1, 4, 5]));
+
+        handle.retain(|value: &i32| value % 2 == 1).await;
+        assert_eq!(handle.get().await, VecDeque::from([1, 5]));
+    }
+}

--- a/actify/src/lib.rs
+++ b/actify/src/lib.rs
@@ -373,6 +373,7 @@
 //! - [`HashMapHandle`] for `Handle<HashMap<K, V>>`
 //! - [`HashSetHandle`] for `Handle<HashSet<K>>`
 //! - [`StringHandle`] for `Handle<String>`
+//! - [`VecDequeHandle`] for `Handle<VecDeque<T>>`
 //!
 //! # Views and non-Clone types
 //!
@@ -472,7 +473,7 @@ pub use actify_macros::{actify, broadcast, skip_broadcast};
 pub use cache::{Cache, CacheRecvError};
 pub use extensions::{
     map::HashMapHandle, option::OptionHandle, set::HashSetHandle, string::StringHandle,
-    vec::VecHandle,
+    vec::VecHandle, vecdeque::VecDequeHandle,
 };
 pub use handles::{Handle, ReadHandle, ToView};
 pub use throttle::{BoxFuture, Frequency, Throttle};


### PR DESCRIPTION
Item 12b, the second slice of PR #58.

`VecDequeHandle` for `Handle<VecDeque<T>>`: `push_back`, `push_front`, `pop_back`, `pop_front`, `front`, `back`, `get_index`, `len`, `is_empty`, `clear`, `contains`, `drain`, `retain`.

Every name is `std`'s except `get_index`, which keeps its suffix because an inherent `Handle::get` shadows a generated method called `get`, the collision #66 was about. `front`, `back` and `get_index` clone what `std` borrows, as elsewhere.

## What changed from #58

Only the `use crate as actify;` line, dropped since #115, plus the tests. The methods and their receivers came over as they were, so broadcasting behaves correctly under #83 with no attributes.

## Verification

Four tests: getters do not broadcast, both ends push and pop, the borrowing reads return owned values, and drain and retain remove in place. Doctests on every method come from #58.

Mutation-verified:

| Mutation | Test that failed |
| --- | --- |
| `#[actify::skip_broadcast]` on `push_back` | `test_getter_does_not_broadcast` |
| `#[actify::broadcast]` on `len` | same |
| `front` returns the back element | `test_reads_return_owned_values` |
| `retain` ignores its predicate | `test_drain_and_retain_remove_in_place` |
| `drain` ignores its range | same |

A sixth attempt, rewriting `retain(f)` as `retain(|value| !f(value))`, did not compile, since calling an `FnMut` inside a closure needs it captured mutably. It proved nothing, so it is not in the table; the two that replaced it do compile.

Full local gate green: workspace tests, `-p actify`, clippy `--all-targets --all-features -D warnings`, fmt, docs with `-D warnings` both with and without `--all-features`, and a 1.85 MSRV check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)