### PR TITLE
Make the release version assertion accept the exact macro pin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,11 @@ jobs:
             echo "::error::tag ${GITHUB_REF_NAME} does not match actify version ${actify}"
             exit 1
           fi
-          if [ "${req#^}" != "$macros" ]; then
-            echo "::error::actify requires actify-macros ${req}, workspace has ${macros}"
+          # The requirement is an exact pin, not a range: generated code reaches
+          # into actify::__private, which carries no stability promise. Asserting
+          # the exact form also catches a pin loosened back to a caret range.
+          if [ "$req" != "=$macros" ]; then
+            echo "::error::actify requires actify-macros ${req}, expected =${macros}"
             exit 1
           fi
 


### PR DESCRIPTION
**This would have failed the 0.9.0 release at the tag.** Found while preparing
R2, not by CI, because `release.yml` only runs on a tag push.

## The bug

The version job asserts that actify requires the macro version the workspace
holds:

```sh
req=$(... select(.name == "actify-macros") | .req)     # was "0.5.0", now "=0.5.0"
if [ "${req#^}" != "$macros" ]; then                   # strips a caret, nothing else
```

`${req#^}` removes a leading caret. #131 changed the pin to `=0.5.0`, so the
strip leaves `=0.5.0`, which is compared against `0.5.0` and fails. Simulated
against the manifests on main to confirm rather than reading it off:

```
req reported by cargo: '=0.5.0'
macros version:        '0.5.0'
release.yml computes:  '=0.5.0'
RESULT: the version assertion in release.yml WOULD FAIL
```

## The fix, and why it is stricter than a bigger strip

The obvious repair is `${req#[=^]}`, stripping either operator. That would also
accept `^0.6.0`, which is the shape the exact pin exists to prevent: generated
code reaches into `actify::__private`, so actify only works with the macro
version it was built against.

So the assertion now requires the exact form:

```sh
if [ "$req" != "=$macros" ]; then
  echo "::error::actify requires actify-macros ${req}, expected =${macros}"
```

A pin loosened back to a range now fails the release instead of publishing a
crate that can pair itself with a macro it never saw.

## Exercised, since it runs once per release

The logic was run against six inputs rather than reasoned about:

| case | verdict |
|---|---|
| `v0.9.0` / actify 0.9.0 / macros 0.6.0 / `=0.6.0` | accept |
| tag ahead of the manifest | reject (tag) |
| pin loosened to `^0.6.0` | reject (pin) |
| pin left at `=0.5.0` while macros moved to 0.6.0 | reject (pin) |
| bare `0.6.0`, no operator | reject (pin) |
| today's `v0.8.3` / 0.8.3 / 0.5.0 / `=0.5.0` | accept |

The two rejects in the middle are the realistic R2 mistakes: forgetting to move
the pin when bumping the macro version, or relaxing it to make a local build
resolve.

## Verification

No Rust changed, so the gate is unaffected. The assertion cannot be exercised by
CI on a branch, which is the reason it broke unnoticed; the table above is the
substitute.
