### PR TITLE
Ask tokio for four features instead of full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,19 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 
 ### Changed
 
+- **Breaking:** actify asks tokio for `macros`, `rt`, `sync` and `time` instead of
+  `full`. Those four are what its own code uses: `sync` for the channels, `rt` for
+  `tokio::spawn` and `AbortHandle`, `time` for the throttle interval, and `macros`
+  for the two `tokio::select!` sites. On Windows this takes a dependent's tree from
+  22 crates to 11, dropping `bytes`, `mio`, `socket2`, `parking_lot`, `lock_api`,
+  `parking_lot_core`, `scopeguard`, `smallvec`, `cfg-if`, `windows-sys` and
+  `windows-link`.
+
+  Cargo unions features across a dependency graph, so code that used `tokio::fs`,
+  `tokio::net` or another module without asking for it in its own manifest was
+  relying on actify to enable it, and must now name the feature itself.
+
+
 - **Breaking:** the generated handle traits declare their methods
   `-> impl Future<Output = R> + Send` rather than `async fn`.
 
@@ -172,7 +185,6 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
   standard library types by absolute path (`::std::boxed::Box`) and reaches the
   crate as `::actify`, neither of which a local item can shadow.
 
-### Changed
 
 - **Breaking:** `Handle::send_job` is renamed to `Handle::__send_job`, and `Actor`
   moves from the crate root to `actify::__private`. Both were `#[doc(hidden)]`

--- a/actify-test/Cargo.toml
+++ b/actify-test/Cargo.toml
@@ -15,7 +15,9 @@ tracing = "0.1"
 
 [dev-dependencies]
 trybuild = "1"
-tokio = { version = "1.15", features = ["test-util"] }
+# trybuild builds the compile-fail cases in a generated crate that takes its
+# tokio features from this section, not from [dependencies].
+tokio = { version = "1.15", features = ["rt-multi-thread", "test-util"] }
 
 [features]
 default = []

--- a/actify/Cargo.toml
+++ b/actify/Cargo.toml
@@ -10,12 +10,17 @@ documentation = "https://docs.rs/actify/latest/actify/"
 readme = "../README.md"
 
 [dependencies]
-tokio = { version = "1.44.1", features = ["full"] }
+tokio = { version = "1.44.1", default-features = false, features = [
+    "macros",
+    "rt",
+    "sync",
+    "time",
+] }
 log = "0.4"
 actify-macros = { path = "../actify-macros", version = "0.5.0" }
 
 [dev-dependencies]
-tokio = { version = "1.44.1", features = ["test-util"] }
+tokio = { version = "1.44.1", features = ["rt-multi-thread", "test-util"] }
 
 [features]
 default = []


### PR DESCRIPTION
actify asked tokio for `full`, which is every feature the runtime has: the
filesystem, TCP and UDP, child processes, Unix signals, the IO utilities. It
uses four of them.

## What it needs, and how each was checked

| feature | used by |
|---|---|
| `sync` | `mpsc`, `oneshot`, `watch` and `broadcast`, the actor's whole plumbing |
| `rt` | `tokio::spawn` for the actor task and the throttle tasks, and `AbortHandle` |
| `time` | `Interval` and `Duration` in the throttle |
| `macros` | the two `tokio::select!` sites, in `wait_until` and the throttle loop |

Not assumed: each of the four was removed in turn and the library rebuilt.
Dropping `macros` fails on `cannot find select in tokio`, `rt` on
`unresolved import tokio::task::AbortHandle` and three `cannot find function
spawn`, `sync` on 42 errors, `time` on `unresolved import tokio::time`. So the
set is minimal as well as sufficient.

`macros` is the surprising one, and it is why the plan's note that it could move
to dev-dependencies was wrong. `tokio::select!` lives behind that feature, and
both call sites are library code, not tests.

## What it costs a dependent

Measured with a scratch crate whose only dependency is actify, so workspace
feature unification cannot flatter the result:

```
before: 22 crates    after: 11 crates
```

Gone: `bytes`, `mio`, `socket2`, `parking_lot`, `lock_api`, `parking_lot_core`,
`scopeguard`, `smallvec`, `cfg-if`, `windows-sys`, `windows-link`. On Linux the
two windows crates would be `libc` instead.

`tokio-macros` and its own `syn` stay, pulled in by `macros`. Dropping those two
would mean hand-rolling both `select!` sites, which is not worth it, and most
dependents enable `macros` themselves for `#[tokio::main]` anyway.

## Why this is breaking

Cargo unions features across the graph, so a dependent that called `tokio::fs`
or `tokio::net` without listing the feature in its own manifest was compiling on
actify's `full`. That code now fails, with tokio's own "unresolved import"
rather than anything cryptic, and the fix is one word in their manifest. The
changelog says so and item 16 will repeat it in the migration guide.

## The trybuild dev-dependency

`cargo test --workspace` caught one thing worth naming. trybuild builds the
compile-fail cases in a generated crate, and it takes tokio's features from
actify-test's `[dev-dependencies]`, not from its `[dependencies]` where `full`
sits. One case uses `#[tokio::main]`, so it had been getting a multi-thread
runtime only through actify. Fixed by asking for `rt-multi-thread` there, with a
comment, since the line looks redundant next to a `full` two entries above it.

actify's own dev-dependencies gained `rt-multi-thread` for the same reason: the
doc examples use `#[tokio::main]`, whose default flavor is multi-thread. Also
checked by removal, which fails with "The default runtime flavor is
multi_thread, but the rt-multi-thread feature is disabled".

## Notes

- `default-features = false` is a no-op today, since tokio's default set is
  empty. It is there so the list stays exhaustive if that ever changes. Say the
  word and it goes.
- No red test: this is a manifest change with no behaviour to assert. The
  evidence is the removal experiments above, which a committed test cannot
  express, since a test cannot compile the crate under a different feature set.
- actify-test still asks for `full`. It is `publish = false`, its features reach
  no dependent, and narrowing it would only constrain the integration tests.

## Verification

Full gate green: `cargo test --workspace`, `cargo test -p actify`, clippy with
`-D warnings` over all targets and features, `cargo fmt --check`, both doc
builds with `RUSTDOCFLAGS="-D warnings"`, `cargo +1.85 check -p actify`, and the
18 trybuild snapshots.
