### PR TITLE
Generated traits promise a Send future

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,8 +134,10 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 
   Hand-written implementations, such as test stand-ins, keep compiling: an
   `async fn` in an implementation satisfies the new signature, as long as the
-  future it produces is `Send`. One that is not, because it holds a non-`Send`
-  value across an await, now fails to compile.
+  future it produces is `Send`. One that is not, because it holds an `Rc` or a
+  `RefCell` guard across an await, now fails to compile. Such an implementation
+  was legal before, since nothing in actify constrained a type that is not a
+  `Handle`.
 
   The generated implementation also bounds the broadcast type
   `Send + Sync + 'static`, since the future holds a `&Handle<T, V>` and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,28 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 
 ### Fixed
 
+- Code that is generic over a generated handle trait can now spawn the call. The
+  traits declared their methods `async fn`, which promises nothing about the
+  returned future, so a caller with `H: MyHandle` writing
+  `tokio::spawn(async move { handle.method().await })` was rejected with "future
+  cannot be sent between threads safely". The methods are now declared
+  `fn method(..) -> impl Future<Output = R> + Send`, which says it.
+
+  Concrete `Handle<T>` calls were never affected, which is why nothing in this
+  workspace hit it.
+
+### Changed
+
+- **Breaking:** the generated handle traits declare their methods
+  `-> impl Future<Output = R> + Send` rather than `async fn`. An `async fn` in an
+  implementation still satisfies them, so only code that implements a generated
+  trait by hand, such as a mock, needs updating.
+
+  The generated implementation now also requires the broadcast type to be
+  `Send + Sync + 'static`. Every handle that can exist already satisfies this,
+  since `Handle::new` requires it.
+
+
 - Generated code no longer breaks when something in scope shares a name with what
   that code refers to. A user type called `Box` next to an `#[actify]` impl made
   the generated body resolve `Box::new` to that type, and a module named `actify`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,13 +130,27 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 ### Changed
 
 - **Breaking:** the generated handle traits declare their methods
-  `-> impl Future<Output = R> + Send` rather than `async fn`. An `async fn` in an
-  implementation still satisfies them, so only code that implements a generated
-  trait by hand, such as a mock, needs updating.
+  `-> impl Future<Output = R> + Send` rather than `async fn`.
 
-  The generated implementation now also requires the broadcast type to be
-  `Send + Sync + 'static`. Every handle that can exist already satisfies this,
-  since `Handle::new` requires it.
+  Hand-written implementations, such as test stand-ins, keep compiling: an
+  `async fn` in an implementation satisfies the new signature, as long as the
+  future it produces is `Send`. One that is not, because it holds a non-`Send`
+  value across an await, now fails to compile.
+
+  The generated implementation also bounds the broadcast type
+  `Send + Sync + 'static`, since the future holds a `&Handle<T, V>` and a
+  reference is `Send` only if its referent is `Sync`. This breaks code that is
+  generic over the broadcast type without bounding it:
+
+  ```rust
+  // Compiled before, now needs V: Send + Sync + 'static
+  async fn read<V>(handle: Handle<Counter, V>) -> i32 {
+      handle.value().await
+  }
+  ```
+
+  Calls on a concrete handle are unaffected, because `Handle::new` already
+  requires those bounds of the broadcast type.
 
 
 - Generated code no longer breaks when something in scope shares a name with what

--- a/actify-macros/src/codegen/handle.rs
+++ b/actify-macros/src/codegen/handle.rs
@@ -64,12 +64,14 @@ pub fn generate_trait_impl(info: &ImplInfo) -> proc_macro2::TokenStream {
 /// e.g. `async fn foo(&self, i: i32) -> f64;`
 /// Generate one method signature for the handle trait.
 ///
-/// Written `-> impl Future<Output = R> + Send` rather than `async fn`. A trait
-/// method declared `async fn` returns a future whose type the caller cannot
-/// name and about which it is told nothing, so a function generic over this
-/// trait cannot pass the call to `tokio::spawn`: the compiler rejects it with
-/// "future cannot be sent between threads safely". Spelling the return type out
-/// states the `Send` bound the caller needs.
+/// Written `-> impl Future<Output = R> + Send` rather than `async fn`, because
+/// `async fn` in a trait states no bounds on the future it returns.
+///
+/// That only matters to a caller that is generic over this trait, since a
+/// concrete `Handle<T>` call lets the compiler see the future's real type and
+/// work out for itself that it is `Send`. A generic caller has nothing but the
+/// trait, so requiring `Send` of the call, by spawning it or otherwise, fails
+/// with "future cannot be sent between threads safely".
 fn method_signature(method: &MethodInfo) -> proc_macro2::TokenStream {
     let attrs = &method.attributes;
     let ident = &method.ident;

--- a/actify-macros/src/codegen/handle.rs
+++ b/actify-macros/src/codegen/handle.rs
@@ -34,10 +34,10 @@ pub fn generate_trait_impl(info: &ImplInfo) -> proc_macro2::TokenStream {
     // TypeGenerics renders; the full Generics would emit `T: Clone` there.
     let (_, trait_generics, where_clause) = info.generics.split_for_impl();
 
-    // The trait promises the returned future is Send, and the future holds
-    // `&Handle<T, __V>`, which is Send only if the handle is Sync. Every handle
-    // that can exist already satisfies this: `Handle::new` requires it of the
-    // broadcast type.
+    // The future returned by each method holds `&Handle<T, __V>`, and a
+    // reference is Send only if what it points at is Sync, so promising Send
+    // means the broadcast type has to be bounded here. Code generic over that
+    // type must bound it too, which is the one visible cost of the promise.
     let mut generics_with_broadcast = info.generics.clone();
     generics_with_broadcast
         .params
@@ -62,6 +62,14 @@ pub fn generate_trait_impl(info: &ImplInfo) -> proc_macro2::TokenStream {
 
 /// Generate a handle trait method signature.
 /// e.g. `async fn foo(&self, i: i32) -> f64;`
+/// Generate one method signature for the handle trait.
+///
+/// Written `-> impl Future<Output = R> + Send` rather than `async fn`. A trait
+/// method declared `async fn` returns a future whose type the caller cannot
+/// name and about which it is told nothing, so a function generic over this
+/// trait cannot pass the call to `tokio::spawn`: the compiler rejects it with
+/// "future cannot be sent between threads safely". Spelling the return type out
+/// states the `Send` bound the caller needs.
 fn method_signature(method: &MethodInfo) -> proc_macro2::TokenStream {
     let attrs = &method.attributes;
     let ident = &method.ident;
@@ -69,9 +77,6 @@ fn method_signature(method: &MethodInfo) -> proc_macro2::TokenStream {
     let arg_types: Vec<_> = method.arg_types.iter().collect();
     let method_generics = &method.method_generics;
     let where_clause = &method.method_generics.where_clause;
-    // A trait method written `async fn` returns a future the caller knows
-    // nothing about, so code generic over this trait cannot spawn the call. The
-    // desugared form promises `Send`, which is what makes that possible.
     let output_type = &method.output_type;
 
     quote! {

--- a/actify-macros/src/codegen/handle.rs
+++ b/actify-macros/src/codegen/handle.rs
@@ -34,8 +34,14 @@ pub fn generate_trait_impl(info: &ImplInfo) -> proc_macro2::TokenStream {
     // TypeGenerics renders; the full Generics would emit `T: Clone` there.
     let (_, trait_generics, where_clause) = info.generics.split_for_impl();
 
+    // The trait promises the returned future is Send, and the future holds
+    // `&Handle<T, __V>`, which is Send only if the handle is Sync. Every handle
+    // that can exist already satisfies this: `Handle::new` requires it of the
+    // broadcast type.
     let mut generics_with_broadcast = info.generics.clone();
-    generics_with_broadcast.params.push(syn::parse_quote!(__V));
+    generics_with_broadcast
+        .params
+        .push(syn::parse_quote!(__V: Send + Sync + 'static));
     let (impl_generics, _, _) = generics_with_broadcast.split_for_impl();
 
     let call_prefix = build_call_prefix(info);
@@ -63,11 +69,16 @@ fn method_signature(method: &MethodInfo) -> proc_macro2::TokenStream {
     let arg_types: Vec<_> = method.arg_types.iter().collect();
     let method_generics = &method.method_generics;
     let where_clause = &method.method_generics.where_clause;
-    let return_type = quote_return_type(&method.output_type);
+    // A trait method written `async fn` returns a future the caller knows
+    // nothing about, so code generic over this trait cannot spawn the call. The
+    // desugared form promises `Send`, which is what makes that possible.
+    let output_type = &method.output_type;
 
     quote! {
         #(#attrs)*
-        async fn #ident #method_generics(&self, #(#arg_names: #arg_types),*) #return_type #where_clause;
+        fn #ident #method_generics(&self, #(#arg_names: #arg_types),*)
+            -> impl ::std::future::Future<Output = #output_type> + Send
+        #where_clause;
     }
 }
 

--- a/actify-test/src/main.rs
+++ b/actify-test/src/main.rs
@@ -159,6 +159,37 @@ mod shadowed_std_names {
     }
 }
 
+/// Code that is generic over a generated trait and spawns the call. This is the
+/// case that fails when the generated trait uses `async fn`, because the caller
+/// cannot then know the returned future is `Send`.
+///
+/// Only the test build reaches it, hence the allowance.
+#[allow(dead_code)]
+mod generic_over_the_trait {
+    use actify::actify;
+
+    #[derive(Clone, Debug)]
+    pub struct Counter {
+        pub value: i32,
+    }
+
+    #[actify]
+    impl Counter {
+        fn value(&self) -> i32 {
+            self.value
+        }
+    }
+
+    pub async fn read_on_another_task<H>(handle: H) -> i32
+    where
+        H: CounterHandle + Send + Sync + 'static,
+    {
+        tokio::spawn(async move { handle.value().await })
+            .await
+            .unwrap()
+    }
+}
+
 /// Generic bounds written inline on the impl block instead of in a where clause
 #[allow(dead_code)]
 #[derive(Clone, Debug)]
@@ -446,6 +477,16 @@ mod tests {
         let handle = Handle::new(ShadowedStdNames { value: 7 });
 
         assert_eq!(handle.value().await, 7);
+    }
+
+    /// A caller generic over the generated trait must be able to spawn the call.
+    #[tokio::test]
+    async fn test_a_generic_caller_can_spawn_the_call() {
+        use crate::generic_over_the_trait::{Counter, read_on_another_task};
+
+        let handle = Handle::new(Counter { value: 7 });
+
+        assert_eq!(read_on_another_task(handle).await, 7);
     }
 
     #[tokio::test]

--- a/actify-test/src/main.rs
+++ b/actify-test/src/main.rs
@@ -159,9 +159,17 @@ mod shadowed_std_names {
     }
 }
 
-/// Why a caller would be generic over a generated trait at all: so that the
-/// same code works with a real actor or with a stand-in, and so it can be moved
-/// onto its own task.
+/// The shape that needs the generated trait to promise a `Send` future: a
+/// caller that is generic over the trait, whose call has to satisfy a `Send`
+/// bound.
+///
+/// Neither half alone needs the promise. A concrete `Handle<Thermostat>` can be
+/// spawned without it, because the compiler can see the future's real type. A
+/// generic caller that never requires `Send` is fine without it too. Only the
+/// combination fails, because there the compiler has nothing to go on but the
+/// trait, and `async fn` in a trait says nothing about the future.
+///
+/// `tokio::spawn` is the usual way to require `Send`, not the only one.
 ///
 /// Only the test build reaches it, hence the allowance.
 #[allow(dead_code)]
@@ -181,10 +189,9 @@ mod generic_over_the_trait {
         }
     }
 
-    /// Watches a thermostat from its own task. Taking `H` rather than
-    /// `Handle<Thermostat>` lets a test pass the stub below, and `tokio::spawn`
-    /// requires the future the call returns to be `Send`, which the generated
-    /// trait has to promise for this to compile at all.
+    /// Watches a thermostat from its own task. It is generic so that a test can
+    /// pass the stand-in below instead of a real actor, and it spawns, which is
+    /// what requires the future to be `Send`.
     pub fn spawn_watcher<H>(handle: H) -> JoinHandle<i32>
     where
         H: ThermostatHandle + Send + Sync + 'static,

--- a/actify-test/src/main.rs
+++ b/actify-test/src/main.rs
@@ -160,22 +160,18 @@ mod shadowed_std_names {
 }
 
 /// The shape that needs the generated trait to promise a `Send` future: a
-/// caller that is generic over the trait, whose call has to satisfy a `Send`
-/// bound.
+/// caller generic over the trait, whose call has to satisfy a `Send` bound.
 ///
-/// Neither half alone needs the promise. A concrete `Handle<Thermostat>` can be
-/// spawned without it, because the compiler can see the future's real type. A
-/// generic caller that never requires `Send` is fine without it too. Only the
-/// combination fails, because there the compiler has nothing to go on but the
-/// trait, and `async fn` in a trait says nothing about the future.
-///
-/// `tokio::spawn` is the usual way to require `Send`, not the only one.
+/// Neither half alone needs the promise. A concrete `Handle<Thermostat>` is
+/// fine without it, because the compiler sees the future's real type and works
+/// `Send` out for itself. A generic caller that never requires `Send` is fine
+/// too. Only the combination fails, because there the compiler has nothing but
+/// the trait to go on, and `async fn` in a trait states no bounds.
 ///
 /// Only the test build reaches it, hence the allowance.
 #[allow(dead_code)]
 mod generic_over_the_trait {
     use actify::actify;
-    use tokio::task::JoinHandle;
 
     #[derive(Clone, Debug)]
     pub struct Thermostat {
@@ -189,14 +185,21 @@ mod generic_over_the_trait {
         }
     }
 
-    /// Watches a thermostat from its own task. It is generic so that a test can
-    /// pass the stand-in below instead of a real actor, and it spawns, which is
-    /// what requires the future to be `Send`.
-    pub fn spawn_watcher<H>(handle: H) -> JoinHandle<i32>
+    /// Generic so that a test can pass the stand-in below instead of a real
+    /// actor, and requiring the call's future to be `Send`.
+    ///
+    /// The requirement is spelled out rather than reached through
+    /// `tokio::spawn`, which is where it comes from in practice: spawning, or
+    /// anything else that moves the future to another thread, demands `Send`.
+    pub async fn read<H>(handle: H) -> i32
     where
-        H: ThermostatHandle + Send + Sync + 'static,
+        H: ThermostatHandle,
     {
-        tokio::spawn(async move { handle.reading().await })
+        fn require_send<F: Send>(future: F) -> F {
+            future
+        }
+
+        require_send(handle.reading()).await
     }
 
     /// A stand-in for the actor, written by hand. It is still written
@@ -500,17 +503,17 @@ mod tests {
         assert_eq!(handle.value().await, 7);
     }
 
-    /// The same watcher runs against a real actor and against a hand-written
-    /// stand-in, which is the reason for being generic over the trait rather
-    /// than taking a `Handle`.
+    /// The same reader runs against a real actor and against a hand-written
+    /// stand-in, which is why it is generic over the trait rather than taking a
+    /// `Handle`.
     #[tokio::test]
-    async fn test_a_generic_caller_can_spawn_the_call() {
-        use crate::generic_over_the_trait::{FrozenThermostat, Thermostat, spawn_watcher};
+    async fn test_a_generic_caller_can_require_a_send_future() {
+        use crate::generic_over_the_trait::{FrozenThermostat, Thermostat, read};
 
         let handle = Handle::new(Thermostat { celsius: 21 });
 
-        assert_eq!(spawn_watcher(handle).await.unwrap(), 21);
-        assert_eq!(spawn_watcher(FrozenThermostat).await.unwrap(), -40);
+        assert_eq!(read(handle).await, 21);
+        assert_eq!(read(FrozenThermostat).await, -40);
     }
 
     #[tokio::test]

--- a/actify-test/src/main.rs
+++ b/actify-test/src/main.rs
@@ -159,34 +159,48 @@ mod shadowed_std_names {
     }
 }
 
-/// Code that is generic over a generated trait and spawns the call. This is the
-/// case that fails when the generated trait uses `async fn`, because the caller
-/// cannot then know the returned future is `Send`.
+/// Why a caller would be generic over a generated trait at all: so that the
+/// same code works with a real actor or with a stand-in, and so it can be moved
+/// onto its own task.
 ///
 /// Only the test build reaches it, hence the allowance.
 #[allow(dead_code)]
 mod generic_over_the_trait {
     use actify::actify;
+    use tokio::task::JoinHandle;
 
     #[derive(Clone, Debug)]
-    pub struct Counter {
-        pub value: i32,
+    pub struct Thermostat {
+        pub celsius: i32,
     }
 
     #[actify]
-    impl Counter {
-        fn value(&self) -> i32 {
-            self.value
+    impl Thermostat {
+        fn reading(&self) -> i32 {
+            self.celsius
         }
     }
 
-    pub async fn read_on_another_task<H>(handle: H) -> i32
+    /// Watches a thermostat from its own task. Taking `H` rather than
+    /// `Handle<Thermostat>` lets a test pass the stub below, and `tokio::spawn`
+    /// requires the future the call returns to be `Send`, which the generated
+    /// trait has to promise for this to compile at all.
+    pub fn spawn_watcher<H>(handle: H) -> JoinHandle<i32>
     where
-        H: CounterHandle + Send + Sync + 'static,
+        H: ThermostatHandle + Send + Sync + 'static,
     {
-        tokio::spawn(async move { handle.value().await })
-            .await
-            .unwrap()
+        tokio::spawn(async move { handle.reading().await })
+    }
+
+    /// A stand-in for the actor, written by hand. It is still written
+    /// `async fn`, which satisfies the trait as long as the future it produces
+    /// is `Send`, so existing stand-ins keep compiling.
+    pub struct FrozenThermostat;
+
+    impl ThermostatHandle for FrozenThermostat {
+        async fn reading(&self) -> i32 {
+            -40
+        }
     }
 }
 
@@ -479,14 +493,17 @@ mod tests {
         assert_eq!(handle.value().await, 7);
     }
 
-    /// A caller generic over the generated trait must be able to spawn the call.
+    /// The same watcher runs against a real actor and against a hand-written
+    /// stand-in, which is the reason for being generic over the trait rather
+    /// than taking a `Handle`.
     #[tokio::test]
     async fn test_a_generic_caller_can_spawn_the_call() {
-        use crate::generic_over_the_trait::{Counter, read_on_another_task};
+        use crate::generic_over_the_trait::{FrozenThermostat, Thermostat, spawn_watcher};
 
-        let handle = Handle::new(Counter { value: 7 });
+        let handle = Handle::new(Thermostat { celsius: 21 });
 
-        assert_eq!(read_on_another_task(handle).await, 7);
+        assert_eq!(spawn_watcher(handle).await.unwrap(), 21);
+        assert_eq!(spawn_watcher(FrozenThermostat).await.unwrap(), -40);
     }
 
     #[tokio::test]

--- a/actify/src/lib.rs
+++ b/actify/src/lib.rs
@@ -64,9 +64,11 @@
 //!     }
 //! }
 //!
-//! // Defines the method signatures exposed on the handle
+//! // Defines the method signatures exposed on the handle. The future is
+//! // promised to be Send, so a caller generic over this trait can spawn the
+//! // call; `async fn` in a trait would not say that.
 //! pub trait GreeterHandle {
-//!     async fn say_hi(&self, name: String) -> String;
+//!     fn say_hi(&self, name: String) -> impl std::future::Future<Output = String> + Send;
 //! }
 //!
 //! // Implements the methods: boxes args, sends a job to the actor,


### PR DESCRIPTION
Item 13.

## The problem

A generated handle trait declares its methods `async fn`, which states no bounds on the future they return. Any caller that is generic over the trait therefore cannot require that future to be `Send`:

```rust
pub async fn read<H: ThermostatHandle>(handle: H) -> i32 {
    fn require_send<F: Send>(future: F) -> F { future }
    require_send(handle.reading()).await
}
```

```
error[E0277]: `impl Future<Output = i32>` cannot be sent between threads safely
```

In practice that requirement arrives via `tokio::spawn`, or anything else that moves a future to another thread. The fixture spells it out instead, so the mechanism is visible without a runtime in the way.

## When it applies

Two conditions have to hold together. Measured by compiling each shape against both versions:

| | main | this PR |
| --- | --- | --- |
| Concrete `Handle<Thermostat>`, `Send` required | compiles | compiles |
| Generic over the trait, no `Send` required | compiles | compiles |
| **Generic over the trait, `Send` required** | **fails** | compiles |

A concrete call is fine because the compiler sees the future's real type and works `Send` out for itself. A generic caller has only the trait to go on. This is also why nothing in this workspace ever hit it, and why the plan's original justification for this item, that the `async_fn_in_trait` lint fires, was wrong.

## Why a caller would be generic over the trait

So the same code works against a real actor or a stand-in, which is how a service is tested without spawning its dependencies. The fixture runs one reader against both a `Handle<Thermostat>` and a hand-written `FrozenThermostat`.

## The options

| Option | Verdict |
| --- | --- |
| Declare `-> impl Future<Output = R> + Send` (this PR) | Stable, no allocation, no new dependency |
| Leave `async fn`, let the caller write `H: Handle<reading(..): Send>` | **Not available.** Return type notation is still experimental: `error[E0658]: return type notation is experimental` on rustc 1.97 |
| Return `Pin<Box<dyn Future + Send>>` | Works on stable, allocates on every method call |
| Declare an associated future type | Works on stable, but every implementation, generated or hand-written, must name a future type and cannot use `async fn` |

Return type notation is the option that leaves the choice with the caller, so it is worth revisiting if it stabilises. Until then this is the only one that costs nothing.

## What it costs

**Hand-written implementations keep compiling.** An `async fn` in an implementation satisfies the new signature, which the stand-in demonstrates:

```rust
impl ThermostatHandle for FrozenThermostat {
    async fn reading(&self) -> i32 { -40 }
}
```

It breaks only if that future is not `Send`, and that case is real rather than theoretical. This stand-in compiles and runs on main:

```rust
impl ThermostatHandle for NotSendThermostat {
    async fn reading(&self) -> i32 {
        let local = Rc::new(-40);
        tokio::task::yield_now().await;
        *local
    }
}

async fn read<H: ThermostatHandle>(handle: H) -> i32 {
    handle.reading().await
}
```

Nothing in actify objected, because a stand-in is not a `Handle`, so none of the crate's own `Send` bounds applied to it, and the generic caller above never required `Send` either. With this PR it fails:

```
error: future cannot be sent between threads safely
   = help: within `impl Future<Output = i32>`, the trait `Send` is not implemented for `Rc<i32>`
note: future is not `Send` as this value is used across an await
```

So the promise is not free: it rules out single-threaded stand-ins that were previously legal. The fix is to make the future `Send`, which for a test double normally means not holding an `Rc` or a `RefCell` guard across an await.

**Code generic over the broadcast type must now bound it.** Promising `Send` means the future, which holds `&Handle<T, __V>`, must be `Send`, and a reference is `Send` only if its referent is `Sync`. So the generated implementation bounds `__V: Send + Sync + 'static`. Measured the same way:

```rust
async fn read<V>(handle: Handle<Counter, V>) -> i32 {
    handle.value().await
}
```

```
main:     compiles
this PR:  error[E0599]: the method `value` exists for struct `Handle<Counter, V>`,
                        but its trait bounds were not satisfied
                        note: the following trait bounds were not satisfied: `V: Send`
```

Adding `V: Send + Sync + 'static` fixes it. Calls on a concrete handle are unaffected, since `Handle::new` already requires those bounds.

## Verification

`test_a_generic_caller_can_require_a_send_future` is the red: the fixture does not compile against main's macro, with the error quoted above. Mutation-verified by dropping `+ Send` from the emitted signature, which brings it back.

The "roughly desugars to" example in `lib.rs` shows generated code, so it shows the new signature and says why.

Full local gate green: workspace tests, `-p actify`, clippy `--all-targets --all-features -D warnings`, fmt, docs with `-D warnings` both with and without `--all-features`, 1.85 MSRV, and trybuild with unchanged snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

