### PR TITLE
Extend VecHandle with eighteen methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 
 ### Added
 
+- `VecHandle` gains `len`, `pop`, `clear`, `remove`, `swap_remove`, `insert`,
+  `truncate`, `reverse`, `split_off`, `get_index`, `first`, `last`, `contains`,
+  `append`, `dedup`, `sort`, `sort_by` and `retain`.
+
+  `first`, `last` and `get_index` clone what `std` borrows. `get_index` carries
+  its suffix because an inherent `Handle::get` shadows a generated method called
+  `get`.
+
+
 - `HashMapHandle` gains `len`, `contains_key`, `drain`, `extend`, `retain` and
   `get_or_insert_with`. `drain` returns `Vec<(K, V)>` rather than an iterator, and
   `get_or_insert_with` returns a clone of the value, since a reference cannot

--- a/actify/src/extensions/vec.rs
+++ b/actify/src/extensions/vec.rs
@@ -1,4 +1,5 @@
 use actify_macros::actify;
+use core::cmp::Ordering;
 use core::ops::RangeBounds;
 
 /// An extension trait for `Vec<T>` actors, made available on the [`Handle`](crate::Handle)
@@ -11,6 +12,52 @@ trait ActorVec<T> {
     fn drain<R>(&mut self, range: R) -> Vec<T>
     where
         R: RangeBounds<usize> + Send + Sync + 'static;
+
+    fn len(&self) -> usize;
+
+    fn pop(&mut self) -> Option<T>;
+
+    fn clear(&mut self);
+
+    fn remove(&mut self, index: usize) -> T;
+
+    fn swap_remove(&mut self, index: usize) -> T;
+
+    fn insert(&mut self, index: usize, element: T);
+
+    fn truncate(&mut self, len: usize);
+
+    fn reverse(&mut self);
+
+    fn split_off(&mut self, at: usize) -> Vec<T>;
+
+    fn get_index(&self, index: usize) -> Option<T>;
+
+    fn first(&self) -> Option<T>;
+
+    fn last(&self) -> Option<T>;
+
+    fn contains(&self, value: T) -> bool
+    where
+        T: PartialEq;
+
+    fn append(&mut self, other: Vec<T>);
+
+    fn dedup(&mut self)
+    where
+        T: PartialEq;
+
+    fn sort(&mut self)
+    where
+        T: Ord;
+
+    fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&T) -> bool + Send + Sync + 'static;
+
+    fn sort_by<F>(&mut self, compare: F)
+    where
+        F: FnMut(&T, &T) -> Ordering + Send + Sync + 'static;
 }
 
 /// Extension methods for `Handle<Vec<T>>`, exposed as [`VecHandle`](crate::VecHandle).
@@ -72,6 +119,345 @@ where
     {
         self.drain(range).collect()
     }
+
+    /// Returns the number of elements in the vector.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(vec![1, 2, 3]);
+    /// assert_eq!(handle.len().await, 3);
+    /// # }
+    /// ```
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    /// Removes the last element from a vector and returns it, or `None` if it is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(vec![1, 2, 3]);
+    /// assert_eq!(handle.pop().await, Some(3));
+    /// assert_eq!(handle.get().await, vec![1, 2]);
+    /// # }
+    /// ```
+    fn pop(&mut self) -> Option<T> {
+        self.pop()
+    }
+
+    /// Clears the vector, removing all values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(vec![1, 2, 3]);
+    /// handle.clear().await;
+    /// assert!(handle.is_empty().await);
+    /// # }
+    /// ```
+    fn clear(&mut self) {
+        self.clear()
+    }
+
+    /// Removes and returns the element at position `index`, shifting all elements after it to the left.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(vec![1, 2, 3]);
+    /// assert_eq!(handle.remove(1).await, 2);
+    /// assert_eq!(handle.get().await, vec![1, 3]);
+    /// # }
+    /// ```
+    fn remove(&mut self, index: usize) -> T {
+        self.remove(index)
+    }
+
+    /// Removes an element from the vector and returns it.
+    /// The removed element is replaced by the last element of the vector.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(vec![1, 2, 3, 4]);
+    /// assert_eq!(handle.swap_remove(1).await, 2);
+    /// assert_eq!(handle.get().await, vec![1, 4, 3]);
+    /// # }
+    /// ```
+    fn swap_remove(&mut self, index: usize) -> T {
+        self.swap_remove(index)
+    }
+
+    /// Inserts an element at position `index`, shifting all elements after it to the right.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index > len`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(vec![1, 3]);
+    /// handle.insert(1, 2).await;
+    /// assert_eq!(handle.get().await, vec![1, 2, 3]);
+    /// # }
+    /// ```
+    fn insert(&mut self, index: usize, element: T) {
+        self.insert(index, element)
+    }
+
+    /// Shortens the vector, keeping the first `len` elements and dropping the rest.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(vec![1, 2, 3, 4, 5]);
+    /// handle.truncate(2).await;
+    /// assert_eq!(handle.get().await, vec![1, 2]);
+    /// # }
+    /// ```
+    fn truncate(&mut self, len: usize) {
+        self.truncate(len)
+    }
+
+    /// Reverses the order of elements in the vector, in place.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(vec![1, 2, 3]);
+    /// handle.reverse().await;
+    /// assert_eq!(handle.get().await, vec![3, 2, 1]);
+    /// # }
+    /// ```
+    fn reverse(&mut self) {
+        self.as_mut_slice().reverse()
+    }
+
+    /// Splits the vector into two at the given index.
+    /// Returns a newly allocated vector containing the elements in the range `[at, len)`.
+    /// After the call, the original vector will contain elements `[0, at)`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `at > len`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(vec![1, 2, 3, 4, 5]);
+    /// let tail = handle.split_off(3).await;
+    /// assert_eq!(tail, vec![4, 5]);
+    /// assert_eq!(handle.get().await, vec![1, 2, 3]);
+    /// # }
+    /// ```
+    fn split_off(&mut self, at: usize) -> Vec<T> {
+        self.split_off(at)
+    }
+
+    /// Returns a clone of the element at the given index, or `None` if out of bounds.
+    /// Named `get_index` to avoid conflict with [`Handle::get`](crate::Handle::get).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(vec![10, 20, 30]);
+    /// assert_eq!(handle.get_index(1).await, Some(20));
+    /// assert_eq!(handle.get_index(5).await, None);
+    /// # }
+    /// ```
+    fn get_index(&self, index: usize) -> Option<T> {
+        self.get(index).cloned()
+    }
+
+    /// Returns a clone of the first element, or `None` if the vector is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(vec![10, 20, 30]);
+    /// assert_eq!(handle.first().await, Some(10));
+    /// # }
+    /// ```
+    fn first(&self) -> Option<T> {
+        self.as_slice().first().cloned()
+    }
+
+    /// Returns a clone of the last element, or `None` if the vector is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(vec![10, 20, 30]);
+    /// assert_eq!(handle.last().await, Some(30));
+    /// # }
+    /// ```
+    fn last(&self) -> Option<T> {
+        self.as_slice().last().cloned()
+    }
+
+    /// Returns `true` if the vector contains an element equal to the given value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(vec![1, 2, 3]);
+    /// assert!(handle.contains(2).await);
+    /// assert!(!handle.contains(5).await);
+    /// # }
+    /// ```
+    fn contains(&self, value: T) -> bool
+    where
+        T: PartialEq,
+    {
+        self.as_slice().contains(&value)
+    }
+
+    /// Moves all the elements of `other` into the vector, leaving `other` empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(vec![1, 2]);
+    /// handle.append(vec![3, 4]).await;
+    /// assert_eq!(handle.get().await, vec![1, 2, 3, 4]);
+    /// # }
+    /// ```
+    fn append(&mut self, other: Vec<T>) {
+        self.extend(other)
+    }
+
+    /// Removes consecutive duplicate elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(vec![1, 1, 2, 3, 3]);
+    /// handle.dedup().await;
+    /// assert_eq!(handle.get().await, vec![1, 2, 3]);
+    /// # }
+    /// ```
+    fn dedup(&mut self)
+    where
+        T: PartialEq,
+    {
+        self.dedup()
+    }
+
+    /// Sorts the vector in ascending order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(vec![3, 1, 2]);
+    /// handle.sort().await;
+    /// assert_eq!(handle.get().await, vec![1, 2, 3]);
+    /// # }
+    /// ```
+    fn sort(&mut self)
+    where
+        T: Ord,
+    {
+        self.as_mut_slice().sort()
+    }
+
+    /// Retains only the elements specified by the predicate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(vec![1, 2, 3, 4, 5]);
+    /// handle.retain(|x| *x > 2).await;
+    /// assert_eq!(handle.get().await, vec![3, 4, 5]);
+    /// # }
+    /// ```
+    fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&T) -> bool + Send + Sync + 'static,
+    {
+        self.retain(f)
+    }
+
+    /// Sorts the vector with a comparator function.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(vec![3, 1, 2]);
+    /// handle.sort_by(|a, b| b.cmp(a)).await;
+    /// assert_eq!(handle.get().await, vec![3, 2, 1]);
+    /// # }
+    /// ```
+    fn sort_by<F>(&mut self, compare: F)
+    where
+        F: FnMut(&T, &T) -> Ordering + Send + Sync + 'static,
+    {
+        self.as_mut_slice().sort_by(compare)
+    }
 }
 
 #[cfg(test)]
@@ -79,18 +465,145 @@ mod tests {
     use super::*;
     use crate::Handle;
 
-    /// Reading the length leaves the vector untouched. The `push` afterwards
-    /// proves the subscription is live and the first assertion did not pass by
-    /// accident.
+    /// Reading leaves the vector untouched. The `push` afterwards proves the
+    /// subscription is live and the assertions above did not pass by accident.
     #[tokio::test]
-    async fn test_getter_does_not_broadcast() {
+    async fn test_getters_do_not_broadcast() {
         let handle = Handle::new(vec![1, 2, 3]);
         let mut rx = handle.subscribe();
 
         assert!(!handle.is_empty().await);
+        assert_eq!(handle.len().await, 3);
+        assert_eq!(handle.first().await, Some(1));
+        assert_eq!(handle.last().await, Some(3));
+        assert_eq!(handle.get_index(1).await, Some(2));
+        assert!(handle.contains(2).await);
         assert!(rx.try_recv().is_err());
 
+        // The actor broadcasts before it replies, so the value is already
+        // queued and a missing broadcast fails here instead of hanging.
         handle.push(4).await;
         assert_eq!(rx.try_recv().unwrap(), vec![1, 2, 3, 4]);
+    }
+
+    /// Every method taking `&mut self` broadcasts, whether or not it changed
+    /// anything.
+    #[tokio::test]
+    async fn test_every_mutator_broadcasts() {
+        let handle = Handle::new(vec![3, 1, 2]);
+        let mut rx = handle.subscribe();
+
+        handle.insert(0, 9).await;
+        assert!(rx.try_recv().is_ok(), "insert did not broadcast");
+
+        handle.remove(0).await;
+        assert!(rx.try_recv().is_ok(), "remove did not broadcast");
+
+        handle.swap_remove(0).await;
+        assert!(rx.try_recv().is_ok(), "swap_remove did not broadcast");
+
+        handle.append(vec![5, 4]).await;
+        assert!(rx.try_recv().is_ok(), "append did not broadcast");
+
+        handle.sort().await;
+        assert!(rx.try_recv().is_ok(), "sort did not broadcast");
+
+        handle.sort_by(|a: &i32, b: &i32| b.cmp(a)).await;
+        assert!(rx.try_recv().is_ok(), "sort_by did not broadcast");
+
+        handle.reverse().await;
+        assert!(rx.try_recv().is_ok(), "reverse did not broadcast");
+
+        handle.dedup().await;
+        assert!(rx.try_recv().is_ok(), "dedup did not broadcast");
+
+        handle.retain(|value: &i32| value % 2 == 0).await;
+        assert!(rx.try_recv().is_ok(), "retain did not broadcast");
+
+        handle.truncate(1).await;
+        assert!(rx.try_recv().is_ok(), "truncate did not broadcast");
+
+        handle.split_off(0).await;
+        assert!(rx.try_recv().is_ok(), "split_off did not broadcast");
+
+        handle.pop().await;
+        assert!(rx.try_recv().is_ok(), "pop did not broadcast");
+
+        handle.clear().await;
+        assert!(rx.try_recv().is_ok(), "clear did not broadcast");
+    }
+
+    /// The methods that borrow in `std` clone here, since nothing borrowed can
+    /// leave the actor.
+    #[tokio::test]
+    async fn test_reads_return_owned_values() {
+        let handle = Handle::new(vec![1, 2, 3]);
+
+        assert_eq!(handle.get_index(9).await, None);
+        assert!(!handle.contains(9).await);
+
+        let empty: Handle<Vec<i32>> = Handle::new(Vec::new());
+        assert_eq!(empty.first().await, None);
+        assert_eq!(empty.last().await, None);
+    }
+
+    #[tokio::test]
+    async fn test_removals_return_what_they_removed() {
+        let handle = Handle::new(vec![1, 2, 3, 4]);
+
+        assert_eq!(handle.pop().await, Some(4));
+        assert_eq!(handle.get().await, vec![1, 2, 3]);
+
+        assert_eq!(handle.remove(0).await, 1);
+        assert_eq!(handle.get().await, vec![2, 3]);
+
+        handle.append(vec![4, 5]).await;
+        // swap_remove moves the last element into the freed slot, which is what
+        // distinguishes it from remove
+        assert_eq!(handle.swap_remove(0).await, 2);
+        assert_eq!(handle.get().await, vec![5, 3, 4]);
+
+        assert_eq!(handle.split_off(1).await, vec![3, 4]);
+        assert_eq!(handle.get().await, vec![5]);
+        handle.clear().await;
+        assert!(handle.is_empty().await);
+        assert_eq!(handle.pop().await, None);
+    }
+
+    #[tokio::test]
+    async fn test_ordering_and_dedup() {
+        let handle = Handle::new(vec![3, 1, 2, 2]);
+
+        handle.sort().await;
+        assert_eq!(handle.get().await, vec![1, 2, 2, 3]);
+
+        handle.dedup().await;
+        assert_eq!(handle.get().await, vec![1, 2, 3]);
+
+        handle.reverse().await;
+        assert_eq!(handle.get().await, vec![3, 2, 1]);
+
+        handle.sort_by(|a: &i32, b: &i32| a.cmp(b)).await;
+        assert_eq!(handle.get().await, vec![1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn test_insert_append_retain_and_truncate() {
+        let handle = Handle::new(vec![1, 2]);
+
+        handle.insert(1, 9).await;
+        assert_eq!(handle.get().await, vec![1, 9, 2]);
+
+        handle.append(vec![3, 4]).await;
+        assert_eq!(handle.get().await, vec![1, 9, 2, 3, 4]);
+
+        handle.retain(|value: &i32| *value < 4).await;
+        assert_eq!(handle.get().await, vec![1, 2, 3]);
+
+        handle.truncate(2).await;
+        assert_eq!(handle.get().await, vec![1, 2]);
+
+        handle.clear().await;
+        assert!(handle.is_empty().await);
     }
 }

--- a/actify/src/extensions/vec.rs
+++ b/actify/src/extensions/vec.rs
@@ -580,10 +580,10 @@ mod tests {
         handle.dedup().await;
         assert_eq!(handle.get().await, vec![1, 2, 3]);
 
-        handle.reverse().await;
+        handle.sort_by(|a: &i32, b: &i32| b.cmp(a)).await;
         assert_eq!(handle.get().await, vec![3, 2, 1]);
 
-        handle.sort_by(|a: &i32, b: &i32| a.cmp(b)).await;
+        handle.reverse().await;
         assert_eq!(handle.get().await, vec![1, 2, 3]);
     }
 


### PR DESCRIPTION
Item 12d. #58's remaining work is 36 methods across `vec.rs`, `set.rs` and `option.rs`, which is too much for one PR, so it is split by type: this is vec, then set, then option.

`VecHandle` had three methods. It gains eighteen: `len`, `pop`, `clear`, `remove`, `swap_remove`, `insert`, `truncate`, `reverse`, `split_off`, `get_index`, `first`, `last`, `contains`, `append`, `dedup`, `sort`, `sort_by`, `retain`.

All `std` names. `first`, `last` and `get_index` clone what `std` borrows, and `get_index` keeps its suffix because an inherent `Handle::get` shadows a generated `get`. One import added, `core::cmp::Ordering` for `sort_by`, using `core` to match the existing `core::ops::RangeBounds` rather than #58's `std`.

## Verification

Six tests: getters do not broadcast, every mutator does, the borrowing reads return owned values, removals return what they removed, ordering and dedup, and insert/append/retain/truncate.

Mutation-verified, 20 mutations. The thirteen `&mut self` methods were each given `#[actify::skip_broadcast]` in turn, and each failed `test_every_mutator_broadcasts` with its own message. Then seven value-level mutations: `len` broadcasting, `first` returning the last element, `swap_remove` behaving like `remove`, `split_off` returning the wrong half, `dedup` doing nothing, `reverse` doing nothing, `retain` inverting its predicate, and `sort_by` reversing its comparator.

**Two survivors, both weak tests of mine.**

Replacing `swap_remove` with `remove` passed, because my assertion ran on a two-element vector where the two are indistinguishable: both return the element at index 0 and leave one behind. The test now works on three elements and asserts the resulting order, `vec![5, 3, 4]`, which is only right if the last element was moved into the freed slot.

`sort_by` was called with an ascending comparator, which is indistinguishable from `sort`. The ordering test now sorts descending from a sorted state, so only a real comparator produces `vec![3, 2, 1]`.

Three of my mutation patterns did not match the impl block or did not compile: `self.first().cloned()` against the actual `self.as_slice().first().cloned()`, the same for `reverse`, and rewriting `sort_by` as `self.sort()`, which needs a `T: Ord` bound that method does not have. Each asserted or failed loudly rather than passing silently, which is the guard added after #118.

Full local gate green: workspace tests, `-p actify`, clippy `--all-targets --all-features -D warnings`, fmt, docs with `-D warnings` both with and without `--all-features`, and a 1.85 MSRV check. 246 doctests now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
