### PR TITLE
Inherit shared metadata from the workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,11 @@ and behave differently.
 
 ### Changed
 
+- actify pins `actify-macros` to an exact version rather than a caret range.
+  Generated code reaches into `actify::__private`, which carries no stability
+  promise, so the two crates only work as the pair they were built as.
+
+
 - **Breaking:** actify asks tokio for `macros`, `rt`, `sync` and `time` instead of
   `full`. Those four are what its own code uses: `sync` for the channels, `rt` for
   `tokio::spawn` and `AbortHandle`, `time` for the throttle interval, and `macros`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,27 @@
 [workspace]
 
-resolver = "2"
+resolver = "3"
 members = [
     "actify",
     "actify-macros",
     "actify-test",
 ]
+
+[workspace.package]
+edition = "2024"
+rust-version = "1.85"
+license = "MIT"
+repository = "https://github.com/AvalorAI/actify"
+
+[workspace.dependencies]
+# actify requires the exact macro version it was built against: generated code
+# reaches into actify::__private, which carries no stability promise.
+actify-macros = { path = "actify-macros", version = "=0.5.0" }
+env_logger = "0.11"
+log = "0.4"
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "2.0", features = ["full"] }
+tokio = { version = "1.44.1", default-features = false }
+tracing = "0.1"
+trybuild = "1"

--- a/actify-macros/Cargo.toml
+++ b/actify-macros/Cargo.toml
@@ -1,16 +1,20 @@
 [package]
 name = "actify-macros"
 version = "0.5.0"
-edition = "2024"
-rust-version = "1.85"
 description = "Actify's procedural macros"
-license = "MIT"
-repository = "https://github.com/AvalorAI/actify"
+documentation = "https://docs.rs/actify-macros/latest/actify_macros/"
+readme = "README.md"
+keywords = ["actor", "async", "macro", "proc-macro", "tokio"]
+categories = ["asynchronous", "development-tools::procedural-macro-helpers"]
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-quote = "1.0"
-syn = { version = "2.0", features = ["full"] }
-proc-macro2 = "1.0"
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true
 
 [lib]
 proc-macro = true

--- a/actify-macros/README.md
+++ b/actify-macros/README.md
@@ -1,0 +1,14 @@
+# actify-macros
+
+The procedural macros behind [actify](https://crates.io/crates/actify). This crate
+is not meant to be used on its own: the code it generates reaches into
+`actify::__private`, so it only compiles as part of an actify build.
+
+Add actify instead, which re-exports what you need:
+
+```sh
+cargo add actify
+```
+
+See the [actify documentation](https://docs.rs/actify/latest/actify/) for what the
+`#[actify]` attribute generates and which method signatures it accepts.

--- a/actify-test/Cargo.toml
+++ b/actify-test/Cargo.toml
@@ -1,23 +1,24 @@
 [package]
 name = "actify-test"
 version = "0.1.0"
-edition = "2024"
 description = "Actify testing crate"
-repository = "https://github.com/AvalorAI/actify"
 publish = false
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
 
 [dependencies]
 actify = { path = "../actify", features = ["profiler"] }
-env_logger = "0.11"
-log = "0.4"
-tokio = { version = "1.15", features = ["full"] }
-tracing = "0.1"
+env_logger.workspace = true
+log.workspace = true
+tokio = { workspace = true, features = ["full"] }
+tracing.workspace = true
 
 [dev-dependencies]
-trybuild = "1"
+trybuild.workspace = true
 # trybuild builds the compile-fail cases in a generated crate that takes its
 # tokio features from this section, not from [dependencies].
-tokio = { version = "1.15", features = ["rt-multi-thread", "test-util"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "test-util"] }
 
 [features]
 default = []

--- a/actify/Cargo.toml
+++ b/actify/Cargo.toml
@@ -1,26 +1,23 @@
 [package]
 name = "actify"
 version = "0.8.3"
-edition = "2024"
-rust-version = "1.85"
 description = "An intuitive actor model with minimal boilerplate"
-license = "MIT"
-repository = "https://github.com/AvalorAI/actify"
 documentation = "https://docs.rs/actify/latest/actify/"
 readme = "../README.md"
+keywords = ["actor", "async", "tokio", "concurrency", "macro"]
+categories = ["asynchronous", "concurrency"]
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-tokio = { version = "1.44.1", default-features = false, features = [
-    "macros",
-    "rt",
-    "sync",
-    "time",
-] }
-log = "0.4"
-actify-macros = { path = "../actify-macros", version = "0.5.0" }
+tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
+log.workspace = true
+actify-macros.workspace = true
 
 [dev-dependencies]
-tokio = { version = "1.44.1", features = ["rt-multi-thread", "test-util"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "test-util"] }
 
 [features]
 default = []


### PR DESCRIPTION
Item 17. Four manifests, one source of truth for the fields they shared.

## What moved

`edition`, `rust-version`, `license` and `repository` were written out three
times each. They now live in `[workspace.package]`, and every dependency version
lives in `[workspace.dependencies]`.

Features stay per crate, because they genuinely differ: actify wants four tokio
features, actify-test wants `full`, and the dev-dependencies want
`rt-multi-thread` and `test-util` on top. `default-features = false` sits on the
workspace entry so the members only ever add.

One version requirement got tighter as a side effect: actify-test asked for tokio
`1.15` where actify asked for `1.44.1`. It now asks for `1.44.1` like everything
else, which is what the lockfile already resolved to.

## actify-macros had almost no crates.io page

It carried a name, a version and a one-line description. It now has
`documentation`, `keywords`, `categories` and a README.

The README exists to answer the question its page invites: it says the crate is
not usable on its own, because the code it generates reaches into
`actify::__private`, and points at actify instead.

## The exact pin

`actify-macros = { version = "=0.5.0" }`, where it was `"0.5.0"`, which is a
caret range.

That range let a build pair actify with any newer 0.5.x macro. Generated code
reaches into `actify::__private`, which carries no stability promise, so the two
crates only work as the pair they were built as. **This makes the R2 checklist
one item longer: the pin has to move with the macro version, not just the
manifest version.**

## resolver = "3"

Resolution is now MSRV-aware: cargo will not select a dependency version that
needs a newer compiler than the `rust-version` we declare, which the workspace
inheritance also puts in one place.

`Cargo.lock` does not change, so nothing in the current tree was at risk. The
value is on the next `cargo update`.

## Verified rather than assumed

Manifest edits are easy to get subtly wrong and the failure lands at publish
time, on CI, at a tag. So:

- `cargo metadata` shows the inherited fields resolved on all three crates:
  edition 2024, rust-version 1.85, MIT, the repository, and the keywords and
  categories on the two published ones.
- `cargo package --list` on both published crates: actify-macros now ships its
  README and LICENSE, actify still copies the workspace README in.
- The manifest cargo would actually upload was extracted from the `.crate` and
  read: `actify-macros = "=0.5.0"`, tokio with exactly `macros`, `rt`, `sync`,
  `time` and `default-features = false`.
- Every category slug is one a crate already on crates.io publishes:
  `asynchronous` (tokio, tokio-macros), `concurrency` (parking_lot, lock_api),
  `development-tools::procedural-macro-helpers` (syn, proc-macro2). An invalid
  slug is rejected by crates.io and nothing local catches it, so these were
  checked against the vendored manifests rather than from memory.
- Keywords are within the limits: five each, longest 11 characters.
- The scratch consumer crate still resolves to 11 dependencies, so nothing
  re-enabled a tokio feature by accident.

## Verification

Full gate green: `cargo test --workspace`, `cargo test -p actify`, clippy over
all targets and features with `-D warnings`, `cargo fmt --check`, both doc builds
with `RUSTDOCFLAGS="-D warnings"`, and `cargo +1.85 check -p actify -p
actify-macros --all-features`.
