### PR TITLE
Give VecHandle its remaining atomics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 
 ### Added
 
+- `VecHandle` gains `retain_mut`, `swap` and `resize`.
+
+  `retain_mut` filters and edits in one pass, where `retain` can only filter.
+  `resize` is the only one of the three that can both grow and shrink the vector;
+  `truncate` shrinks alone.
+
+
 - `HashMapHandle` gains `modify` and `remove_entry`.
 
   `modify(key, f)` applies `f` to the value stored under `key` and reports whether

--- a/actify/src/extensions/vec.rs
+++ b/actify/src/extensions/vec.rs
@@ -58,6 +58,14 @@ trait ActorVec<T> {
     fn sort_by<F>(&mut self, compare: F)
     where
         F: FnMut(&T, &T) -> Ordering + Send + Sync + 'static;
+
+    fn retain_mut<F>(&mut self, f: F)
+    where
+        F: FnMut(&mut T) -> bool + Send + Sync + 'static;
+
+    fn swap(&mut self, a: usize, b: usize);
+
+    fn resize(&mut self, new_len: usize, value: T);
 }
 
 /// Extension methods for `Handle<Vec<T>>`, exposed as [`VecHandle`](crate::VecHandle).
@@ -458,6 +466,68 @@ where
     {
         self.as_mut_slice().sort_by(compare)
     }
+
+    /// Keeps only the elements the predicate accepts, and lets it change the ones
+    /// it keeps.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(vec![1, 2, 3, 4]);
+    /// handle.retain_mut(|x| { *x *= 10; *x > 20 }).await;
+    /// assert_eq!(handle.get().await, vec![30, 40]);
+    /// # }
+    /// ```
+    fn retain_mut<F>(&mut self, f: F)
+    where
+        F: FnMut(&mut T) -> bool + Send + Sync + 'static,
+    {
+        self.retain_mut(f)
+    }
+
+    /// Swaps the elements at the two given indices.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either index is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(vec![1, 2, 3]);
+    /// handle.swap(0, 2).await;
+    /// assert_eq!(handle.get().await, vec![3, 2, 1]);
+    /// # }
+    /// ```
+    fn swap(&mut self, a: usize, b: usize) {
+        self.as_mut_slice().swap(a, b)
+    }
+
+    /// Resizes the vector to the given length, dropping the surplus or filling
+    /// the shortfall with clones of `value`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, VecHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(vec![1, 2]);
+    /// handle.resize(4, 9).await;
+    /// assert_eq!(handle.get().await, vec![1, 2, 9, 9]);
+    /// handle.resize(1, 0).await;
+    /// assert_eq!(handle.get().await, vec![1]);
+    /// # }
+    /// ```
+    fn resize(&mut self, new_len: usize, value: T) {
+        self.resize(new_len, value)
+    }
 }
 
 #[cfg(test)]
@@ -537,5 +607,34 @@ mod tests {
 
         handle.clear().await;
         assert!(handle.is_empty().await);
+    }
+
+    /// The predicate changes every element it sees, so a `retain` in disguise
+    /// would leave the kept values untouched and fail here.
+    #[tokio::test]
+    async fn test_retain_mut_can_change_what_it_keeps() {
+        let handle = Handle::new(vec![1, 2, 3, 4]);
+
+        handle
+            .retain_mut(|value: &mut i32| {
+                *value *= 10;
+                *value > 20
+            })
+            .await;
+        assert_eq!(handle.get().await, vec![30, 40]);
+    }
+
+    #[tokio::test]
+    async fn test_swap_and_resize_change_order_and_length() {
+        let handle = Handle::new(vec![1, 2, 3]);
+
+        handle.swap(0, 2).await;
+        assert_eq!(handle.get().await, vec![3, 2, 1]);
+
+        handle.resize(5, 9).await;
+        assert_eq!(handle.get().await, vec![3, 2, 1, 9, 9]);
+
+        handle.resize(2, 0).await;
+        assert_eq!(handle.get().await, vec![3, 2]);
     }
 }


### PR DESCRIPTION
Third result of the extension audit. `VecHandle` gains `retain_mut`, `swap` and
`resize`.

`retain_mut` filters and edits in one pass, which `retain` cannot do at all.
`resize` is the only one of the three that both grows and shrinks; `truncate`
only shrinks. `swap` reorders in place.

## What is not here, and why the MSRV did not move

An earlier version of this PR raised the MSRV to 1.86 and added `pop_if`. Both
are gone. The MSRV stays at 1.85, which is the floor of edition 2024, so it is
now the one number the edition already fixes rather than a policy that needs
defending and revisiting.

`Vec::pop_if` reached stable in 1.86 and `VecDeque::pop_front_if` in 1.93, so
neither is reachable from 1.85. The two ways to have them were to copy `std`'s
body or to raise the floor, and the third option is better than both: leave them
out. They are the smallest additions the audit found, and nothing is lost that a
caller cannot write themselves in one line, since `with_mut` hands the closure a
`&mut Vec<T>` inside the actor:

```rust
handle.with_mut(|v| v.pop_if(|x| *x == 3)).await
```

That runs on the caller's own MSRV, not actify's, so anyone on 1.86 or later has
`pop_if` available without actify making the choice for them.

The same reasoning removed `pop_front_if` and `pop_back_if` from #126.

For the record, since these were checked by compiling against each toolchain
rather than read off a release note:

| method | stable since | released |
|---|---|---|
| `Vec::pop_if` | 1.86 | 2025-03-31 |
| `VecDeque::pop_front_if`, `pop_back_if` | 1.93 | 2026-02-11 |

Also worth recording: nothing in the dependency tree constrains this. tokio,
log, syn, quote, proc-macro2 and tokio-macros all declare 1.71 or lower, so the
floor is entirely actify's own choice, and the edition is the natural place to
pin it.

## Tests

Two new tests, and the broadcast test covers the three new mutators. Three
mutations, all killed, all compiled first:

| mutation | killed by |
|---|---|
| `retain_mut` falls back to `retain`, dropping its edits | `test_retain_mut_can_change_what_it_keeps` |
| `swap` does nothing | `test_swap_and_resize_change_order_and_length` |
| `resize` only ever grows | `test_swap_and_resize_change_order_and_length` |

The `retain_mut` predicate changes every element it sees, so a plain `retain` in
disguise leaves the kept values untouched and fails. The `resize` assertions
grow and then shrink, so a version that only appends fails on the second.

## Verification

Full gate green: `cargo test --workspace`, `cargo test -p actify`, clippy over
all targets and features with `-D warnings`, `cargo fmt --check`, both doc builds
with `RUSTDOCFLAGS="-D warnings"`, and `cargo +1.85 check -p actify -p
actify-macros --all-features`.
