### PR TITLE
Close the last atomic gaps on option, set and map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 
 ### Added
 
+- `HashMapHandle` gains `modify` and `remove_entry`.
+
+  `modify(key, f)` applies `f` to the value stored under `key` and reports whether
+  there was one, which is `entry(key).and_modify(f)` reached from a handle. It
+  inserts nothing when the key is absent. `remove_entry` returns the stored key
+  alongside the value, where `remove` returns the value alone.
+
+
+- `HashSetHandle` gains `take` and `replace`, and `OptionHandle` gains `take_if`
+  and `get_or_insert_with`.
+
+  `take` and `replace` act on the element the set is holding, which `remove` and
+  `insert` cannot reach: `remove` reports only whether something was there, and
+  `insert` keeps the stored element when an equal one arrives. `take_if` removes
+  the value only when the predicate accepts it. `OptionHandle::get_or_insert_with`
+  matches the `HashMapHandle` method of the same name.
+
+
 - `VecDequeHandle` gains `insert`, `remove`, `swap`, `truncate`, `append` and
   `split_off`, closing the gap with `VecHandle`, which had all six.
 

--- a/actify/src/extensions/map.rs
+++ b/actify/src/extensions/map.rs
@@ -34,6 +34,12 @@ trait ActorMap<K, V> {
     fn get_or_insert_with<F>(&mut self, key: K, default: F) -> V
     where
         F: FnOnce() -> V + Send + Sync + 'static;
+
+    fn remove_entry(&mut self, key: K) -> Option<(K, V)>;
+
+    fn modify<F>(&mut self, key: K, f: F) -> bool
+    where
+        F: FnOnce(&mut V) + Send + Sync + 'static;
 }
 
 /// Extension methods for `Handle<HashMap<K, V>>`, exposed as [`HashMapHandle`](crate::HashMapHandle).
@@ -313,6 +319,60 @@ where
     {
         self.entry(key).or_insert_with(default).clone()
     }
+
+    /// Removes the entry for `key` and returns both halves of it, or `None` if the
+    /// map holds no such key.
+    ///
+    /// Where [`remove`](crate::HashMapHandle::remove) returns the value alone, this also hands
+    /// back the key the map was storing, which can carry more than the key looked
+    /// up with.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, HashMapHandle};
+    /// # use std::collections::HashMap;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(HashMap::from([("a", 1)]));
+    /// assert_eq!(handle.remove_entry("a").await, Some(("a", 1)));
+    /// assert_eq!(handle.remove_entry("a").await, None);
+    /// # }
+    /// ```
+    fn remove_entry(&mut self, key: K) -> Option<(K, V)> {
+        self.remove_entry(&key)
+    }
+
+    /// Applies `f` to the value stored under `key`, and returns whether there was
+    /// one to apply it to.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, HashMapHandle};
+    /// # use std::collections::HashMap;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(HashMap::from([("a", 1)]));
+    ///
+    /// assert!(handle.modify("a", |v| *v += 10).await);
+    /// assert_eq!(handle.get_key("a").await, Some(11));
+    ///
+    /// assert!(!handle.modify("b", |v| *v += 10).await);
+    /// # }
+    /// ```
+    fn modify<F>(&mut self, key: K, f: F) -> bool
+    where
+        F: FnOnce(&mut V) + Send + Sync + 'static,
+    {
+        match self.get_mut(&key) {
+            Some(value) => {
+                f(value);
+                true
+            }
+            None => false,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -364,5 +424,67 @@ mod tests {
         assert_eq!(handle.get_or_insert_with("a".to_string(), || 99).await, 1);
         assert_eq!(handle.get_or_insert_with("c".to_string(), || 3).await, 3);
         assert_eq!(handle.len().await, 3);
+    }
+    /// `Eq` and `Hash` read only the id, so two keys can be equal while carrying
+    /// different labels. Without that, nothing shows which key `remove_entry`
+    /// hands back.
+    #[derive(Clone, Debug)]
+    struct Tagged {
+        id: i32,
+        label: &'static str,
+    }
+
+    impl PartialEq for Tagged {
+        fn eq(&self, other: &Self) -> bool {
+            self.id == other.id
+        }
+    }
+
+    impl Eq for Tagged {}
+
+    impl Hash for Tagged {
+        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            self.id.hash(state);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_remove_entry_returns_the_stored_key() {
+        let stored = Tagged {
+            id: 1,
+            label: "stored",
+        };
+        let lookup = Tagged {
+            id: 1,
+            label: "lookup",
+        };
+        let handle = Handle::new(HashMap::from([(stored, 7)]));
+
+        let (key, value) = handle.remove_entry(lookup.clone()).await.unwrap();
+        assert_eq!(key.label, "stored");
+        assert_eq!(value, 7);
+        assert!(handle.is_empty().await);
+
+        assert!(handle.remove_entry(lookup).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_modify_changes_an_existing_value_and_inserts_nothing() {
+        let handle = map();
+
+        assert!(
+            handle
+                .modify("a".to_string(), |value: &mut i32| *value += 10)
+                .await
+        );
+        assert_eq!(handle.get_key("a".to_string()).await, Some(11));
+        assert_eq!(handle.get_key("b".to_string()).await, Some(2));
+
+        assert!(
+            !handle
+                .modify("z".to_string(), |value: &mut i32| *value += 10)
+                .await
+        );
+        assert_eq!(handle.len().await, 2);
     }
 }

--- a/actify/src/extensions/option.rs
+++ b/actify/src/extensions/option.rs
@@ -27,6 +27,14 @@ trait ActorOption<T> {
     where
         F: FnOnce(T) -> U + Send + Sync + 'static,
         U: Send + Sync + 'static;
+
+    fn take_if<F>(&mut self, predicate: F) -> Option<T>
+    where
+        F: FnOnce(&mut T) -> bool + Send + Sync + 'static;
+
+    fn get_or_insert_with<F>(&mut self, f: F) -> T
+    where
+        F: FnOnce() -> T + Send + Sync + 'static;
 }
 
 /// An implementation of the ActorOption extension trait for the standard [`Option`].
@@ -208,6 +216,52 @@ where
     {
         self.clone().map(f)
     }
+
+    /// Takes the value out and returns it if the predicate accepts it, and leaves
+    /// the option alone otherwise.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, OptionHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(Some(2));
+    /// assert_eq!(handle.take_if(|v| *v == 9).await, None);
+    /// assert_eq!(handle.get().await, Some(2));
+    ///
+    /// assert_eq!(handle.take_if(|v| *v == 2).await, Some(2));
+    /// assert_eq!(handle.get().await, None);
+    /// # }
+    /// ```
+    fn take_if<F>(&mut self, predicate: F) -> Option<T>
+    where
+        F: FnOnce(&mut T) -> bool + Send + Sync + 'static,
+    {
+        self.take_if(predicate)
+    }
+
+    /// Returns the contained value, inserting the result of `f` first if there is
+    /// none.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, OptionHandle};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(None);
+    /// assert_eq!(handle.get_or_insert_with(|| 2).await, 2);
+    /// assert_eq!(handle.get_or_insert_with(|| 9).await, 2);
+    /// assert_eq!(handle.get().await, Some(2));
+    /// # }
+    /// ```
+    fn get_or_insert_with<F>(&mut self, f: F) -> T
+    where
+        F: FnOnce() -> T + Send + Sync + 'static,
+    {
+        self.get_or_insert_with(f).clone()
+    }
 }
 
 #[cfg(test)]
@@ -256,5 +310,26 @@ mod tests {
 
         assert_eq!(handle.take().await, None);
         assert!(handle.is_none().await);
+    }
+    #[tokio::test]
+    async fn test_take_if_only_takes_what_the_predicate_accepts() {
+        let handle = Handle::new(Some(2));
+
+        assert_eq!(handle.take_if(|value: &mut i32| *value == 9).await, None);
+        assert_eq!(handle.get().await, Some(2));
+
+        assert_eq!(handle.take_if(|value: &mut i32| *value == 2).await, Some(2));
+        assert_eq!(handle.get().await, None);
+
+        assert_eq!(handle.take_if(|_: &mut i32| true).await, None);
+    }
+
+    #[tokio::test]
+    async fn test_get_or_insert_with_only_inserts_when_none() {
+        let handle: Handle<Option<i32>> = Handle::new(None);
+
+        assert_eq!(handle.get_or_insert_with(|| 2).await, 2);
+        assert_eq!(handle.get_or_insert_with(|| 9).await, 2);
+        assert_eq!(handle.get().await, Some(2));
     }
 }

--- a/actify/src/extensions/set.rs
+++ b/actify/src/extensions/set.rs
@@ -36,6 +36,10 @@ trait ActorSet<K> {
     fn is_subset(&self, other: HashSet<K>) -> bool;
 
     fn is_superset(&self, other: HashSet<K>) -> bool;
+
+    fn take(&mut self, value: K) -> Option<K>;
+
+    fn replace(&mut self, value: K) -> Option<K>;
 }
 
 /// Extension methods for `Handle<HashSet<K>>`, exposed as [`HashSetHandle`](crate::HashSetHandle).
@@ -330,6 +334,53 @@ where
     fn is_superset(&self, other: HashSet<K>) -> bool {
         self.is_superset(&other)
     }
+
+    /// Removes the stored element equal to `value` and returns it, or `None` if
+    /// the set does not hold one.
+    ///
+    /// Where [`remove`](crate::HashSetHandle::remove) reports only whether something was
+    /// there, this hands back what the set was holding, which can carry more than
+    /// the value looked up with.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, HashSetHandle};
+    /// # use std::collections::HashSet;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(HashSet::from([1, 2]));
+    /// assert_eq!(handle.take(1).await, Some(1));
+    /// assert_eq!(handle.take(1).await, None);
+    /// assert_eq!(handle.len().await, 1);
+    /// # }
+    /// ```
+    fn take(&mut self, value: K) -> Option<K> {
+        self.take(&value)
+    }
+
+    /// Inserts `value` and returns the element it displaced, or `None` if the set
+    /// held no equal element.
+    ///
+    /// Where [`insert`](crate::HashSetHandle::insert) keeps the stored element when an equal
+    /// one is already there, this swaps the new one in.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use actify::{Handle, HashSetHandle};
+    /// # use std::collections::HashSet;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let handle = Handle::new(HashSet::from([1]));
+    /// assert_eq!(handle.replace(1).await, Some(1));
+    /// assert_eq!(handle.replace(2).await, None);
+    /// assert_eq!(handle.len().await, 2);
+    /// # }
+    /// ```
+    fn replace(&mut self, value: K) -> Option<K> {
+        self.replace(value)
+    }
 }
 
 #[cfg(test)]
@@ -384,5 +435,65 @@ mod tests {
         let subset = HashSet::from([1, 2]);
         assert!(handle.is_superset(subset.clone()).await);
         assert!(!handle.is_subset(subset).await);
+    }
+    /// `Eq` and `Hash` read only the id, so two elements can be equal while
+    /// carrying different labels. Without that, nothing tells `take` from
+    /// `remove` or `replace` from `insert`.
+    #[derive(Clone, Debug)]
+    struct Tagged {
+        id: i32,
+        label: &'static str,
+    }
+
+    impl PartialEq for Tagged {
+        fn eq(&self, other: &Self) -> bool {
+            self.id == other.id
+        }
+    }
+
+    impl Eq for Tagged {}
+
+    impl Hash for Tagged {
+        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            self.id.hash(state);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_take_and_replace_act_on_the_stored_element() {
+        let stored = Tagged {
+            id: 1,
+            label: "stored",
+        };
+        let lookup = Tagged {
+            id: 1,
+            label: "lookup",
+        };
+        let handle = Handle::new(HashSet::from([stored.clone()]));
+
+        handle.insert(lookup.clone()).await;
+        assert_eq!(
+            handle.to_vec().await[0].label,
+            "stored",
+            "insert keeps the element already there"
+        );
+
+        let displaced = handle.replace(lookup.clone()).await;
+        assert_eq!(displaced.unwrap().label, "stored");
+        assert_eq!(
+            handle.to_vec().await[0].label,
+            "lookup",
+            "replace swaps the new element in"
+        );
+
+        let taken = handle.take(stored).await;
+        assert_eq!(
+            taken.unwrap().label,
+            "lookup",
+            "take returns what was stored"
+        );
+        assert!(handle.is_empty().await);
+
+        assert!(handle.take(lookup).await.is_none());
     }
 }


### PR DESCRIPTION
Last of the extension audit. Six methods across three handles, and then the
category-1 list is empty.

| handle | method | what `get`/`set` cannot do |
|---|---|---|
| `HashMapHandle` | `modify(key, f)` | apply `f` to the stored value and know whether there was one |
| `HashMapHandle` | `remove_entry(key)` | get the stored key back, not just the value |
| `HashSetHandle` | `take(value)` | get the stored element back, not just a yes/no |
| `HashSetHandle` | `replace(value)` | swap the new element in over an equal one |
| `OptionHandle` | `take_if(predicate)` | take only when the predicate accepts |
| `OptionHandle` | `get_or_insert_with(f)` | insert-if-none and read, in one call |

`modify` is the one you asked for. It is `entry(key).and_modify(f)` reached from
a handle, which is the commonest atomic map operation there is: increment a
counter, push into a nested collection. It inserts nothing when the key is
absent, and returns whether it found anything. The name is ours, since `std`
puts `and_modify` on `Entry` and there is no entry to speak of here.

`OptionHandle::get_or_insert_with` closes an asymmetry: `HashMapHandle` has had
one since #118.

## The part worth reviewing

`take` versus `remove`, and `replace` versus `insert`, differ only in what the
collection was already holding. `insert` keeps the stored element when an equal
one arrives; `replace` swaps the new one in. `remove` says yes or no; `take`
hands back what was there.

With `HashSet<i32>` none of that is observable, so a test on integers would pass
against `remove` and `insert` and prove nothing. The tests use a type whose `Eq`
and `Hash` read one field:

```rust
struct Tagged { id: i32, label: &'static str }   // Eq and Hash read id only
```

so `Tagged { id: 1, label: "stored" }` and `Tagged { id: 1, label: "lookup" }`
are equal and still tell each other apart. One test then pins all three claims:
`insert` keeps "stored", `replace` puts "lookup" in and returns "stored", and
`take` returns "lookup". The map test does the same for `remove_entry`.

## Tests

Five new tests, no broadcast assertions. Eight mutations, all killed, all
compiled first:

| mutation | killed by |
|---|---|
| `take_if` ignores the predicate | `test_take_if_only_takes_what_the_predicate_accepts` |
| `take_if` returns the value but leaves it in place | `test_take_if_only_takes_what_the_predicate_accepts` |
| `get_or_insert_with` overwrites what is there | `test_get_or_insert_with_only_inserts_when_none` |
| `take` returns the argument, not the stored element | `test_take_and_replace_act_on_the_stored_element` |
| `replace` keeps the stored element, as `insert` does | `test_take_and_replace_act_on_the_stored_element` |
| `remove_entry` returns the key looked up with | `test_remove_entry_returns_the_stored_key` |
| `modify` applies `f` to a copy | `test_modify_changes_an_existing_value_and_inserts_nothing` |
| `modify` reports success on a missing key | `test_modify_changes_an_existing_value_and_inserts_nothing` |

## Where the audit lands

Category 1 is now empty. What was deliberately left out, so it does not come
back as a suggestion: `Vec::pop_if` and the two `VecDeque` conditional pops
(reachable through `with_mut` on the caller's own MSRV), `Handle::compare_and_set`
(an actor serialises calls, so `with_mut` already is the atomic read-modify-write),
`sort_by_key` (subsumed by `sort_by`), and capacity methods, which are not state.

Still open and cheap if you want them, all category 2:
`HashSetHandle::symmetric_difference` and `is_disjoint` (we have the other five),
`VecHandle::dedup_by_key`, `OptionHandle::get_or_insert` and
`get_or_insert_default`.

## Verification

Full gate green: `cargo test --workspace`, `cargo test -p actify`, clippy over
all targets and features with `-D warnings`, `cargo fmt --check`, both doc builds
with `RUSTDOCFLAGS="-D warnings"`, and `cargo +1.85 check -p actify -p
actify-macros --all-features`.
