### PR TITLE
Name the element-wise insertions extend on every handle

### DIFF
--- a/actify/src/extensions/vec.rs
+++ b/actify/src/extensions/vec.rs
@@ -41,7 +41,7 @@ trait ActorVec<T> {
     where
         T: PartialEq;
 
-    fn append(&mut self, other: Vec<T>);
+    fn extend(&mut self, items: Vec<T>);
 
     fn dedup(&mut self)
     where
@@ -370,7 +370,7 @@ where
         self.as_slice().contains(&value)
     }
 
-    /// Moves all the elements of `other` into the vector, leaving `other` empty.
+    /// Extends the vector with the contents of the given `Vec`.
     ///
     /// # Examples
     ///
@@ -379,12 +379,12 @@ where
     /// # #[tokio::main]
     /// # async fn main() {
     /// let handle = Handle::new(vec![1, 2]);
-    /// handle.append(vec![3, 4]).await;
+    /// handle.extend(vec![3, 4]).await;
     /// assert_eq!(handle.get().await, vec![1, 2, 3, 4]);
     /// # }
     /// ```
-    fn append(&mut self, other: Vec<T>) {
-        self.extend(other)
+    fn extend(&mut self, items: Vec<T>) {
+        <Self as Extend<T>>::extend(self, items)
     }
 
     /// Removes consecutive duplicate elements.
@@ -559,7 +559,7 @@ mod tests {
         assert_eq!(handle.remove(0).await, 1);
         assert_eq!(handle.get().await, vec![2, 3]);
 
-        handle.append(vec![4, 5]).await;
+        handle.extend(vec![4, 5]).await;
         // swap_remove moves the last element into the freed slot, which is what
         // distinguishes it from remove
         assert_eq!(handle.swap_remove(0).await, 2);
@@ -590,13 +590,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_insert_append_retain_and_truncate() {
+    async fn test_insert_extend_retain_and_truncate() {
         let handle = Handle::new(vec![1, 2]);
 
         handle.insert(1, 9).await;
         assert_eq!(handle.get().await, vec![1, 9, 2]);
 
-        handle.append(vec![3, 4]).await;
+        handle.extend(vec![3, 4]).await;
         assert_eq!(handle.get().await, vec![1, 9, 2, 3, 4]);
 
         handle.retain(|value: &i32| *value < 4).await;

--- a/actify/src/extensions/vecdeque.rs
+++ b/actify/src/extensions/vecdeque.rs
@@ -45,7 +45,7 @@ trait ActorVecDeque<T> {
 
     fn truncate(&mut self, len: usize);
 
-    fn append(&mut self, other: VecDeque<T>);
+    fn extend(&mut self, items: VecDeque<T>);
 
     fn split_off(&mut self, at: usize) -> VecDeque<T>;
 }
@@ -379,7 +379,7 @@ where
         self.truncate(len)
     }
 
-    /// Moves every element of `other` to the back of the deque.
+    /// Extends the back of the deque with the contents of the given `VecDeque`.
     ///
     /// # Examples
     ///
@@ -389,12 +389,12 @@ where
     /// # #[tokio::main]
     /// # async fn main() {
     /// let handle = Handle::new(VecDeque::from([1, 2]));
-    /// handle.append(VecDeque::from([3, 4])).await;
+    /// handle.extend(VecDeque::from([3, 4])).await;
     /// assert_eq!(handle.get().await, VecDeque::from([1, 2, 3, 4]));
     /// # }
     /// ```
-    fn append(&mut self, other: VecDeque<T>) {
-        self.extend(other)
+    fn extend(&mut self, items: VecDeque<T>) {
+        <Self as Extend<T>>::extend(self, items)
     }
 
     /// Splits the deque in two at `at`, leaving the actor with the front part and
@@ -492,7 +492,7 @@ mod tests {
     async fn test_the_deque_can_be_grown_and_cut() {
         let handle = deque();
 
-        handle.append(VecDeque::from([4, 5])).await;
+        handle.extend(VecDeque::from([4, 5])).await;
         assert_eq!(handle.get().await, VecDeque::from([1, 2, 3, 4, 5]));
 
         assert_eq!(handle.split_off(2).await, VecDeque::from([3, 4, 5]));


### PR DESCRIPTION
`VecHandle::append` and `VecDequeHandle::append` call `Extend::extend` on the underlying collection, while `HashMapHandle` and `HashSetHandle` already expose the same operation as `extend`. A handle method should carry the name of the operation it performs on the underlying type, so both are renamed to `extend`. Their signatures are unchanged.

`append` also promised `std`'s append semantics it did not have: `Vec::append` empties the other vector in place, which cannot happen to a vector that was moved into the call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)