### PR TITLE
Give VecDequeHandle the mutators it lacked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 
 ### Added
 
+- `VecDequeHandle` gains `insert`, `remove`, `swap`, `truncate`, `append` and
+  `split_off`, closing the gap with `VecHandle`, which had all six.
+
+  `remove` returns `Option<T>` rather than panicking on a bad index, because that
+  is what `VecDeque::remove` does. `VecHandle::remove` panics, because that is
+  what `Vec::remove` does.
+
+
 - `StringHandle` gains `pop`, `remove`, `insert`, `insert_str`, `retain`, `drain`,
   `split_off` and `replace_range`.
 

--- a/actify/src/extensions/vecdeque.rs
+++ b/actify/src/extensions/vecdeque.rs
@@ -36,6 +36,18 @@ trait ActorVecDeque<T> {
     fn retain<F>(&mut self, f: F)
     where
         F: FnMut(&T) -> bool + Send + Sync + 'static;
+
+    fn insert(&mut self, index: usize, value: T);
+
+    fn remove(&mut self, index: usize) -> Option<T>;
+
+    fn swap(&mut self, i: usize, j: usize);
+
+    fn truncate(&mut self, len: usize);
+
+    fn append(&mut self, other: VecDeque<T>);
+
+    fn split_off(&mut self, at: usize) -> VecDeque<T>;
 }
 
 /// Extension methods for `Handle<VecDeque<T>>`, exposed as [`VecDequeHandle`](crate::VecDequeHandle).
@@ -284,6 +296,129 @@ where
     {
         self.retain(f)
     }
+
+    /// Inserts an element at `index`, shifting every later element towards the back.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater than the length of the deque.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecDequeHandle};
+    /// # use std::collections::VecDeque;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(VecDeque::from([1, 3]));
+    /// handle.insert(1, 2).await;
+    /// assert_eq!(handle.get().await, VecDeque::from([1, 2, 3]));
+    /// # }
+    /// ```
+    fn insert(&mut self, index: usize, value: T) {
+        self.insert(index, value)
+    }
+
+    /// Removes and returns the element at `index`, or `None` if the index is out
+    /// of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecDequeHandle};
+    /// # use std::collections::VecDeque;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(VecDeque::from([1, 2, 3]));
+    /// assert_eq!(handle.remove(1).await, Some(2));
+    /// assert_eq!(handle.remove(9).await, None);
+    /// assert_eq!(handle.get().await, VecDeque::from([1, 3]));
+    /// # }
+    /// ```
+    fn remove(&mut self, index: usize) -> Option<T> {
+        self.remove(index)
+    }
+
+    /// Swaps the elements at the two given indices.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either index is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecDequeHandle};
+    /// # use std::collections::VecDeque;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(VecDeque::from([1, 2, 3]));
+    /// handle.swap(0, 2).await;
+    /// assert_eq!(handle.get().await, VecDeque::from([3, 2, 1]));
+    /// # }
+    /// ```
+    fn swap(&mut self, i: usize, j: usize) {
+        self.swap(i, j)
+    }
+
+    /// Shortens the deque to the given length, dropping the elements past it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecDequeHandle};
+    /// # use std::collections::VecDeque;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(VecDeque::from([1, 2, 3]));
+    /// handle.truncate(1).await;
+    /// assert_eq!(handle.get().await, VecDeque::from([1]));
+    /// # }
+    /// ```
+    fn truncate(&mut self, len: usize) {
+        self.truncate(len)
+    }
+
+    /// Moves every element of `other` to the back of the deque.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecDequeHandle};
+    /// # use std::collections::VecDeque;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(VecDeque::from([1, 2]));
+    /// handle.append(VecDeque::from([3, 4])).await;
+    /// assert_eq!(handle.get().await, VecDeque::from([1, 2, 3, 4]));
+    /// # }
+    /// ```
+    fn append(&mut self, other: VecDeque<T>) {
+        self.extend(other)
+    }
+
+    /// Splits the deque in two at `at`, leaving the actor with the front part and
+    /// returning the back part.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `at` is greater than the length of the deque.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecDequeHandle};
+    /// # use std::collections::VecDeque;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(VecDeque::from([1, 2, 3]));
+    /// assert_eq!(handle.split_off(1).await, VecDeque::from([2, 3]));
+    /// assert_eq!(handle.get().await, VecDeque::from([1]));
+    /// # }
+    /// ```
+    fn split_off(&mut self, at: usize) -> VecDeque<T> {
+        self.split_off(at)
+    }
 }
 
 #[cfg(test)]
@@ -351,5 +486,82 @@ mod tests {
 
         handle.retain(|value: &i32| value % 2 == 1).await;
         assert_eq!(handle.get().await, VecDeque::from([1, 5]));
+    }
+
+    /// Every method taking `&mut self` broadcasts, whether or not it changed
+    /// anything.
+    #[tokio::test]
+    async fn test_every_mutator_broadcasts() {
+        let handle = deque();
+        let mut rx = handle.subscribe();
+
+        handle.push_back(4).await;
+        assert!(rx.try_recv().is_ok(), "push_back did not broadcast");
+
+        handle.push_front(0).await;
+        assert!(rx.try_recv().is_ok(), "push_front did not broadcast");
+
+        handle.insert(1, 9).await;
+        assert!(rx.try_recv().is_ok(), "insert did not broadcast");
+
+        handle.remove(1).await;
+        assert!(rx.try_recv().is_ok(), "remove did not broadcast");
+
+        handle.swap(0, 1).await;
+        assert!(rx.try_recv().is_ok(), "swap did not broadcast");
+
+        handle.append(VecDeque::from([5])).await;
+        assert!(rx.try_recv().is_ok(), "append did not broadcast");
+
+        handle.split_off(3).await;
+        assert!(rx.try_recv().is_ok(), "split_off did not broadcast");
+
+        handle.truncate(2).await;
+        assert!(rx.try_recv().is_ok(), "truncate did not broadcast");
+
+        handle.retain(|value: &i32| *value > 0).await;
+        assert!(rx.try_recv().is_ok(), "retain did not broadcast");
+
+        handle.drain(..1).await;
+        assert!(rx.try_recv().is_ok(), "drain did not broadcast");
+
+        handle.pop_front().await;
+        assert!(rx.try_recv().is_ok(), "pop_front did not broadcast");
+
+        handle.pop_back().await;
+        assert!(rx.try_recv().is_ok(), "pop_back did not broadcast");
+
+        handle.clear().await;
+        assert!(rx.try_recv().is_ok(), "clear did not broadcast");
+    }
+
+    #[tokio::test]
+    async fn test_positions_move_the_right_element() {
+        let handle = deque();
+
+        handle.insert(1, 9).await;
+        assert_eq!(handle.get().await, VecDeque::from([1, 9, 2, 3]));
+
+        assert_eq!(handle.remove(2).await, Some(2));
+        assert_eq!(handle.get().await, VecDeque::from([1, 9, 3]));
+
+        handle.swap(0, 1).await;
+        assert_eq!(handle.get().await, VecDeque::from([9, 1, 3]));
+
+        assert_eq!(handle.remove(9).await, None);
+    }
+
+    #[tokio::test]
+    async fn test_the_deque_can_be_grown_and_cut() {
+        let handle = deque();
+
+        handle.append(VecDeque::from([4, 5])).await;
+        assert_eq!(handle.get().await, VecDeque::from([1, 2, 3, 4, 5]));
+
+        assert_eq!(handle.split_off(2).await, VecDeque::from([3, 4, 5]));
+        assert_eq!(handle.get().await, VecDeque::from([1, 2]));
+
+        handle.truncate(1).await;
+        assert_eq!(handle.get().await, VecDeque::from([1]));
     }
 }


### PR DESCRIPTION
Second result of the extension audit. `VecDequeHandle` could push and pop at
both ends and nothing else: no way to touch an element in the middle, no way to
grow or cut the deque.

All six are a straight asymmetry with `VecHandle`, which has them already:
`insert`, `remove`, `swap`, `truncate`, `append`, `split_off`.

`remove` returns `Option<T>` rather than panicking, because that is what
`VecDeque::remove` does. `VecHandle::remove` panics, because that is what
`Vec::remove` does. The two differ in `std` and they differ here.

## What came out again

An earlier version of this PR also added `pop_front_if` and `pop_back_if`,
hand-written because `std` only stabilised them in 1.93. They are gone. The MSRV
stays at 1.85, the floor of edition 2024, and nothing in the crate reimplements
something `std` already offers.

Nothing is lost that a caller cannot write in one line, since `with_mut` hands
the closure a `&mut VecDeque<T>` inside the actor, and it runs on their MSRV
rather than actify's:

```rust
handle.with_mut(|d| d.pop_front_if(|x| *x == 3)).await
```

`Vec::pop_if` came out of #127 for the same reason.

## Tests

Three new tests. Six mutations, all killed, all compiled first:

| mutation | killed by |
|---|---|
| `insert` appends | `test_positions_move_the_right_element` |
| `remove` ignores the index | `test_positions_move_the_right_element` |
| `swap` does nothing | `test_positions_move_the_right_element` |
| `truncate` does nothing | `test_the_deque_can_be_grown_and_cut` |
| `append` adds to the front | `test_the_deque_can_be_grown_and_cut` |
| `split_off` splits at zero | `test_the_deque_can_be_grown_and_cut` |

`test_positions_move_the_right_element` uses index 1 and 2 rather than 0, so a
method that ignores its argument fails instead of coincidentally agreeing.

## Verification

Full gate green: `cargo test --workspace`, `cargo test -p actify`, clippy over
all targets and features with `-D warnings`, `cargo fmt --check`, both doc builds
with `RUSTDOCFLAGS="-D warnings"`, and `cargo +1.85 check -p actify -p
actify-macros --all-features`.
