### PR TITLE
Name the view in Debug, and drain the blocking receive like the async one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,13 @@ and behave differently.
 
 ### Changed
 
+- `Handle` and `ReadHandle` name the view in their `Debug` output when it differs
+  from the actor type: `Handle<BigState, usize>` rather than `Handle<BigState>`.
+  A handle with an explicit view used to print the same thing as one without, so
+  a log line could not tell them apart. Handles whose view is the actor type,
+  which is every `Clone` actor by default, print exactly as before.
+
+
 - actify pins `actify-macros` to an exact version rather than a caret range.
   Generated code reaches into `actify::__private`, which carries no stability
   promise, so the two crates only work as the pair they were built as.
@@ -398,6 +405,11 @@ and behave differently.
   anything from nothing to a full interval.
 
 ### Internal
+
+- `Cache::blocking_recv_newest` drains through `drain_to_newest`, as its async
+  twin already did, rather than hand-rolling the same loop. Its receive path was
+  unreachable from the existing tests, since the first call returns through
+  `newest`; two tests now cover it.
 
 - A 2.1MB slide deck is no longer in the repository. It sat outside both crate
   directories, so it never reached crates.io; this only shrinks a clone.

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -562,14 +562,14 @@ where
             match self.rx.blocking_recv() {
                 Ok(val) => {
                     self.inner = val;
-                    if self.rx.is_empty() {
-                        return Ok(&self.inner);
-                    }
+                    break;
                 }
                 Err(RecvError::Closed) => return Err(CacheRecvError::Closed),
                 Err(RecvError::Lagged(nr)) => log_lag::<V>(nr),
             }
         }
+        _ = self.drain_to_newest();
+        Ok(&self.inner)
     }
 
     /// Waits until the cached value satisfies `predicate` and returns it.
@@ -1179,6 +1179,45 @@ mod tests {
         std::thread::spawn(move || {
             // First call drains to newest
             assert_eq!(cache.blocking_recv_newest().unwrap(), &3);
+        })
+        .join()
+        .unwrap();
+    }
+
+    /// The first call returns through `newest`, so only a later one reaches the
+    /// receive loop.
+    #[tokio::test(start_paused = true)]
+    async fn test_blocking_recv_newest_drains_after_the_first_call() {
+        let handle = Handle::new(1);
+        let mut cache = handle.cache().await;
+        cache.blocking_recv_newest().unwrap(); // Consume first request
+
+        handle.set(2).await;
+        handle.set(3).await;
+
+        std::thread::spawn(move || {
+            assert_eq!(cache.blocking_recv_newest().unwrap(), &3);
+        })
+        .join()
+        .unwrap();
+    }
+
+    /// The same guarantee as `test_recv_newest_returns_last_value_before_close`,
+    /// for the blocking variant.
+    #[tokio::test(start_paused = true)]
+    async fn test_blocking_recv_newest_returns_last_value_before_close() {
+        let handle = Handle::new(1);
+        let mut cache = handle.cache().await;
+        cache.blocking_recv_newest().unwrap(); // Consume first request
+
+        handle.set(2).await;
+        drop(handle);
+        sleep(Duration::from_millis(10)).await; // Let the actor task exit
+
+        std::thread::spawn(move || {
+            assert_eq!(cache.blocking_recv_newest().unwrap(), &2);
+            // Only once the queue is drained does the closed channel surface
+            assert_eq!(cache.blocking_recv_newest(), Err(CacheRecvError::Closed));
         })
         .join()
         .unwrap();

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -107,7 +107,13 @@ impl<T, V> Clone for Handle<T, V> {
 
 impl<T, V> Debug for Handle<T, V> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Handle<{}>", type_name::<T>())
+        let actor = type_name::<T>();
+        let view = type_name::<V>();
+        if actor == view {
+            write!(f, "Handle<{actor}>")
+        } else {
+            write!(f, "Handle<{actor}, {view}>")
+        }
     }
 }
 
@@ -1277,6 +1283,23 @@ mod tests {
         // Read-only operation through with_mut still broadcasts
         let _len = handle.with_mut(|v| v.len()).await;
         assert!(rx.try_recv().is_ok());
+    }
+
+    /// `Handle<BigState, usize>` and `Handle<BigState>` used to print the same
+    /// thing, so the view a handle exposes was invisible in a log line.
+    #[tokio::test]
+    async fn test_debug_names_the_view_only_when_it_differs() {
+        let plain: Handle<i32> = Handle::new(1);
+        assert_eq!(format!("{plain:?}"), "Handle<i32>");
+
+        let viewed: Handle<BigState, usize> = Handle::new(BigState {
+            data: vec![1],
+            count: 1,
+        });
+        assert_eq!(
+            format!("{viewed:?}"),
+            format!("Handle<{}, usize>", type_name::<BigState>())
+        );
     }
 
     #[tokio::test]

--- a/actify/src/handles/read_handle.rs
+++ b/actify/src/handles/read_handle.rs
@@ -22,7 +22,13 @@ impl<T, V> Clone for ReadHandle<T, V> {
 
 impl<T, V> Debug for ReadHandle<T, V> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "ReadHandle<{}>", type_name::<T>())
+        let actor = type_name::<T>();
+        let view = type_name::<V>();
+        if actor == view {
+            write!(f, "ReadHandle<{actor}>")
+        } else {
+            write!(f, "ReadHandle<{actor}, {view}>")
+        }
     }
 }
 
@@ -232,5 +238,26 @@ mod tests {
 
         handle.set(2).await;
         assert_eq!(read_handle.get().await, 2);
+    }
+
+    #[derive(Clone, Debug)]
+    struct Counted(Vec<u8>);
+
+    impl crate::ToView<usize> for Counted {
+        fn to_view(&self) -> usize {
+            self.0.len()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_debug_names_the_view_only_when_it_differs() {
+        let plain: Handle<i32> = Handle::new(1);
+        assert_eq!(format!("{:?}", plain.read_handle()), "ReadHandle<i32>");
+
+        let viewed: Handle<Counted, usize> = Handle::new(Counted(vec![1, 2]));
+        assert_eq!(
+            format!("{:?}", viewed.read_handle()),
+            format!("ReadHandle<{}, usize>", type_name::<Counted>())
+        );
     }
 }


### PR DESCRIPTION
**Merge before #134**, since this adds to the changelog's Unreleased section that
#134 renames to 0.9.0.

## Debug names the view

`Handle<BigState, usize>` and `Handle<BigState>` printed the same thing, so a log
line could not tell a handle with an explicit view from one without. Both handles
now name the view when it differs, and print byte for byte as before when it does
not, which is every `Clone` actor by default.

This belongs in the breaking release: `Debug` output is what people read in logs,
so moving it is a visible change, and #109 already made the view the thing a
handle exposes.

## The blocking receive drains like the async one

```rust
// recv_newest, and now blocking_recv_newest
loop {
    match self.rx.recv().await {
        Ok(val) => { self.inner = val; break; }
        Err(RecvError::Closed) => return Err(CacheRecvError::Closed),
        Err(RecvError::Lagged(nr)) => log_lag::<V>(nr),
    }
}
_ = self.drain_to_newest();
Ok(&self.inner)
```

`blocking_recv_newest` was the only one of six call sites hand-rolling that tail,
with an `rx.is_empty()` check. It now reads as the same function with a different
await.

**The `_ =` is load-bearing.** `drain_to_newest` reports a closed channel as an
error, which is wrong once a value has been taken: the value is delivered and the
close surfaces on the next call. A `?` there would discard the value, which is one
of the mutations below.

## The loop had no test

`test_blocking_recv_newest` looks like it covers this, but the first call returns
early:

```rust
if self.is_first_request() {
    return Ok(self.newest());     // where the only existing test stopped
}
```

So the receive loop was reachable only from a second call, and nothing called it
twice. Two tests now do: one draining to the newest queued value, and one
mirroring `test_recv_newest_returns_last_value_before_close`. The second closes
the channel with a `sleep` under `start_paused`, the idiom the async test uses, so
the close is deterministic before the thread starts rather than the thread
blocking forever.

## Mutations

All five killed, all compiled first:

| mutation | killed by |
|---|---|
| Debug prints the actor type alone | `test_debug_names_the_view_only_when_it_differs` |
| Debug prints both even when equal | `test_debug_names_the_view_only_when_it_differs` |
| Debug swaps actor and view | `test_debug_names_the_view_only_when_it_differs` |
| `blocking_recv_newest` propagates the close with `?` | `test_blocking_recv_newest_returns_last_value_before_close` |
| `blocking_recv_newest` skips the drain | `test_blocking_recv_newest_drains_after_the_first_call` |

The last two are the ways this refactor could have been wrong.

## Verification

Full gate green: `cargo test --workspace`, `cargo test -p actify`, clippy over
all targets and features with `-D warnings`, `cargo fmt --check`, both doc builds
with `RUSTDOCFLAGS="-D warnings"`, and `cargo +1.85 check -p actify -p
actify-macros --all-features`.
