### PR TITLE
Extend OptionHandle with five methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 
 ### Added
 
+- `OptionHandle` gains `unwrap_or`, `unwrap_or_default`, `unwrap_or_else`,
+  `filter` and `map`.
+
+  These take `&self` where `std`'s consume `self`, so they read the actor's value
+  without changing it and do not broadcast. `map` may return a different type,
+  which the actor produces before the value leaves it.
+
+
 - `HashSetHandle` gains `len`, `clear`, `contains`, `remove`, `to_vec`, `drain`,
   `extend`, `retain`, `difference`, `intersection`, `union`, `is_subset` and
   `is_superset`.

--- a/actify/src/extensions/option.rs
+++ b/actify/src/extensions/option.rs
@@ -8,6 +8,25 @@ trait ActorOption<T> {
     fn take(&mut self) -> Option<T>;
 
     fn replace(&mut self, value: T) -> Option<T>;
+
+    fn unwrap_or(&self, default: T) -> T;
+
+    fn unwrap_or_default(&self) -> T
+    where
+        T: Default;
+
+    fn unwrap_or_else<F>(&self, f: F) -> T
+    where
+        F: FnOnce() -> T + Send + Sync + 'static;
+
+    fn filter<F>(&self, predicate: F) -> Option<T>
+    where
+        F: FnOnce(&T) -> bool + Send + Sync + 'static;
+
+    fn map<F, U>(&self, f: F) -> Option<U>
+    where
+        F: FnOnce(T) -> U + Send + Sync + 'static,
+        U: Send + Sync + 'static;
 }
 
 /// An implementation of the ActorOption extension trait for the standard [`Option`].
@@ -86,6 +105,109 @@ where
     fn replace(&mut self, value: T) -> Option<T> {
         self.replace(value)
     }
+
+    /// Returns the contained value or a provided default.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, OptionHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(Some(10));
+    /// assert_eq!(handle.unwrap_or(0).await, 10);
+    ///
+    /// let handle = Handle::new(Option::<i32>::None);
+    /// assert_eq!(handle.unwrap_or(0).await, 0);
+    /// # }
+    /// ```
+    fn unwrap_or(&self, default: T) -> T {
+        self.clone().unwrap_or(default)
+    }
+
+    /// Returns the contained value or a default.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, OptionHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(Option::<i32>::None);
+    /// assert_eq!(handle.unwrap_or_default().await, 0);
+    /// # }
+    /// ```
+    fn unwrap_or_default(&self) -> T
+    where
+        T: Default,
+    {
+        self.clone().unwrap_or_default()
+    }
+
+    /// Returns the contained value or computes it from a closure.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, OptionHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(Option::<i32>::None);
+    /// assert_eq!(handle.unwrap_or_else(|| 42).await, 42);
+    /// # }
+    /// ```
+    fn unwrap_or_else<F>(&self, f: F) -> T
+    where
+        F: FnOnce() -> T + Send + Sync + 'static,
+    {
+        self.clone().unwrap_or_else(f)
+    }
+
+    /// Returns `None` if the option is `None`, otherwise calls `predicate`
+    /// with the contained value and returns `Some(value)` if the predicate
+    /// returns `true`, or `None` if it returns `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, OptionHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(Some(4));
+    /// assert_eq!(handle.filter(|x| *x > 3).await, Some(4));
+    /// assert_eq!(handle.filter(|x| *x > 5).await, None);
+    /// # }
+    /// ```
+    fn filter<F>(&self, predicate: F) -> Option<T>
+    where
+        F: FnOnce(&T) -> bool + Send + Sync + 'static,
+    {
+        self.clone().filter(predicate)
+    }
+
+    /// Maps an `Option<T>` to `Option<U>` by applying a function to a contained value
+    /// (if `Some`) or returns `None` (if `None`).
+    ///
+    /// This is a read-only transform and does not mutate the actor state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, OptionHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(Some(3));
+    /// let doubled: Option<i32> = handle.map(|x| x * 2).await;
+    /// assert_eq!(doubled, Some(6));
+    /// # }
+    /// ```
+    fn map<F, U>(&self, f: F) -> Option<U>
+    where
+        F: FnOnce(T) -> U + Send + Sync + 'static,
+        U: Send + Sync + 'static,
+    {
+        self.clone().map(f)
+    }
 }
 
 #[cfg(test)]
@@ -107,6 +229,61 @@ mod tests {
     }
 
     /// `take` on a None option is not an error, and it still reports the state.
+    /// The reading methods clone the value out, so none of them mutates the
+    /// actor and none of them broadcasts.
+    #[tokio::test]
+    async fn test_readers_do_not_broadcast() {
+        let handle = Handle::new(Some(1));
+        let mut rx = handle.subscribe();
+
+        assert_eq!(handle.unwrap_or(9).await, 1);
+        assert_eq!(handle.unwrap_or_default().await, 1);
+        assert_eq!(handle.unwrap_or_else(|| 9).await, 1);
+        assert_eq!(handle.filter(|value: &i32| *value > 0).await, Some(1));
+        assert_eq!(handle.map(|value: i32| value * 2).await, Some(2));
+        assert!(rx.try_recv().is_err());
+
+        // The actor broadcasts before it replies, so the value is already
+        // queued and a missing broadcast fails here instead of hanging.
+        handle.replace(2).await;
+        assert_eq!(rx.try_recv().unwrap(), Some(2));
+    }
+
+    #[tokio::test]
+    async fn test_the_defaults_apply_only_when_none() {
+        let handle: Handle<Option<i32>> = Handle::new(None);
+
+        assert_eq!(handle.unwrap_or(9).await, 9);
+        assert_eq!(handle.unwrap_or_default().await, 0);
+        assert_eq!(handle.unwrap_or_else(|| 7).await, 7);
+
+        // A default must not be written back
+        assert!(handle.is_none().await);
+    }
+
+    #[tokio::test]
+    async fn test_filter_and_map_on_none() {
+        let handle: Handle<Option<i32>> = Handle::new(None);
+
+        assert_eq!(handle.filter(|_: &i32| true).await, None);
+        assert_eq!(handle.map(|value: i32| value * 2).await, None);
+    }
+
+    #[tokio::test]
+    async fn test_filter_rejects_and_map_changes_type() {
+        let handle = Handle::new(Some(3));
+
+        assert_eq!(handle.filter(|value: &i32| *value > 5).await, None);
+        assert_eq!(handle.filter(|value: &i32| *value > 1).await, Some(3));
+        assert_eq!(
+            handle.map(|value: i32| value.to_string()).await,
+            Some("3".to_string())
+        );
+
+        // Reading left the actor as it was
+        assert_eq!(handle.get().await, Some(3));
+    }
+
     #[tokio::test]
     async fn test_take_when_none() {
         let handle = Handle::new(Option::<i32>::None);


### PR DESCRIPTION
Item 12f, the last slice of #58.

`OptionHandle` gains `unwrap_or`, `unwrap_or_default`, `unwrap_or_else`, `filter` and `map`.

The interesting difference from `std`: all five take `&self` where `std`'s consume `self`. They read the actor's value, clone it, and leave the actor untouched, so none of them broadcasts. In particular a default is never written back, which is the thing a reader might assume `unwrap_or_default` does.

`map` may return a different type, and the actor produces it before the value leaves the actor, so `Handle<Option<i32>>` can hand back an `Option<String>`.

## Verification

Four new tests: the readers do not broadcast, the defaults apply only when the value is `None` and are not stored, `filter` and `map` pass `None` through, and `filter` can reject while `map` changes type. The two existing tests for `take` and `replace` are untouched.

Mutation-verified, six mutations, each failing an intended test:

| Mutation | Result |
| --- | --- |
| `#[actify::broadcast]` on `unwrap_or` | `test_readers_do_not_broadcast` fails |
| `unwrap_or` always returns the default | same |
| `unwrap_or_else` always calls the closure | same |
| `unwrap_or_default` always returns `T::default()` | same |
| `filter` inverts its predicate | `test_filter_rejects_and_map_changes_type` fails |
| `map` ignores its function | same |

One attempt did not compile: rewriting `unwrap_or_else` in terms of `unwrap_or_default` needs a `T: Default` bound that method does not have. It was replaced by the version in the table.

Full local gate green: workspace tests, `-p actify`, clippy `--all-targets --all-features -D warnings`, fmt, docs with `-D warnings` both with and without `--all-features`, and a 1.85 MSRV check. 300 doctests.

## This closes item 12

With this merged, everything in PR #58 has landed: `StringHandle` (#116), `VecDequeHandle` (#117), the six map methods (#118), eighteen vec methods (#119), thirteen set methods (#120) and these five. #58 can be closed as superseded rather than merged, since its 1618-line diff no longer applies and every method in it is now here with tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)