### PR TITLE
Release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ they record what changed rather than why, and are not exhaustive. 0.8.0 through
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-08-19
+
 This release is breaking. [MIGRATING.md](MIGRATING.md) walks through the
 changes call site by call site, starting with the four that compile cleanly
 and behave differently.
@@ -550,6 +552,7 @@ drift; the dependency is now declared by path and version together.
 
 - Removed unnecessary mutability.
 
+[0.9.0]: https://github.com/AvalorAI/actify/compare/v0.8.3...v0.9.0
 [0.8.3]: https://github.com/AvalorAI/actify/compare/0.7.3...v0.8.3
 [0.7.3]: https://github.com/AvalorAI/actify/compare/0.7.2...0.7.3
 [0.7.2]: https://github.com/AvalorAI/actify/compare/0.7.0...0.7.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "actify"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "actify-macros",
  "log",
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "actify-macros"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/AvalorAI/actify"
 [workspace.dependencies]
 # actify requires the exact macro version it was built against: generated code
 # reaches into actify::__private, which carries no stability promise.
-actify-macros = { path = "actify-macros", version = "=0.5.0" }
+actify-macros = { path = "actify-macros", version = "=0.6.0" }
 env_logger = "0.11"
 log = "0.4"
 proc-macro2 = "1.0"

--- a/actify-macros/Cargo.toml
+++ b/actify-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actify-macros"
-version = "0.5.0"
+version = "0.6.0"
 description = "Actify's procedural macros"
 documentation = "https://docs.rs/actify-macros/latest/actify_macros/"
 readme = "README.md"

--- a/actify/Cargo.toml
+++ b/actify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actify"
-version = "0.8.3"
+version = "0.9.0"
 description = "An intuitive actor model with minimal boilerplate"
 documentation = "https://docs.rs/actify/latest/actify/"
 readme = "../README.md"


### PR DESCRIPTION
R2, minus the tag. **This PR does not publish anything. It does not tag.** The
tag is the irreversible step and it needs your go-ahead.

## The diff

| file | change |
|---|---|
| `actify/Cargo.toml` | 0.8.3 to 0.9.0 |
| `actify-macros/Cargo.toml` | 0.5.0 to 0.6.0 |
| `Cargo.toml` | the exact pin, `=0.5.0` to `=0.6.0` |
| `Cargo.lock` | the two version lines |
| `CHANGELOG.md` | Unreleased becomes `[0.9.0] - 2026-08-19`, plus a compare link and a fresh empty Unreleased |

The pin and the macro version move together, which is the checklist item #131
created. Forgetting it would publish actify 0.9.0 demanding macros 0.5.0.

**Change the changelog date if the tag slips.** It reads 2026-08-19.

## Simulated the version job

`release.yml` runs a version assertion that no branch CI can reach, and #133 just
fixed a break in it that would have failed this release. So it was run by hand
against these manifests:

```
tag=v0.9.0 actify=0.9.0 macros=0.6.0 req==0.6.0
ACCEPT: the version job would pass
```

## Packaging

`actify-macros` 0.6.0 packages cleanly, 11.6KB, and the manifest it would upload
carries the fields #131 moved to the workspace: edition 2024, rust-version 1.85,
MIT, its README and its documentation URL.

**`actify` cannot be packaged locally, and that is expected.** The exact pin needs
`actify-macros = 0.6.0` on the index, which it will not be until the release
workflow publishes the macro crate first:

```
failed to select a version for the requirement `actify-macros = "=0.6.0"`
candidate versions found which didn't match: 0.5.0, 0.4.0, ...
```

Worth noting as a small cost of the exact pin: under the old caret range,
packaging actify 0.9.0 locally would have resolved against the published 0.5.0
and succeeded. It no longer can. The publish order in `release.yml` exists for
this, and its file list is still verifiable: 20 files, README and LICENSE
included, unchanged by the bump.

## What is in 0.9.0, and what is not

**#106 is not in it.** The parked handle builder stays parked, which is where you
left it. If you want it in 0.9.0, say so and it goes in ahead of this PR rather
than after: adding it later means 0.9.1.

Everything else on the train is in: the extension audit through #129, the tokio
narrowing, the migration guide, the workspace metadata, the repo polish and the
release fix.

## The release, when you say go

1. Merge this.
2. `git tag -a v0.9.0 -m "..." && git push origin v0.9.0`.
3. `release.yml` asserts the versions, runs the full CI gate against the tagged
   commit, then publishes actify-macros and actify in that order. The publish job
   is gated by the `release` environment and waits on your review.
4. After: check both docs.rs builds, then activate cargo-semver-checks with the
   published 0.9.0 as the baseline and smoke-test `actify = "0.9"` from the
   registry in a scratch project.

Note that Sonatype holds new packages for 7 days, so a consumer behind the
firewall cannot pull 0.9.0 until roughly a week after publishing. That is not a
broken release.

## Verification

Full gate green: `cargo test --workspace`, `cargo test -p actify`, clippy over
all targets and features with `-D warnings`, `cargo fmt --check`, both doc builds
with `RUSTDOCFLAGS="-D warnings"`, and `cargo +1.85 check -p actify -p
actify-macros --all-features`.
