### PR TITLE
Hold every doc comment to the house rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,8 +73,8 @@ differently, each detailed in its own entry:
 
   For an inherent impl a second `impl` block does the same job and needs nothing
   from actify. This is for trait impls, which Rust requires to hold every method
-  of the trait in one block: before this, one unactorizable method meant the
-  whole trait impl could not be actorized.
+  of the trait in one block: before this, one unactifiable method meant the
+  whole trait impl could not be actified.
 
 
 - `OptionHandle` gains `unwrap_or`, `unwrap_or_default`, `unwrap_or_else`,

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ By generating the boilerplate code for you, a few key benefits are provided:
 - No need to manually define message structs or enums!
 - Built-in methods like `get()`, `set()`, `set_if_changed()`, and `subscribe()` even without using the macro.
 - Automatic broadcasting to subscribers from methods taking `&mut self`, with `#[actify::broadcast]` and `#[actify::skip_broadcast]` overrides.
-- Methods that cannot be actorized can stay in the impl block with `#[actify::skip]`.
+- Methods that cannot be actified can stay in the impl block with `#[actify::skip]`.
 - Local synchronization through `Cache`, with `recv`, `recv_newest`, and non-blocking variants.
 - Rate-limited updates through `Throttle` with configurable `Frequency`.
 - Generic type parameters supported in both actor types and method arguments.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Actify is a pre-1.0 crate used in production. The API may still change between minor versions.
 
-Sharing (mutable) state across async tasks in Rust usually means juggling mutexes and channels, and a lot of boilerplate like hand-writen message enums. Actify gives you a typed, async [actor model](https://en.wikipedia.org/wiki/Actor_model) built on [Tokio](https://tokio.rs) for any struct. Just add `#[actify]` to an `impl` block and call your methods through a clonable [`Handle`].
+Sharing (mutable) state across async tasks in Rust usually means juggling mutexes and channels, and a lot of boilerplate like hand-written message enums. Actify gives you a typed, async [actor model](https://en.wikipedia.org/wiki/Actor_model) built on [Tokio](https://tokio.rs) for any struct. Just add `#[actify]` to an `impl` block and call your methods through a clonable [`Handle`].
 
 [![Crates.io][crates-badge]][crates-url]
 [![License][mit-badge]][mit-url]
@@ -31,10 +31,11 @@ By generating the boilerplate code for you, a few key benefits are provided:
 - No need to manually define message structs or enums!
 - Built-in methods like `get()`, `set()`, `set_if_changed()`, and `subscribe()` even without using the macro.
 - Automatic broadcasting to subscribers from methods taking `&mut self`, with `#[actify::broadcast]` and `#[actify::skip_broadcast]` overrides.
+- Methods that cannot be actorized can stay in the impl block with `#[actify::skip]`.
 - Local synchronization through `Cache`, with `recv`, `recv_newest`, and non-blocking variants.
 - Rate-limited updates through `Throttle` with configurable `Frequency`.
 - Generic type parameters supported in both actor types and method arguments.
-- Extension traits for common types: `Vec`, `Option`, `HashMap`, `HashSet`.
+- Extension traits for common types: `Vec`, `VecDeque`, `String`, `Option`, `HashMap`, `HashSet`.
 
 ## Example
 

--- a/actify-macros/src/codegen/handle.rs
+++ b/actify-macros/src/codegen/handle.rs
@@ -36,8 +36,8 @@ pub fn generate_trait_impl(info: &ImplInfo) -> proc_macro2::TokenStream {
 
     // The future returned by each method holds `&Handle<T, __V>`, and a
     // reference is Send only if what it points at is Sync, so promising Send
-    // means the broadcast type has to be bounded here. Code generic over that
-    // type must bound it too, which is the one visible cost of the promise.
+    // means the broadcast type has to be bounded here, and code generic over
+    // that type must bound it too.
     let mut generics_with_broadcast = info.generics.clone();
     generics_with_broadcast
         .params
@@ -60,18 +60,11 @@ pub fn generate_trait_impl(info: &ImplInfo) -> proc_macro2::TokenStream {
     }
 }
 
-/// Generate a handle trait method signature.
-/// e.g. `async fn foo(&self, i: i32) -> f64;`
-/// Generate one method signature for the handle trait.
+/// Generate one method signature for the handle trait,
+/// e.g. `fn foo(&self, i: i32) -> impl Future<Output = f64> + Send;`.
 ///
-/// Written `-> impl Future<Output = R> + Send` rather than `async fn`, because
-/// `async fn` in a trait states no bounds on the future it returns.
-///
-/// That only matters to a caller that is generic over this trait, since a
-/// concrete `Handle<T>` call lets the compiler see the future's real type and
-/// work out for itself that it is `Send`. A generic caller has nothing but the
-/// trait, so requiring `Send` of the call, by spawning it or otherwise, fails
-/// with "future cannot be sent between threads safely".
+/// The `Send` promise is what lets a caller that is generic over this trait
+/// spawn the call.
 fn method_signature(method: &MethodInfo) -> proc_macro2::TokenStream {
     let attrs = &method.attributes;
     let ident = &method.ident;

--- a/actify-macros/src/lib.rs
+++ b/actify-macros/src/lib.rs
@@ -1,7 +1,7 @@
 //! Procedural macros for the [actify](https://docs.rs/actify) crate.
 //!
-//! Depend on `actify` rather than this crate: everything here is re-exported
-//! from there, and the generated code refers to `actify`'s types.
+//! Everything here is re-exported from `actify`, and the generated code refers
+//! to `actify`'s types, so the macros only work alongside that crate.
 #![warn(missing_docs)]
 
 mod codegen;
@@ -53,9 +53,8 @@ pub fn broadcast(_args: TokenStream, input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// The method stays on the type and is unchanged. Use it for helpers that have
-/// no business on a handle, and for methods an actor call cannot express, such
-/// as ones taking a reference.
+/// The method stays on the type and is unchanged. It is not validated, so it
+/// may take or return references, which an actor call cannot express.
 ///
 /// Expands to nothing: `#[actify]` reads it and strips it from the output.
 #[proc_macro_attribute]
@@ -119,9 +118,9 @@ fn report(error: syn::Error, impl_block: &syn::ItemImpl) -> TokenStream {
     .into()
 }
 
-/// The actify macro expands an impl block of a rust struct to support usage in an actor model.
-/// Effectively, this macro allows to remotely call an actor method through a handle.
-/// By using traits, the methods on the handle have the same signatures, so that type checking is enforced
+/// Expands an impl block so its methods can be called remotely through a handle.
+/// The generated handle trait keeps the method signatures, so arguments and
+/// return values stay typed.
 #[proc_macro_attribute]
 pub fn actify(attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut impl_block = syn::parse_macro_input!(item as syn::ItemImpl);

--- a/actify-macros/src/parse.rs
+++ b/actify-macros/src/parse.rs
@@ -296,10 +296,11 @@ fn is_propagated_attribute(attr: &Attribute) -> bool {
 
 /// Keep only whitelisted built-in attributes for generated code.
 ///
-/// Proc-macro attributes (e.g. `#[instrument]`) and actify-specific attributes
-/// (e.g. `#[skip_broadcast]`) are stripped. The former transform function
-/// bodies and are semantically wrong on generated plumbing code; the latter
-/// are consumed during parsing.
+/// A proc-macro attribute like `#[instrument]` rewrites the function it is
+/// placed on, which is meant for the user's method and not for a generated
+/// method that forwards a call to it. An actify attribute like
+/// `#[skip_broadcast]` has already done its work during parsing. Both are
+/// stripped and remain only on the original impl method.
 fn filter_attributes(attrs: &[Attribute]) -> Vec<Attribute> {
     attrs
         .iter()

--- a/actify-macros/src/parse.rs
+++ b/actify-macros/src/parse.rs
@@ -266,7 +266,7 @@ fn get_impl_type_ident(impl_type: &Type) -> syn::Result<Ident> {
 }
 
 /// Built-in compiler attributes that are safe to propagate onto generated trait
-/// signatures and handle impl methods.  Everything else (proc-macro attributes
+/// signatures and handle impl methods. Everything else (proc-macro attributes
 /// like `#[instrument]`, actify-specific attributes like `#[skip_broadcast]`)
 /// is stripped so it only appears on the original impl method where it belongs.
 const PROPAGATED_ATTRIBUTES: &[&str] = &[
@@ -297,9 +297,9 @@ fn is_propagated_attribute(attr: &Attribute) -> bool {
 /// Keep only whitelisted built-in attributes for generated code.
 ///
 /// Proc-macro attributes (e.g. `#[instrument]`) and actify-specific attributes
-/// (e.g. `#[skip_broadcast]`) are stripped. The former transforms
-/// function bodies and are semantically wrong on generated plumbing code, the
-/// latter because they are consumed during parsing.
+/// (e.g. `#[skip_broadcast]`) are stripped. The former transform function
+/// bodies and are semantically wrong on generated plumbing code; the latter
+/// are consumed during parsing.
 fn filter_attributes(attrs: &[Attribute]) -> Vec<Attribute> {
     attrs
         .iter()
@@ -559,8 +559,6 @@ mod tests {
         assert!(find_marker_attribute(&attrs, "skip_broadcast").is_some());
     }
 
-    /// Another crate's attribute must not be mistaken for one of actify's, or
-    /// the user is told their own attribute is a superfluous actify one.
     #[test]
     fn marker_attributes_of_other_crates_are_ignored() {
         let attrs: Vec<Attribute> = vec![attr(parse_quote!(#[other_crate::broadcast]))];
@@ -573,7 +571,6 @@ mod tests {
         assert!(find_marker_attribute(&attrs, "skip_broadcast").is_none());
     }
 
-    /// `skip_broadcast` must not register as `broadcast`.
     #[test]
     fn marker_attribute_names_do_not_overlap() {
         let attrs: Vec<Attribute> = vec![attr(parse_quote!(#[skip_broadcast]))];

--- a/actify/src/actor.rs
+++ b/actify/src/actor.rs
@@ -74,7 +74,7 @@ impl<T> Actor<T> {
 /// A single call on an actor, sent from a handle and run once by [`serve`].
 ///
 /// The lifetime is bound with `for<'a>` because the returned future borrows the
-/// actor it was handed, which `futures::BoxFuture` used to elide.
+/// actor it was handed.
 pub(crate) type ActorMethod<T> = Box<
     dyn for<'a> FnOnce(&'a mut Actor<T>, Box<dyn Any + Send>) -> BoxFuture<'a, Box<dyn Any + Send>>
         + Send,

--- a/actify/src/cache.rs
+++ b/actify/src/cache.rs
@@ -734,9 +734,6 @@ mod tests {
     use crate::Handle;
     use tokio::time::{Duration, sleep};
 
-    /// One error type covers the whole receive family. The `_newest` methods
-    /// never lag, which their docs state, but they no longer need a type of
-    /// their own to say so.
     #[tokio::test(start_paused = true)]
     async fn test_every_receive_reports_the_same_error_type() {
         let handle = Handle::new(0);

--- a/actify/src/extensions/vec.rs
+++ b/actify/src/extensions/vec.rs
@@ -107,7 +107,13 @@ where
         self.is_empty()
     }
 
-    /// Removes the complete range from the vector in bulk, and returns it as a new vector
+    /// Removes the specified range from the vector and returns the removed
+    /// items as a new `Vec`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the start of the range is greater than the end, or if the end
+    /// is greater than the length of the vector.
     ///
     /// # Examples
     ///

--- a/actify/src/extensions/vecdeque.rs
+++ b/actify/src/extensions/vecdeque.rs
@@ -262,6 +262,11 @@ where
 
     /// Removes the specified range from the deque and returns the removed items as a `Vec`.
     ///
+    /// # Panics
+    ///
+    /// Panics if the start of the range is greater than the end, or if the end
+    /// is greater than the length of the deque.
+    ///
     /// # Examples
     ///
     /// ```

--- a/actify/src/handles/handle.rs
+++ b/actify/src/handles/handle.rs
@@ -79,8 +79,8 @@ where
 
 /// A clonable handle that can be used to remotely execute a closure on the corresponding [`Actor`].
 ///
-/// Handles are the primary way to interact with actors. Clone them freely to share
-/// access across tasks. For read-only access, see [`ReadHandle`]. For local
+/// Handles are the primary way to interact with actors. Cloning a handle shares
+/// access to the same actor across tasks. For read-only access, see [`ReadHandle`]. For local
 /// synchronization, see [`Cache`]. For rate-limited updates, see [`Throttle`].
 ///
 /// The second type parameter `V` is the view the handle exposes: what
@@ -614,8 +614,8 @@ impl<T: Send + Sync + 'static, V> Handle<T, V> {
     /// Runs a read-only closure on the actor's value and returns the result.
     /// Does not broadcast.
     ///
-    /// This is useful for reading parts of the actor state without cloning
-    /// the entire value, and works with non-Clone types.
+    /// This reads parts of the actor state without cloning the entire value,
+    /// and works with non-Clone types.
     ///
     /// # Examples
     ///
@@ -625,7 +625,6 @@ impl<T: Send + Sync + 'static, V> Handle<T, V> {
     /// # async fn main() {
     /// let handle = Handle::new(vec![1, 2, 3]);
     ///
-    /// // Extract just what you need, without cloning the whole Vec
     /// let len = handle.with(|v| v.len()).await;
     /// assert_eq!(len, 3);
     ///
@@ -649,12 +648,12 @@ impl<T: Send + Sync + 'static, V> Handle<T, V> {
 
     /// Runs a closure on the actor's value mutably and returns the result.
     ///
-    /// This is useful for atomic read-modify-return operations without
-    /// defining a dedicated `#[actify]` method.
+    /// This performs an atomic read-modify-return without a dedicated
+    /// `#[actify]` method.
     ///
-    /// **Note:** This always broadcasts after the closure returns, even if
-    /// the closure did not actually mutate anything. Use [`Handle::with`]
-    /// for read-only access that does not broadcast.
+    /// This always broadcasts after the closure returns, even if the closure
+    /// did not mutate anything; [`Handle::with`] is the read-only counterpart
+    /// and does not broadcast.
     ///
     /// # Examples
     ///
@@ -955,8 +954,6 @@ mod tests {
         }
     }
 
-    /// Deriving the broadcast value inside the actor means the actor value
-    /// itself is never cloned, so these work on actor types that are not Clone.
     mod broadcast_derivation {
         use super::*;
         use crate::Frequency;
@@ -1034,8 +1031,6 @@ mod tests {
         }
     }
 
-    /// `V` is what a handle exposes: reads return it, and the actor type stays
-    /// private behind `with`.
     mod views {
         use super::*;
 
@@ -1280,7 +1275,6 @@ mod tests {
         let handle = Handle::new(vec![1, 2, 3]);
         let mut rx = handle.subscribe();
 
-        // Read-only operation through with_mut still broadcasts
         let _len = handle.with_mut(|v| v.len()).await;
         assert!(rx.try_recv().is_ok());
     }

--- a/actify/src/handles/read_handle.rs
+++ b/actify/src/handles/read_handle.rs
@@ -84,7 +84,6 @@ impl<T: Send + Sync + 'static, V> ReadHandle<T, V> {
     /// });
     /// let read_handle = handle.read_handle();
     ///
-    /// // Read parts of the value without cloning the whole thing
     /// let count = read_handle.with(|inv| inv.items.len()).await;
     /// assert_eq!(count, 2);
     ///

--- a/actify/src/lib.rs
+++ b/actify/src/lib.rs
@@ -5,7 +5,7 @@
 //! Actify is a pre-1.0 crate used in production. The API may still change between minor versions.
 //!
 //! Sharing (mutable) state across async tasks in Rust usually means juggling mutexes and channels,
-//! and a lot of boilerplate like hand-writen message enums. Actify gives you a typed, async
+//! and a lot of boilerplate like hand-written message enums. Actify gives you a typed, async
 //! actor model built on [Tokio][tokio] for any struct. Just add `#[actify]` to an `impl` block and call your methods
 //! through a clonable [`Handle`].
 //!
@@ -103,7 +103,7 @@
 //! ```
 //!
 //! ## Async functions in impl blocks
-//! Async function are fully supported, and work as you would expect:
+//! Async functions are fully supported, and work as you would expect:
 //! ```
 //! # use actify::{Handle, actify};
 //! # use std::fmt::Debug;
@@ -208,8 +208,8 @@
 //! # Leaving methods off the handle
 //!
 //! Every method in an `#[actify]` block gets a handle method. For an inherent
-//! impl, the plainest way to keep one off the handle is a second `impl` block,
-//! which needs nothing from actify.
+//! impl, a second `impl` block keeps a method off the handle and needs nothing
+//! from actify.
 //!
 //! A trait impl cannot be split that way: Rust requires every method of a trait
 //! in one impl block. Mark the method
@@ -398,9 +398,9 @@
 //!
 //! Spawning a throttle returns a [`Throttle`] handle. Dropping it leaves the
 //! throttle running, so a throttle attached to an actor can be spawned and
-//! forgotten: it stops when the actor does. [`Throttle::spawn_interval`] has no
-//! actor attached and runs until [`Throttle::abort`] or the runtime shuts down,
-//! which is why it is the one spawn that must not have its handle discarded.
+//! forgotten: it stops when the actor does. [`Throttle::spawn_interval`] and
+//! [`Throttle::spawn_async_interval`] have no actor attached and run until
+//! [`Throttle::abort`] or the runtime shuts down, so both are `#[must_use]`.
 //!
 //! # Extension traits
 //!
@@ -520,8 +520,8 @@ pub use throttle::{BoxFuture, Frequency, Throttle};
 /// The crate's own items that the [`actify`](macro@crate::actify) macro needs in
 /// generated code. Standard library types are named by absolute path instead.
 ///
-/// Not part of the public API. Anything here may change in a patch release, and
-/// nothing outside generated code should name it.
+/// Not part of the public API. Anything here may change in a patch release;
+/// only generated code names it.
 #[doc(hidden)]
 pub mod __private {
     pub use crate::actor::Actor;

--- a/actify/src/throttle.rs
+++ b/actify/src/throttle.rs
@@ -974,8 +974,6 @@ mod tests {
             assert_eq!(next_sent(&mut received).await, Some(2));
         }
 
-        /// The closure needs no type annotations, so the borrow does not have to
-        /// be spelled out at every call site.
         #[tokio::test(start_paused = true)]
         async fn test_the_callback_needs_no_type_annotations() {
             let handle = Handle::new(1);
@@ -1043,9 +1041,6 @@ mod tests {
         }
     }
 
-    /// What each [`Frequency`] does when every call takes a full period, so
-    /// updates arrive faster than they can be sent. The unit tests above drive
-    /// `ThrottleState` directly; these go through a spawned throttle.
     mod slow_calls {
         use super::*;
 
@@ -1199,7 +1194,6 @@ mod tests {
         let handle = Handle::new(1);
         let counter = CounterClient::new();
 
-        // Spawn throttle that should only activate once on creation
         handle
             .spawn_throttle(counter.clone(), CounterClient::call, Frequency::OnEvent)
             .await;
@@ -1259,7 +1253,6 @@ mod tests {
         let counter = CounterClient::new();
         let mut cache = handle.cache().await;
 
-        // Spawn throttle that should only activate once on creation
         cache.spawn_throttle(counter.clone(), CounterClient::call, Frequency::OnEvent);
         sleep(Duration::from_millis(200)).await;
 
@@ -1293,7 +1286,6 @@ mod tests {
 
         let counter = CounterClient::new();
 
-        // Spawn throttle
         Throttle::spawn(
             counter.clone(),
             CounterClient::call,
@@ -1329,10 +1321,8 @@ mod tests {
         let mut interval = time::interval(Duration::from_millis(timer as u64));
         interval.tick().await; // Completed immediately
 
-        // Start counter
         let counter = CounterClient::new();
 
-        // Spawn throttle
         let receiver = handle.subscribe();
         Throttle::spawn(
             counter.clone(),
@@ -1360,10 +1350,8 @@ mod tests {
         let mut interval = time::interval(Duration::from_millis(timer as u64));
         interval.tick().await; // Completed immediately
 
-        // Start counter
         let counter = CounterClient::new();
 
-        // Spawn throttle
         let receiver = handle.subscribe();
         Throttle::spawn(
             counter.clone(),
@@ -1373,7 +1361,7 @@ mod tests {
             None,
         );
 
-        // Many updates are triggered in quick succesion
+        // Many updates are triggered in quick succession
         for i in 0..10 {
             handle.set(i).await;
             sleep(Duration::from_millis((timer / 10.) as u64)).await;
@@ -1391,16 +1379,12 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn test_interval() {
-        // The interval passed to the throttle used to send the value each time
-
         let timer = 200.;
         let mut interval = time::interval(Duration::from_millis(timer as u64));
         interval.tick().await; // Completed immediately
 
-        // Start counter
         let counter = CounterClient::new();
 
-        // Spawn throttle
         let _throttle = Throttle::spawn_interval(
             counter.clone(),
             CounterClient::call,
@@ -1432,10 +1416,8 @@ mod tests {
         let mut interval = time::interval(Duration::from_millis(timer as u64));
         interval.tick().await; // Completed immediately
 
-        // Start counter
         let counter = CounterClient::new();
 
-        // Spawn throttle
         let receiver = handle.subscribe();
         Throttle::spawn(
             counter.clone(),
@@ -1466,10 +1448,8 @@ mod tests {
         let mut interval = time::interval(Duration::from_millis(timer as u64));
         interval.tick().await; // Completed immediately
 
-        // Start counter
         let counter = CounterClient::new();
 
-        // Spawn throttle
         let receiver = handle.subscribe();
         Throttle::spawn(
             counter.clone(),


### PR DESCRIPTION
A sweep of the rustdoc and comments against the documentation rules: describe behaviour, no advice, no history, no comments a test name already carries. Also the README omissions and a handful of typos.

README:

- The extension-trait list gains `VecDeque` and `String`, and the benefits list gains `#[actify::skip]`; both were added this release and missing here.

Docs that told the reader what to do now state what the code does:

- `Handle`, `with`, `with_mut`, the crate-level skip section, `__private`, and the `#[actify::skip]` macro doc.
- The crate-level throttle section claimed one spawn "must not have its handle discarded"; both interval spawns are `#[must_use]`, and it now says so.

History removed from comments:

- `actor.rs` referenced a dependency the crate no longer has, a throttle test comment described pre-0.9 behaviour, and a cache test doc narrated the error-type unification.

Deleted comments that restated what the code or test name already says: three mod-level docs on test modules, two test rationale docs in the macro crate, and the `// Spawn throttle` / `// Start counter` labels.

Corrections:

- The macro's signature-generation doc carried two stacked headers, one showing a signature shape it no longer generates.
- `drain` documents its panic on a bad range in vec and vecdeque, as it already did in string.
- Typos: `hand-writen`, `Async function are`, `succesion`, and two ungrammatical sentences in the macro crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)